### PR TITLE
feat: add a basic triaging view

### DIFF
--- a/src/website/webview/templates/triage_view.html
+++ b/src/website/webview/templates/triage_view.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<form method="get">
+  <input name="search_query" type="text" placeholder="Search to filter..." />
+</form>
+<ul>
+  {% for object in object_list %}
+  <li>{{ object.title }}: {{ object.cve.cve_id }} ({{ object.id }})</li>
+  {% endfor %}
+</ul>
+{% endblock content %}

--- a/src/website/webview/urls.py
+++ b/src/website/webview/urls.py
@@ -1,12 +1,13 @@
 from django.urls import path, re_path
 
-from webview.views import HomeView, NixpkgsIssueListView, NixpkgsIssueView
+from webview.views import HomeView, NixpkgsIssueListView, NixpkgsIssueView, TriageView
 
 app_name = "webview"
 
 
 urlpatterns = [
     path("", HomeView.as_view(), name="home"),
+    path("triage/", TriageView.as_view(), name="triage_view"),
     path("issues/", NixpkgsIssueListView.as_view(), name="issue_list"),
     re_path(
         r"^issues/(?P<code>NIXPKGS-[0-9]{4}-[0-9]{4,19})$",

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -5,10 +5,43 @@ from django.db.models.manager import BaseManager
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView, ListView, TemplateView
 from shared.models import Container, CveRecord, NixpkgsIssue
+from django.contrib.postgres.search import SearchVector
 
 
 class HomeView(TemplateView):
     template_name = "home_view.html"
+
+
+class TriageView(ListView):
+    template_name = "triage_view.html"
+    model = Container
+    paginate_by = 25
+
+    def get_queryset(self):
+        qs = (
+            Container.objects.prefetch_related("descriptions", "affected", "cve")
+            .exclude(title="")
+            .order_by("id", "-date_public")
+        )
+        search_query = self.request.GET.get("search_query")
+        if not search_query:
+            return qs.all()
+        else:
+            return (
+                qs.annotate(
+                    search=SearchVector(
+                        "title",
+                        "descriptions__value",
+                        "affected__vendor",
+                        "affected__product",
+                        "affected__package_name",
+                        "affected__repo",
+                        "affected__cpes__name",
+                    )
+                )
+                .filter(search=search_query)
+                .distinct("id")
+            )
 
 
 class NixpkgsIssueView(DetailView):

--- a/staging/sectracker.nix
+++ b/staging/sectracker.nix
@@ -15,6 +15,35 @@ in
     recommendedGzipSettings = true;
     recommendedOptimisation = true;
   };
+  services.postgresql = {
+    enableJIT = true;
+    settings = {
+      # DB Version: 15
+      # OS Type: linux
+      # DB Type: dw
+      # Total Memory (RAM): 16 GB
+      # CPUs num: 8
+      # Data Storage: hdd
+
+      max_connections = 40;
+      shared_buffers = "4GB";
+      effective_cache_size = "12GB";
+      maintenance_work_mem = "2GB";
+      checkpoint_completion_target = "0.9";
+      wal_buffers = "16MB";
+      default_statistics_target = "500";
+      random_page_cost = "4";
+      effective_io_concurrency = "2";
+      work_mem = "13107kB";
+      huge_pages = "off";
+      min_wal_size = "4GB";
+      max_wal_size = "16GB";
+      max_worker_processes = "8";
+      max_parallel_workers_per_gather = "4";
+      max_parallel_workers = "8";
+      max_parallel_maintenance_workers = "4";
+    };
+  };
   security.acme.acceptTerms = true;
   security.acme.defaults.email = obfuscate "zyx.afhal@emca-cilbup";
   networking.firewall.allowedTCPPorts = [


### PR DESCRIPTION
I need the revert to work on the stylesheets in production mode, @fricklerhandwerk, if you can get the deployment setup to work with SASS, I can drop it.

TODO:

- Add indexes to optimize: searching for "Python" on staging takes 7.6s in PostgreSQL queries.
- Improve styling, @Tom-Hubrecht can you help on this side?
- Design the "pairing" UI to pair a group of CVE into a Nix issue.