### PR TITLE
feat: keep CVE data in a local cache directory for efficient reimports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .credentials
 *.jsonl # Evaluation results
 CACHE
+/**/.data_cache

--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,7 @@
 
   shell = pkgs.mkShell {
     packages = [ package pkgs.nix-eval-jobs pkgs.commitizen ];
+    DATA_CACHE_DIRECTORY = toString ./. + "/.data_cache";
     shellHook = ''
       ${pre-commit-check.shellHook}
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -11,7 +11,8 @@ in extraPkgs // {
     version = "0.0.1";
     pyproject = true;
 
-    src = ../src/website;
+    src =
+      final.nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ../src/website;
 
     propagatedBuildInputs = with python.pkgs; [
       # Nix python packages

--- a/src/website/shared/management/commands/ingest_bulk_cve.py
+++ b/src/website/shared/management/commands/ingest_bulk_cve.py
@@ -1,9 +1,12 @@
 import json
 import logging
+import shutil
 import tempfile
 import zipfile
 from datetime import date
 from glob import glob
+from os import environ as env, mkdir, path
+from typing import Optional
 
 import requests
 from django.core.management.base import BaseCommand, CommandError
@@ -25,12 +28,17 @@ class Command(BaseCommand):
             "--subset",
             nargs="?",
             type=int,
-            help="Integer value representing the N subset of total entries. "
+            help="Integer value reprepathsenting the N subset of total entries. "
             + " Useful to generate a small dataset for development.",
             default=0,
         )
+        parser.add_argument(
+            "--force-download",
+            action="store_true",
+            help="Ignore the local data cache content and download the CVEs zip again.",
+        )
 
-    def handle(self, *args, **kwargs) -> None:  # pyright: ignore reportUnusedVariable
+    def _download_gh_bundle(self, data_cache_dir):
         # Initialize a GitHub connection
         g = get_gh()
 
@@ -45,12 +53,11 @@ class Command(BaseCommand):
         # Get the bulk cve list asset
         bundle = release.assets[0]
 
-        if not bundle.name.endswith(".zip.zip"):
+        if not bundle.name.endswith(".zip"):
             logger.error(f"Wrong bundle asset: {bundle.name}")
 
             raise CommandError("Unable to get bundled CVEs.")
 
-        # Create a temporary directory to work in
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_arc = f"{tmp_dir}/cves.zip.zip"
 
@@ -66,7 +73,7 @@ class Command(BaseCommand):
             with open(tmp_arc, "wb") as fz:
                 fz.write(r.content)
 
-            # Extract the archive
+            # Extract the archive into $DATA_CACHE_DIR
             with zipfile.ZipFile(tmp_arc) as z_arc:
                 logger.warn("Extract the first archive to cves.zip")
 
@@ -75,23 +82,55 @@ class Command(BaseCommand):
             with zipfile.ZipFile(f"{tmp_dir}/cves.zip") as z_arc:
                 logger.warn("Extract the second archive to cves")
 
-                z_arc.extractall(path=tmp_dir)
+                z_arc.extractall(path=data_cache_dir)
 
-            # Open a single transaction for the db
-            with transaction.atomic():
-                # Traverse the tree and import cves
-                cve_list = glob(f"{tmp_dir}/cves/*/*/*.json")
-                if kwargs["subset"] > 0:
-                    cve_list = cve_list[: kwargs["subset"]]
-                logger.warn(f"{len(cve_list)} CVEs to ingest.")
+        return release
 
-                for j_cve in cve_list:
-                    with open(j_cve) as fc:
-                        mkCve(json.load(fc), triaged=True)
+    def _set_cve_data_cache_dir(self):
+        data_cache_dir = env.get("DATA_CACHE_DIRECTORY")
 
-        # Record the ingestion
-        v_date = release.tag_name.split("_")[1]
+        if data_cache_dir is None:
+            data_cache_dir = path.join(
+                path.dirname(path.realpath(__file__)), ".data_cache"
+            )
+            logger.warn("$DATA_CACHE_DIRECTORY was not set. Using the local dir.")
 
-        logger.warn(f"Saving the ingestion valid up to {v_date}")
+        # Work in the $DATA_CACHE_DIRECTORY
+        if not path.exists(data_cache_dir):
+            mkdir(path.join(data_cache_dir))
 
-        CveIngestion.objects.create(valid_to=date.fromisoformat(v_date), delta=False)
+        return data_cache_dir, path.join(data_cache_dir, "cves")
+
+    def handle(self, *args, **kwargs) -> None:  # pyright: ignore reportUnusedVariable
+        data_cache_dir, cve_data_cache_dir = self._set_cve_data_cache_dir()
+
+        # delete if force-download
+        if kwargs["force_download"] and path.exists(cve_data_cache_dir):
+            shutil.rmtree(cve_data_cache_dir)
+
+        if not path.exists(cve_data_cache_dir):
+            # Doing a self assignment trick to keep pyright happy ...
+            self.release = self._download_gh_bundle(data_cache_dir)
+
+        # Traverse the tree and import cves if they already exist
+        cve_list = glob(f"{cve_data_cache_dir}/*/*/*.json")
+
+        # Open a single transaction for the db
+        with transaction.atomic():
+            if kwargs["subset"] > 0:
+                cve_list = cve_list[: kwargs["subset"]]
+            logger.warn(f"{len(cve_list)} CVEs to ingest.")
+
+            for j_cve in cve_list:
+                with open(j_cve) as fc:
+                    mkCve(json.load(fc), triaged=True)
+
+        if not path.exists(cve_data_cache_dir):
+            # Record the ingestion
+            v_date = self.release.tag_name.split("_")[1]
+
+            logger.warn(f"Saving the ingestion valid up to {v_date}")
+
+            CveIngestion.objects.create(
+                valid_to=date.fromisoformat(v_date), delta=False
+            )


### PR DESCRIPTION
Most of the time spent on CVE import is fetching and uncompressing the CVE bundle from Github. This penalizes development work on the database, where multiple reimports might be needed.

Now the CVE data gets stored in a local cache directory after the first fetch. It's still possible to force the deletion of the CVE cache to download the bundle again with the `--force-download` option.