### PR TITLE
build: enable naming convention linter

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,14 +20,21 @@ rec {
       "/nix/web-security-tracker.nix"
     ];
 
-    hooks = {
+    hooks = let
+      pythonExcludes = [
+        "$src/website/shared/migrations/.*\\.py^" # auto-generated code
+      ];
+    in {
       # Nix setup
       nixfmt.enable = true;
       statix.enable = true;
       deadnix.enable = true;
 
       # Python setup
-      ruff.enable = true;
+      ruff = {
+        enable = true;
+        excludes = pythonExcludes;
+      };
       ruff-format = {
         enable = true;
         name = "Format python code with ruff";
@@ -36,8 +43,12 @@ rec {
           "python"
         ];
         entry = "${pkgs.lib.getExe pkgs.ruff} format";
+        excludes = pythonExcludes;
       };
-      pyright.enable = true;
+      pyright = {
+        enable = true;
+        excludes = pythonExcludes;
+      };
 
       # Global setup
       prettier = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [tool.ruff]
 target-version = "py311"
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "N"]
 ignore = [
   "F403",
-  "E501" # line too long
+  "E501", # line too long
 ]
+exclude = ["src/website/shared/migrations/*.py"] # auto-generated code
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/src/website/shared/fetchers.py
+++ b/src/website/shared/fetchers.py
@@ -9,7 +9,7 @@ from requests import get
 from shared import models
 
 
-def mkOrganization(
+def make_organization(
     uuid: Optional[str], short_name: Optional[str] = None
 ) -> Optional[models.Organization]:
     if uuid is None:
@@ -24,7 +24,7 @@ def mkOrganization(
     return org
 
 
-def mkDate(date: Optional[str]) -> Optional[datetime]:
+def make_date(date: Optional[str]) -> Optional[datetime]:
     if date is None:
         return None
 
@@ -36,7 +36,7 @@ def mkDate(date: Optional[str]) -> Optional[datetime]:
     return time
 
 
-def mkMedia(data: Dict[str, str]) -> models.SupportingMedia:
+def make_media(data: Dict[str, str]) -> models.SupportingMedia:
     ctx: Dict[str, Any] = dict()
     ctx["_type"] = data["type"]
     ctx["base64"] = data["base64"]
@@ -45,83 +45,83 @@ def mkMedia(data: Dict[str, str]) -> models.SupportingMedia:
     return models.SupportingMedia.objects.create(**ctx)
 
 
-def mkDescription(data: Dict[str, Any]) -> models.Description:
+def make_description(data: Dict[str, Any]) -> models.Description:
     ctx: Dict[str, Any] = dict()
     ctx["lang"] = data["lang"]
     ctx["value"] = data["value"]
 
     obj = models.Description.objects.create(**ctx)
-    obj.media.set(map(mkMedia, data.get("supportingMedia", [])))
+    obj.media.set(map(make_media, data.get("supportingMedia", [])))
 
     return obj
 
 
-def mkTag(name: str) -> models.Tag:
+def make_tag(name: str) -> models.Tag:
     obj, _ = models.Tag.objects.get_or_create(value=name)
 
     return obj
 
 
-def mkReference(data: Dict[str, Any]) -> models.Reference:
+def make_reference(data: Dict[str, Any]) -> models.Reference:
     ctx: Dict[str, Any] = dict()
     ctx["url"] = data["url"]
     ctx["name"] = data.get("name", "")
 
     obj = models.Reference.objects.create(**ctx)
-    obj.tags.set(map(mkTag, data.get("tags", [])))
+    obj.tags.set(map(make_tag, data.get("tags", [])))
 
     return obj
 
 
-def mkProblemType(data: Dict[str, Any]) -> models.ProblemType:
+def make_problem_type(data: Dict[str, Any]) -> models.ProblemType:
     ctx: Dict[str, Any] = dict()
     ctx["cwe_id"] = data.get("cweId")
     ctx["_type"] = data.get("type")
 
     obj = models.ProblemType.objects.create(**ctx)
     obj.description.set(
-        [mkDescription({"lang": data["lang"], "value": data["description"]})]
+        [make_description({"lang": data["lang"], "value": data["description"]})]
     )
-    obj.references.set(map(mkReference, data.get("references", [])))
+    obj.references.set(map(make_reference, data.get("references", [])))
 
     return obj
 
 
-def mkMetric(data: Dict[str, Any]) -> models.Metric:
+def make_metric(data: Dict[str, Any]) -> models.Metric:
     ctx: Dict[str, Any] = dict()
     ctx["format"] = "cvssV3_1"
     ctx["content"] = data.get("cvssV3_1", {})
 
     obj = models.Metric.objects.create(**ctx)
-    obj.scenarios.set(map(mkDescription, data.get("scenarios", [])))
+    obj.scenarios.set(map(make_description, data.get("scenarios", [])))
 
     return obj
 
 
-def mkEvent(data: Dict[str, Any]) -> models.Event:
+def make_event(data: Dict[str, Any]) -> models.Event:
     ctx: Dict[str, Any] = dict()
-    ctx["time"] = mkDate(data["time"])
-    ctx["description"] = mkDescription(data)
+    ctx["time"] = make_date(data["time"])
+    ctx["description"] = make_description(data)
 
     return models.Event.objects.create(**ctx)
 
 
-def mkCredit(data: Dict[str, Any]) -> models.Credit:
+def make_credit(data: Dict[str, Any]) -> models.Credit:
     ctx: Dict[str, Any] = dict()
     ctx["_type"] = data.get("type", "finder")
-    ctx["user"] = mkOrganization(uuid=data.get("user"))
-    ctx["description"] = mkDescription(data)
+    ctx["user"] = make_organization(uuid=data.get("user"))
+    ctx["description"] = make_description(data)
 
     return models.Credit.objects.create(**ctx)
 
 
-def mkPlatform(name: str) -> models.Platform:
+def make_platform(name: str) -> models.Platform:
     obj, _ = models.Platform.objects.get_or_create(name=name)
 
     return obj
 
 
-def mkVersion(data: Dict[str, Any]) -> models.Version:
+def make_version(data: Dict[str, Any]) -> models.Version:
     ctx: Dict[str, Any] = dict()
     ctx["version"] = data.get("version")
     ctx["status"] = data.get("status", models.Version.Status.UNKNOWN)
@@ -132,31 +132,31 @@ def mkVersion(data: Dict[str, Any]) -> models.Version:
     return models.Version.objects.create(**ctx)
 
 
-def mkCpe(name: str) -> models.Cpe:
+def make_cpe(name: str) -> models.Cpe:
     obj, _ = models.Cpe.objects.get_or_create(name=name)
 
     return obj
 
 
-def mkModule(name: str) -> models.Module:
+def make_module(name: str) -> models.Module:
     obj, _ = models.Module.objects.get_or_create(name=name)
 
     return obj
 
 
-def mkProgramFile(name: str) -> models.ProgramFile:
+def make_program_file(name: str) -> models.ProgramFile:
     obj, _ = models.ProgramFile.objects.get_or_create(name=name)
 
     return obj
 
 
-def mkProgramRoutine(name: str) -> models.ProgramRoutine:
+def make_program_routine(name: str) -> models.ProgramRoutine:
     obj, _ = models.ProgramRoutine.objects.get_or_create(name=name)
 
     return obj
 
 
-def mkAffectedProduct(data: Dict[str, Any]) -> models.AffectedProduct:
+def make_affected_product(data: Dict[str, Any]) -> models.AffectedProduct:
     ctx: Dict[str, Any] = dict()
     ctx["vendor"] = data.get("vendor")
     ctx["product"] = data.get("product")
@@ -168,17 +168,17 @@ def mkAffectedProduct(data: Dict[str, Any]) -> models.AffectedProduct:
     )
 
     obj = models.AffectedProduct.objects.create(**ctx)
-    obj.platforms.set(map(mkPlatform, data.get("platforms", [])))
-    obj.versions.set(map(mkVersion, data.get("versions", [])))
-    obj.cpes.set(map(mkCpe, data.get("cpes", [])))
-    obj.modules.set(map(mkModule, data.get("modules", [])))
-    obj.program_files.set(map(mkProgramFile, data.get("programFiles", [])))
-    obj.program_routines.set(map(mkProgramRoutine, data.get("programRoutines", [])))
+    obj.platforms.set(map(make_platform, data.get("platforms", [])))
+    obj.versions.set(map(make_version, data.get("versions", [])))
+    obj.cpes.set(map(make_cpe, data.get("cpes", [])))
+    obj.modules.set(map(make_module, data.get("modules", [])))
+    obj.program_files.set(map(make_program_file, data.get("programFiles", [])))
+    obj.program_routines.set(map(make_program_routine, data.get("programRoutines", [])))
 
     return obj
 
 
-def mkCveRecord(
+def make_cve_record(
     data: Dict[str, Any], cve: Optional[models.CveRecord] = None
 ) -> models.CveRecord:
     if cve is None:
@@ -187,69 +187,69 @@ def mkCveRecord(
     cve.cve_id = data["cveId"]
     cve.state = data["state"]
 
-    org = mkOrganization(
+    org = make_organization(
         uuid=data["assignerOrgId"], short_name=data.get("assignerShortName")
     )
 
     assert org is not None, "Organisation cannot be empty"
 
     cve.assigner = org
-    cve.requester = mkOrganization(uuid=data.get("requesterUserId"))
+    cve.requester = make_organization(uuid=data.get("requesterUserId"))
 
-    cve.date_reserved = mkDate(data.get("dateReserved"))
-    cve.date_updated = mkDate(data.get("dateUpdated"))
-    cve.date_published = mkDate(data.get("datePublished"))
+    cve.date_reserved = make_date(data.get("dateReserved"))
+    cve.date_updated = make_date(data.get("dateUpdated"))
+    cve.date_published = make_date(data.get("datePublished"))
     cve.serial = data.get("serial", 1)
 
     return cve
 
 
-def mkContainer(
+def make_container(
     data: Dict[str, Any], _type: str, cve: models.CveRecord
 ) -> models.Container:
     ctx: Dict[str, Any] = {"_type": _type, "cve": cve}
-    ctx["provider"] = mkOrganization(
+    ctx["provider"] = make_organization(
         uuid=data["providerMetadata"].get("orgId"),
         short_name=data["providerMetadata"].get("shortName"),
     )
     ctx["title"] = data.get("title", "")
 
     if _type == models.Container.Type.CNA:
-        ctx["date_assigned"] = mkDate(data.get("dateAssigned"))
+        ctx["date_assigned"] = make_date(data.get("dateAssigned"))
 
-    ctx["date_public"] = mkDate(data.get("datePublic"))
+    ctx["date_public"] = make_date(data.get("datePublic"))
     ctx["source"] = data.get("source", dict())
 
     obj = models.Container.objects.create(**ctx)
-    obj.descriptions.set(map(mkDescription, data.get("descriptions", [])))
+    obj.descriptions.set(map(make_description, data.get("descriptions", [])))
 
-    obj.affected.set(map(mkAffectedProduct, data.get("affected", [])))
+    obj.affected.set(map(make_affected_product, data.get("affected", [])))
     # Map problem types from the terrible definition to our models
     problems = [
         desc
         for problem in data.get("problemTypes", [])
         for desc in problem.get("description", [])
     ]
-    obj.problem_types.set(map(mkProblemType, problems))
-    obj.references.set(map(mkReference, data.get("references", [])))
-    obj.metrics.set(map(mkMetric, data.get("metrics", [])))
-    obj.configurations.set(map(mkDescription, data.get("configurations", [])))
-    obj.workarounds.set(map(mkDescription, data.get("workarounds", [])))
-    obj.solutions.set(map(mkDescription, data.get("solutions", [])))
-    obj.exploits.set(map(mkDescription, data.get("exploits", [])))
-    obj.timeline.set(map(mkEvent, data.get("timeline", [])))
-    obj.tags.set(map(mkTag, data.get("tags", [])))
-    obj.credits.set(map(mkCredit, data.get("credits", [])))
+    obj.problem_types.set(map(make_problem_type, problems))
+    obj.references.set(map(make_reference, data.get("references", [])))
+    obj.metrics.set(map(make_metric, data.get("metrics", [])))
+    obj.configurations.set(map(make_description, data.get("configurations", [])))
+    obj.workarounds.set(map(make_description, data.get("workarounds", [])))
+    obj.solutions.set(map(make_description, data.get("solutions", [])))
+    obj.exploits.set(map(make_description, data.get("exploits", [])))
+    obj.timeline.set(map(make_event, data.get("timeline", [])))
+    obj.tags.set(map(make_tag, data.get("tags", [])))
+    obj.credits.set(map(make_credit, data.get("credits", [])))
 
     return obj
 
 
-def mkCve(
+def make_cve(
     data: Dict[str, Any],
     record: Optional[models.CveRecord] = None,
     triaged: bool = False,
 ) -> models.CveRecord:
-    cve = mkCveRecord(data["cveMetadata"], cve=record)
+    cve = make_cve_record(data["cveMetadata"], cve=record)
     cve.triaged = triaged
     cve.save()
 
@@ -257,10 +257,10 @@ def mkCve(
         # TODO: Remove stale data to prevent overgrowth
         pass
 
-    mkContainer(data["containers"]["cna"], _type=models.Container.Type.CNA, cve=cve)
+    make_container(data["containers"]["cna"], _type=models.Container.Type.CNA, cve=cve)
 
     for adp in data["containers"].get("adp", []):
-        mkContainer(adp, _type=models.Container.Type.ADP, cve=cve)
+        make_container(adp, _type=models.Container.Type.ADP, cve=cve)
 
     return cve
 
@@ -285,4 +285,4 @@ def fetch_cve_gh(cve_id: str) -> Optional[models.CveRecord]:
 
     data = json.loads(r.text)
 
-    return mkCve(data)
+    return make_cve(data)

--- a/src/website/shared/management/commands/ingest_bulk_cve.py
+++ b/src/website/shared/management/commands/ingest_bulk_cve.py
@@ -11,7 +11,7 @@ from os import mkdir, path
 import requests
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from shared.fetchers import mkCve
+from shared.fetchers import make_cve
 from shared.models import CveIngestion
 from shared.utils import get_gh
 
@@ -122,7 +122,7 @@ class Command(BaseCommand):
 
             for j_cve in cve_list:
                 with open(j_cve) as fc:
-                    mkCve(json.load(fc), triaged=True)
+                    make_cve(json.load(fc), triaged=True)
 
         if not path.exists(cve_data_cache_dir):
             # Record the ingestion

--- a/src/website/shared/management/commands/ingest_delta_cve.py
+++ b/src/website/shared/management/commands/ingest_delta_cve.py
@@ -10,7 +10,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from github import UnknownObjectException
 from shared import models
-from shared.fetchers import mkCve
+from shared.fetchers import make_cve
 from shared.models import CveIngestion
 from shared.utils import get_gh
 
@@ -93,7 +93,7 @@ class Command(BaseCommand):
                         data = json.load(fc)
                         cve_id = data["cveMetadata"]["cveId"]
 
-                        mkCve(
+                        make_cve(
                             data,
                             record=models.CveRecord.objects.filter(
                                 cve_id=cve_id

--- a/src/website/shared/management/commands/ingest_manual_evaluation.py
+++ b/src/website/shared/management/commands/ingest_manual_evaluation.py
@@ -436,31 +436,31 @@ def dict_hash(qwargs):
 class MaintainerAttribute(JSONWizard):
     name: str
     github: str | None = None
-    githubId: int | None = None
+    github_id: int | None = None
     email: str | None = None
     matrix: str | None = None
 
 
 @dataclass
 class LicenseAttribute(JSONWizard):
-    fullName: str | None = None
+    full_name: str | None = None
     deprecated: bool = False
     free: bool = False
     redistributable: bool = False
-    shortName: str | None = None
-    spdxId: str | None = None
+    short_name: str | None = None
+    spdx_id: str | None = None
     url: str | None = None
 
 
 @dataclass
 class MetadataAttribute(JSONWizard, LoadMixin, DumpMixin):
-    outputsToInstall: list[str] = field(default_factory=list)
+    outputs_to_install: list[str] = field(default_factory=list)
     available: bool = True
     broken: bool = False
     unfree: bool = False
     unsupported: bool = False
     insecure: bool = False
-    mainProgram: str | None = None
+    main_program: str | None = None
     position: str | None = None
     homepage: str | None = None
     description: str | None = None
@@ -468,7 +468,7 @@ class MetadataAttribute(JSONWizard, LoadMixin, DumpMixin):
     maintainers: list[MaintainerAttribute] = field(default_factory=list)
     license: list[LicenseAttribute] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
-    knownVulnerabilities: list[str] = field(default_factory=list)
+    known_vulnerabilities: list[str] = field(default_factory=list)
 
     def __pre_as_dict__(self):
         linearized_maintainers = []
@@ -493,11 +493,11 @@ class EvaluatedAttribute(JSONWizard):
     """
 
     attr: str
-    attrPath: list[str]
+    attr_path: list[str]
     name: str
-    drvPath: str
+    drv_path: str
     # drv -> list of outputs.
-    inputDrvs: dict[str, list[str]]
+    input_drvs: dict[str, list[str]]
     meta: MetadataAttribute | None
     outputs: dict[str, str]
     system: str
@@ -512,7 +512,7 @@ class PartialEvaluatedAttribute:
     """
 
     attr: str
-    attrPath: list[str]
+    attr_path: list[str]
     error: str | None = None
     evaluation: EvaluatedAttribute | None = None
 
@@ -559,7 +559,7 @@ def parse_evaluation_results(lines) -> Generator[PartialEvaluatedAttribute, None
         else:
             yield PartialEvaluatedAttribute(
                 attr=raw.get("attr"),
-                attrPath=raw.get("attrPath"),
+                attr_path=raw.get("attrPath"),
                 error=None,
                 evaluation=parse_total_evaluation(raw),
             )
@@ -591,7 +591,7 @@ class BulkEvaluationIngestion:
             # This unfortunately creates a partial view of all maintainers of a
             # given package. If you want to fix this, you can start from
             # looking around https://github.com/NixOS/nixpkgs/pull/273220.
-            if m.github is None or m.githubId is None:
+            if m.github is None or m.github_id is None:
                 continue
 
             # Duplicate...
@@ -602,7 +602,7 @@ class BulkEvaluationIngestion:
                 NixMaintainer(
                     email=m.email,
                     github=m.github,
-                    github_id=m.githubId,
+                    github_id=m.github_id,
                     matrix=m.matrix,
                     name=m.name,
                 )
@@ -638,9 +638,9 @@ class BulkEvaluationIngestion:
                         "free": lic.free,
                         "redistributable": lic.redistributable,
                     },
-                    full_name=lic.fullName,
-                    short_name=lic.shortName,
-                    spdx_id=lic.spdxId,
+                    full_name=lic.full_name,
+                    short_name=lic.short_name,
+                    spdx_id=lic.spdx_id,
                     url=lic.url,
                 )[0]
             )
@@ -675,9 +675,9 @@ class BulkEvaluationIngestion:
             unsupported=metadata.unsupported,
             homepage=metadata.homepage,
             description=metadata.description,
-            main_program=metadata.mainProgram,
+            main_program=metadata.main_program,
             position=metadata.position,
-            known_vulnerabilities=metadata.knownVulnerabilities,
+            known_vulnerabilities=metadata.known_vulnerabilities,
         )
         self.bs.add_insert(meta)
         self.bs.set_m2m(meta, "maintainers", maintainers)
@@ -726,12 +726,12 @@ class BulkEvaluationIngestion:
         meta = None
         if drv.meta is not None:
             meta = self.ingest_meta(drv.meta)
-        dependencies = self.ingest_dependencies(drv.inputDrvs)
+        dependencies = self.ingest_dependencies(drv.input_drvs)
         outputs = self.ingest_outputs(drv.outputs)
 
         derivation = NixDerivation(
             attribute=drv.attr,
-            derivation_path=drv.drvPath,
+            derivation_path=drv.drv_path,
             name=drv.name,
             metadata=meta,
             system=self.platforms[drv.system],


### PR DESCRIPTION
Life is too short to debate about naming conventions. Let's just use something that is widely accepted and move on.

JSONWizard will automatically convert from camelCase:

```
from dataclasses import dataclass
from dataclass_wizard import JSONWizard

@dataclass
class MaintainerAttribute(JSONWizard):
    name: str
    github: str | None = None
    github_id: int | None = None
    email: str | None = None
    matrix: str | None = None

def main() -> None:
    m = MaintainerAttribute.from_json("""
     {
        "name": "John Doe",
        "github": "johndoe",
        "githubId": 123456,
        "email": "john@doe.info",
        "matrix": "johndoe%example.com"
     }
    """)
    print(m.github_id) # 123456

if __name__ == "__main__":
    main()
```