### PR TITLE
fix: m2m relationships on insertion

### DIFF
--- a/src/website/shared/management/commands/ingest_manual_evaluation.py
+++ b/src/website/shared/management/commands/ingest_manual_evaluation.py
@@ -193,7 +193,7 @@ class BulkSave(object):
             if "op_pos" not in model.__dict__.keys():
                 raise RuntimeError(
                     "Temporary model id cannot be set. "
-                    + "Check that all `save` operations set a temporary if "
+                    + "Check that all `save` operations set a temporary id "
                     + "inside `model.op_pos`."
                 )
             mid = model.op_pos

--- a/src/website/shared/management/commands/ingest_manual_evaluation.py
+++ b/src/website/shared/management/commands/ingest_manual_evaluation.py
@@ -149,7 +149,11 @@ class BulkSave(object):
         """
         Add an unsaved model (with no pk) to be inserted.
         """
+        pos = len(self.inserts[model.__class__])
         self.inserts[model.__class__].append(model)
+        # Save to set a temporary id.
+        # Check `set_m2m` for the reason why this is needed.
+        model.op_pos = f"insert-{pos}"
 
     def add_delete(self, model):
         """
@@ -180,6 +184,19 @@ class BulkSave(object):
         """
         klass = model.__class__
         mid = model.pk
+        # Set up a temporary id from the operation position;
+        # otherwise all the m2m operations get collapsed into
+        # a None key and relationships get lost when calling
+        # save_m2m (that is, the m2m will only be set for the
+        # last entry found).
+        if model.pk is None:
+            if "op_pos" not in model.__dict__.keys():
+                raise RuntimeError(
+                    "Temporary model id cannot be set. "
+                    + "Check that all `save` operations set a temporary if "
+                    + "inside `model.op_pos`."
+                )
+            mid = model.op_pos
         if mid not in self.m2m[klass]:
             self.m2m[klass][mid] = {}
         # Assert that all models are of the same type


### PR DESCRIPTION
On insertion, the function `set_m2m` was getting the relationiships for the same class collapsed into a `None` key. This caused m2m relationships to get lost during the processing.

With this fix, the logic can again retrieve the proper foreign keys from the `self.m2m_models` list.

For example, now each `nixderivationmeta` gets correctly linked to its corresponding `nixderivationmeta_maintainers`. This can be checked after ingestion by running the query `SELECT * FROM shared_nixderivationmeta_maintainers;`.