### PR TITLE
feat: allow ingesting a small subset of CVEs

### DIFF
--- a/src/website/shared/management/commands/ingest_bulk_cve.py
+++ b/src/website/shared/management/commands/ingest_bulk_cve.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = "Ingest CVEs in bulk using the Mitre CVE repo"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--test",
+            action="store_true",
+            help="Import a small subset of CVEs for testing",
+        )
+
     def handle(self, *args, **kwargs):
         credentials_dir = env.get("CREDENTIALS_DIRECTORY")
 
@@ -82,6 +89,8 @@ class Command(BaseCommand):
             with transaction.atomic():
                 # Traverse the tree and import cves
                 cve_list = glob(f"{tmp_dir}/cves/*/*/*.json")
+                if kwargs["test"]:
+                    cve_list = cve_list[0:100]
                 logger.warn(f"{len(cve_list)} CVEs to ingest.")
 
                 for j_cve in cve_list:


### PR DESCRIPTION
Now it's possible to run `manage ingest_bulk_cve --test`, which will only ingest the first 100 CVEs for testing.