### PR TITLE
feat: generate feeds per issue

### DIFF
--- a/src/website/webview/feeds.py
+++ b/src/website/webview/feeds.py
@@ -1,0 +1,34 @@
+from django.contrib.syndication.views import Feed
+from django.urls import reverse
+from django.utils.feedgenerator import Atom1Feed
+
+from shared.models import NixpkgsIssue
+
+
+class RssNixpkgsIssueFeed(Feed):
+    description_template = "templates/issue_feed.html"
+
+    def get_object(self, request, code):
+        return NixpkgsIssue.objects.get(code=code)
+
+    def title(self, obj):
+        return "Issue %s" % obj.code
+
+    def link(self, obj):
+        # TODO: make the class compatible with get_absolute_url
+        # return obj.get_absolute_url()
+        return reverse("webview:issue_detail", args=[obj.code])
+
+    def item_link(self, obj):
+        return reverse("webview:issue_detail", args=[obj.code])
+
+    def description(self, obj):
+        return "Recent update for issue %s" % obj.code
+
+    def items(self, obj):
+        return NixpkgsIssue.objects.filter(code=obj.code).order_by("code")[:30]
+
+
+class AtomNixpkgsIssueFeed(RssNixpkgsIssueFeed):
+    feed_type = Atom1Feed
+    subtitle = RssNixpkgsIssueFeed.description

--- a/src/website/webview/templates/issue_feed.html
+++ b/src/website/webview/templates/issue_feed.html
@@ -1,0 +1,1 @@
+{{ obj.description }}

--- a/src/website/webview/urls.py
+++ b/src/website/webview/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path, re_path
 
 from webview.views import HomeView, NixpkgsIssueView, NixpkgsIssueListView
+from webview.feeds import AtomNixpkgsIssueFeed, RssNixpkgsIssueFeed  # type: ignore
 
 app_name = "webview"
 
@@ -12,5 +13,15 @@ urlpatterns = [
         r"^issues/(?P<code>NIXPKGS-[0-9]{4}-[0-9]{4,19})$",
         NixpkgsIssueView.as_view(),
         name="issue_detail",
+    ),
+    re_path(
+        r"^issues/(?P<code>NIXPKGS-[0-9]{4}-[0-9]{4,19})/rss/$",
+        RssNixpkgsIssueFeed(),
+        name="issue_feed_rss",
+    ),
+    re_path(
+        r"^issues/(?P<code>NIXPKGS-[0-9]{4}-[0-9]{4,19})/atom/$",
+        AtomNixpkgsIssueFeed(),
+        name="issue_feed_atom",
     ),
 ]


### PR DESCRIPTION
add `/issues/<code>/rss/` and `/issues/<code>/atom/` endpoints for RSS subscriptions