### PR TITLE
add `cabal install --overwrite-policy=always` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ To get started running the process:
 ```
 nix develop
 export PATH=~/.local/bin:$PATH
-cabal install
+cabal install --overwrite-policy=always
 
 ./scan.sh /nix/var/nix/profiles/system
 ```


### PR DESCRIPTION
to make sure people will be testing the right version