### PR TITLE
Print advisory matches

### DIFF
--- a/CVENix.cabal
+++ b/CVENix.cabal
@@ -30,7 +30,8 @@ library
                       bytestring,
                       lens,
                       directory,
-                      time
+                      time,
+                      containers
 
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/src/CVENix/Examples.hs
+++ b/src/CVENix/Examples.hs
@@ -9,7 +9,12 @@ import Data.Time.Clock
 import Data.Maybe
 import Data.Text (Text)
 
-exampleParseCVE :: IO [Text]
+data Advisory = Advisory
+  { _advisory_cveId :: Text
+  , _advisory_productName :: Maybe Text
+  } deriving Show
+
+exampleParseCVE :: IO [Advisory]
 exampleParseCVE = do
     files' <- listDirectory "CVE/cves/"
     let files = filter (\x -> not (x == "delta.json" || x == "deltaLog.json")) files'
@@ -27,7 +32,7 @@ exampleParseCVE = do
     curTime <- getCurrentTime
     l <- flip mapM thing' $ \x -> do
       file <- decodeFileStrict x :: IO (Maybe CVE)
-      pure $ getCVEIDs file
+      pure $ asAdvisories file
     l2 <- flip mapM thing' $ \x -> do
       file <- decodeFileStrict x
       pure $ getCPEIDs file
@@ -35,15 +40,20 @@ exampleParseCVE = do
     curTime' <- getCurrentTime
     putStrLn $ "[CVE] Time to run: " <> (show $ diffUTCTime curTime curTime' * (-1))
     print $ filter (\a -> _cpe_vendor a /= "microsoft") $ catMaybes $ map parseCPE (concat $ concat $ l2)
-    pure $ catMaybes $ concat $ l
+    pure $ concat $ l
   where
-      getCVEIDs p = case p of
+      asAdvisories :: Maybe CVE -> [Advisory]
+      asAdvisories p = case p of
                       Nothing -> []
                       Just cve -> do
-                          let unwrappedContainer = _cna_affected $ _container_cna $ _cve_containers cve
+                          let
+                            cveId = _cvemetadata_cveId $ _cve_cveMetadata cve
+                            unwrappedContainer = _cna_affected $ _container_cna $ _cve_containers cve
                           case unwrappedContainer of
                             Nothing -> []
-                            Just a -> map (_product_packageName) a
+                            Just a ->
+                              let names = mapMaybe (_product_packageName) a
+                              in map (\n -> Advisory {_advisory_cveId = cveId, _advisory_productName = Just n}) names
       getCPEIDs p = case p of
                       Nothing -> []
                       Just cve -> do

--- a/src/CVENix/Matching.hs
+++ b/src/CVENix/Matching.hs
@@ -13,13 +13,6 @@ data Match = Match
   , _match_advisory :: Advisory
   }
 
-instance Show Match where
-  show m =
-    let pname = _match_pname m
-        drv = _match_drv m
-        cveId = _advisory_cveId $ _match_advisory m
-    in show pname ++ "\t" ++ show drv ++ "\t" ++ show cveId
-
 match :: SBOM -> [Advisory] -> IO ()
 match sbom cves = do
     putStrLn "Matched advisories:"
@@ -29,7 +22,16 @@ match sbom cves = do
           let d = getDeps $ Just s
           case d of
             Nothing -> pure ()
-            Just a' -> mapM_ print $ matchNames a' cves
+            Just a' ->
+              let
+                pretty :: Match -> String
+                pretty m =
+                  let pname = _match_pname m
+                      drv = _match_drv m
+                      cveId = _advisory_cveId $ _match_advisory m
+                  in show pname ++ "\t" ++ show drv ++ "\t" ++ show cveId
+              in
+                mapM_ putStrLn $ map pretty $ matchNames a' cves
 
   where
       getDeps a = case a of

--- a/src/CVENix/Matching.hs
+++ b/src/CVENix/Matching.hs
@@ -1,20 +1,35 @@
 module CVENix.Matching where
 
 import CVENix.SBOM
+import CVENix.Examples
 import Data.Maybe
 import Data.Text (Text)
+import qualified Data.Map as Map
 import qualified Data.Text as T
 
-match :: SBOM -> [Text] -> IO ()
+data Match = Match
+  { _match_pname :: Text
+  , _match_drv :: Text
+  , _match_advisory :: Advisory
+  }
+
+instance Show Match where
+  show m =
+    let pname = _match_pname m
+        drv = _match_drv m
+        cveId = _advisory_cveId $ _match_advisory m
+    in show pname ++ "\t" ++ show drv ++ "\t" ++ show cveId
+
+match :: SBOM -> [Advisory] -> IO ()
 match sbom cves = do
-    putStrLn "Known Deps:"
+    putStrLn "Matched advisories:"
     case _sbom_dependencies sbom of
       Nothing -> putStrLn "No known deps?"
       Just s -> do
           let d = getDeps $ Just s
           case d of
             Nothing -> pure ()
-            Just a' -> print $ catMaybes $ matchNames a' cves
+            Just a' -> mapM_ print $ matchNames a' cves
 
   where
       getDeps a = case a of
@@ -23,8 +38,19 @@ match sbom cves = do
                       let deps = map (_sbomdependency_ref) d
                           stripDeps = T.takeWhile (\x -> x /= '-') . T.drop 1 . T.dropWhile (\x -> x /= '-')
                       map (\x -> (stripDeps x, x)) deps
-      matchNames :: Eq a => [(a, b)] -> [a] -> [Maybe (a, b)]
-      matchNames a b = flip map a $ \(x, y) -> case x `elem` b of
-                                            False -> Nothing
-                                            True -> Just (x, y)
+      matchNames :: [(Text, Text)] -> [Advisory] -> [Match]
+      matchNames inventory advisories =
+                  let
+                    advisoriesByProductName :: Map.Map Text Advisory
+                    advisoriesByProductName =
+                      Map.fromList $ mapMaybe (\a -> case (_advisory_productName a) of
+                                                    Just p -> Just (p, a)
+                                                    Nothing -> Nothing) advisories
+                  in
+                    mapMaybe
+                        (\package -> case (Map.lookup (fst package) advisoriesByProductName) of
+                          Just advisory -> Just (Match { _match_pname = fst package, _match_drv = snd package, _match_advisory = advisory })
+                          Nothing -> Nothing
+                        )
+                        inventory
 


### PR DESCRIPTION
Now produces a result like:

```
Matched advisories:
"avahi"	"/nix/store/08xh2gdj9ji94fcjpf2hpz42jim99kkp-avahi-0.8.drv"	"CVE-2023-38473"
"gawk"	"/nix/store/jzc31i1d1mi6x2rmp9pj6dcvw2mx7daz-gawk-5.2.2.drv"	"CVE-2023-4156"
"glib"	"/nix/store/09yqd7yg7rfjsfbikvc3snx7wn9c6is5-glib-2.76.4.drv"	"CVE-2023-29499"
"glibc"	"/nix/store/30j4y2k04zww68mggx1mkmmi6b9ns2yp-glibc-2.38-27.drv"	"CVE-2023-5156"
"glibc"	"/nix/store/3affpfhnsgifgqkhd1zckk527a86fyrz-glibc-locales-2.38-27.drv"	"CVE-2023-5156"
"kernel"	"/nix/store/h3sqgjbm7a3gvyn50r5k7066xjhgn5iy-kernel-modules.drv"	"CVE-2023-6176"
"libX11"	"/nix/store/wxd38000dmzrd51nl4d0q88c3xximhlr-libX11-1.8.7.drv"	"CVE-2023-43787"
"libXpm"	"/nix/store/a66y6hxcv8qcal43i49nvrzfi7k9jj12-libXpm-3.5.17.drv"	"CVE-2023-43789"
"libtiff"	"/nix/store/c80az5882p200wyi9vk5jkbrqf8wi2q1-libtiff-4.6.0.drv"	"CVE-2023-41175"
"w3m"	"/nix/store/0v1i0bx7ld6lh0g9kkykc08in4y9612w-w3m-0.5.3+git20230121.drv"	"CVE-2023-38253"
```