### PR TITLE
build: enforce type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 target-version = "py311"
-select = ["E", "F", "I", "N"]
+select = ["E", "F", "I", "N", "U"]
 ignore = [
   "F403",
   "E501", # line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,11 @@
 [tool.ruff]
 target-version = "py311"
-select = ["E", "F", "I", "N", "U"]
+select = ["E", "F", "I", "N", "U", "ANN"]
 ignore = [
   "F403",
   "E501", # line too long
+  "ANN101", # Missing type annotation for `self` in method
+  "ANN401" # Dynamically typed expressions (typing.Any) are disallowed
 ]
 exclude = ["src/website/shared/migrations/*.py"] # auto-generated code
 

--- a/src/website/manage.py
+++ b/src/website/manage.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 
-def main():
+def main() -> None:
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tracker.settings")
     try:

--- a/src/website/shared/fetchers.py
+++ b/src/website/shared/fetchers.py
@@ -1,7 +1,7 @@
 import json
 import re
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any
 
 from django.utils.timezone import make_aware
 from requests import get
@@ -10,8 +10,8 @@ from shared import models
 
 
 def make_organization(
-    uuid: Optional[str], short_name: Optional[str] = None
-) -> Optional[models.Organization]:
+    uuid: str | None, short_name: str | None = None
+) -> models.Organization | None:
     if uuid is None:
         return None
 
@@ -24,7 +24,7 @@ def make_organization(
     return org
 
 
-def make_date(date: Optional[str]) -> Optional[datetime]:
+def make_date(date: str | None) -> datetime | None:
     if date is None:
         return None
 
@@ -36,8 +36,8 @@ def make_date(date: Optional[str]) -> Optional[datetime]:
     return time
 
 
-def make_media(data: Dict[str, str]) -> models.SupportingMedia:
-    ctx: Dict[str, Any] = dict()
+def make_media(data: dict[str, str]) -> models.SupportingMedia:
+    ctx: dict[str, Any] = dict()
     ctx["_type"] = data["type"]
     ctx["base64"] = data["base64"]
     ctx["value"] = data["value"]
@@ -45,8 +45,8 @@ def make_media(data: Dict[str, str]) -> models.SupportingMedia:
     return models.SupportingMedia.objects.create(**ctx)
 
 
-def make_description(data: Dict[str, Any]) -> models.Description:
-    ctx: Dict[str, Any] = dict()
+def make_description(data: dict[str, Any]) -> models.Description:
+    ctx: dict[str, Any] = dict()
     ctx["lang"] = data["lang"]
     ctx["value"] = data["value"]
 
@@ -62,8 +62,8 @@ def make_tag(name: str) -> models.Tag:
     return obj
 
 
-def make_reference(data: Dict[str, Any]) -> models.Reference:
-    ctx: Dict[str, Any] = dict()
+def make_reference(data: dict[str, Any]) -> models.Reference:
+    ctx: dict[str, Any] = dict()
     ctx["url"] = data["url"]
     ctx["name"] = data.get("name", "")
 
@@ -73,8 +73,8 @@ def make_reference(data: Dict[str, Any]) -> models.Reference:
     return obj
 
 
-def make_problem_type(data: Dict[str, Any]) -> models.ProblemType:
-    ctx: Dict[str, Any] = dict()
+def make_problem_type(data: dict[str, Any]) -> models.ProblemType:
+    ctx: dict[str, Any] = dict()
     ctx["cwe_id"] = data.get("cweId")
     ctx["_type"] = data.get("type")
 
@@ -87,8 +87,8 @@ def make_problem_type(data: Dict[str, Any]) -> models.ProblemType:
     return obj
 
 
-def make_metric(data: Dict[str, Any]) -> models.Metric:
-    ctx: Dict[str, Any] = dict()
+def make_metric(data: dict[str, Any]) -> models.Metric:
+    ctx: dict[str, Any] = dict()
     ctx["format"] = "cvssV3_1"
     ctx["content"] = data.get("cvssV3_1", {})
 
@@ -98,16 +98,16 @@ def make_metric(data: Dict[str, Any]) -> models.Metric:
     return obj
 
 
-def make_event(data: Dict[str, Any]) -> models.Event:
-    ctx: Dict[str, Any] = dict()
+def make_event(data: dict[str, Any]) -> models.Event:
+    ctx: dict[str, Any] = dict()
     ctx["time"] = make_date(data["time"])
     ctx["description"] = make_description(data)
 
     return models.Event.objects.create(**ctx)
 
 
-def make_credit(data: Dict[str, Any]) -> models.Credit:
-    ctx: Dict[str, Any] = dict()
+def make_credit(data: dict[str, Any]) -> models.Credit:
+    ctx: dict[str, Any] = dict()
     ctx["_type"] = data.get("type", "finder")
     ctx["user"] = make_organization(uuid=data.get("user"))
     ctx["description"] = make_description(data)
@@ -121,8 +121,8 @@ def make_platform(name: str) -> models.Platform:
     return obj
 
 
-def make_version(data: Dict[str, Any]) -> models.Version:
-    ctx: Dict[str, Any] = dict()
+def make_version(data: dict[str, Any]) -> models.Version:
+    ctx: dict[str, Any] = dict()
     ctx["version"] = data.get("version")
     ctx["status"] = data.get("status", models.Version.Status.UNKNOWN)
     ctx["version_type"] = data.get("versionType")
@@ -156,8 +156,8 @@ def make_program_routine(name: str) -> models.ProgramRoutine:
     return obj
 
 
-def make_affected_product(data: Dict[str, Any]) -> models.AffectedProduct:
-    ctx: Dict[str, Any] = dict()
+def make_affected_product(data: dict[str, Any]) -> models.AffectedProduct:
+    ctx: dict[str, Any] = dict()
     ctx["vendor"] = data.get("vendor")
     ctx["product"] = data.get("product")
     ctx["collection_url"] = data.get("collectionURL")
@@ -179,7 +179,7 @@ def make_affected_product(data: Dict[str, Any]) -> models.AffectedProduct:
 
 
 def make_cve_record(
-    data: Dict[str, Any], cve: Optional[models.CveRecord] = None
+    data: dict[str, Any], cve: models.CveRecord | None = None
 ) -> models.CveRecord:
     if cve is None:
         cve = models.CveRecord()
@@ -205,9 +205,9 @@ def make_cve_record(
 
 
 def make_container(
-    data: Dict[str, Any], _type: str, cve: models.CveRecord
+    data: dict[str, Any], _type: str, cve: models.CveRecord
 ) -> models.Container:
-    ctx: Dict[str, Any] = {"_type": _type, "cve": cve}
+    ctx: dict[str, Any] = {"_type": _type, "cve": cve}
     ctx["provider"] = make_organization(
         uuid=data["providerMetadata"].get("orgId"),
         short_name=data["providerMetadata"].get("shortName"),
@@ -245,8 +245,8 @@ def make_container(
 
 
 def make_cve(
-    data: Dict[str, Any],
-    record: Optional[models.CveRecord] = None,
+    data: dict[str, Any],
+    record: models.CveRecord | None = None,
     triaged: bool = False,
 ) -> models.CveRecord:
     cve = make_cve_record(data["cveMetadata"], cve=record)
@@ -265,7 +265,7 @@ def make_cve(
     return cve
 
 
-def fetch_cve_gh(cve_id: str) -> Optional[models.CveRecord]:
+def fetch_cve_gh(cve_id: str) -> models.CveRecord | None:
     """Fetch a cve from the cvelistV5 github repository."""
 
     m = re.fullmatch(

--- a/src/website/shared/management/commands/ingest_bulk_cve.py
+++ b/src/website/shared/management/commands/ingest_bulk_cve.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import logging
 import shutil
@@ -7,10 +8,12 @@ from datetime import date
 from glob import glob
 from os import environ as env
 from os import mkdir, path
+from typing import Any
 
 import requests
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from github.GitRelease import GitRelease
 from shared.fetchers import make_cve
 from shared.models import CveIngestion
 from shared.utils import get_gh
@@ -21,7 +24,7 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = "Ingest CVEs in bulk using the Mitre CVE repo"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "-s",
             "--subset",
@@ -37,7 +40,7 @@ class Command(BaseCommand):
             help="Ignore the local data cache content and download the CVEs zip again.",
         )
 
-    def _download_gh_bundle(self, data_cache_dir):
+    def _download_gh_bundle(self, data_cache_dir: str) -> GitRelease:
         # Initialize a GitHub connection
         g = get_gh()
 
@@ -85,7 +88,7 @@ class Command(BaseCommand):
 
         return release
 
-    def _set_cve_data_cache_dir(self):
+    def _set_cve_data_cache_dir(self) -> tuple[str, str]:
         data_cache_dir = env.get("DATA_CACHE_DIRECTORY")
 
         if data_cache_dir is None:
@@ -100,7 +103,7 @@ class Command(BaseCommand):
 
         return data_cache_dir, path.join(data_cache_dir, "cves")
 
-    def handle(self, *args, **kwargs) -> None:  # pyright: ignore reportUnusedVariable
+    def handle(self, *args: str, **kwargs: Any) -> None:  # pyright: ignore reportUnusedVariable
         data_cache_dir, cve_data_cache_dir = self._set_cve_data_cache_dir()
 
         # delete if force-download

--- a/src/website/shared/management/commands/ingest_delta_cve.py
+++ b/src/website/shared/management/commands/ingest_delta_cve.py
@@ -1,9 +1,11 @@
+import argparse
 import datetime
 import json
 import logging
 import tempfile
 import zipfile
 from glob import glob
+from typing import Any
 
 import requests
 from django.core.management.base import BaseCommand, CommandError
@@ -20,10 +22,10 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = "Ingest CVEs in bulk using the Mitre CVE repo"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("date", help="Date of the delta to download.")
 
-    def handle(self, *args, **kwargs) -> None:
+    def handle(self, *args: Any, **kwargs: Any) -> None:
         _date = kwargs["date"]
 
         try:

--- a/src/website/shared/management/commands/register_channel.py
+++ b/src/website/shared/management/commands/register_channel.py
@@ -1,3 +1,6 @@
+import argparse
+from typing import Any
+
 from django.core.management.base import BaseCommand
 from shared.models.nix_evaluation import NixChannel
 
@@ -5,17 +8,15 @@ from shared.models.nix_evaluation import NixChannel
 class Command(BaseCommand):
     help = "Register Nix channels"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("staging_branch", type=str)
         parser.add_argument("channel_branch", type=str)
         parser.add_argument("state", type=str)
 
-    def handle(self, *args, **kwargs):
-        kwargs["repository"] = "https://github.com/NixOS/nixpkgs"
-        params = {
-            "repository": "https://github.com/NixOS/nixpkgs",
-            "staging_branch": kwargs["staging_branch"],
-            "channel_branch": kwargs["channel_branch"],
-            "state": kwargs["state"],
-        }
-        NixChannel.objects.get_or_create(**params)
+    def handle(self, *args: Any, **kwargs: str) -> None:
+        NixChannel.objects.get_or_create(
+            repository="https://github.com/NixOS/nixpkgs",
+            staging_branch=kwargs["staging_branch"],
+            channel_branch=kwargs["channel_branch"],
+            state=kwargs["state"],
+        )

--- a/src/website/shared/models/cve.py
+++ b/src/website/shared/models/cve.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models.signals import post_save
@@ -9,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from .nix_evaluation import NixDerivation
 
 
-def text_length(choices: Type[models.TextChoices]):
+def text_length(choices: type[models.TextChoices]):
     return max(map(len, choices.values))
 
 

--- a/src/website/shared/models/cve.py
+++ b/src/website/shared/models/cve.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models.signals import post_save
@@ -7,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from .nix_evaluation import NixDerivation
 
 
-def text_length(choices: type[models.TextChoices]):
+def text_length(choices: type[models.TextChoices]) -> int:
     return max(map(len, choices.values))
 
 
@@ -319,7 +321,7 @@ class NixpkgsIssue(models.Model):
         return self.code
 
     @property
-    def status_string(self):
+    def status_string(self) -> str:
         mapping = {
             IssueStatus.UNKNOWN: "unknown",
             IssueStatus.AFFECTED: "affected",
@@ -331,7 +333,9 @@ class NixpkgsIssue(models.Model):
 
 
 @receiver(post_save, sender=NixpkgsIssue)
-def generate_code(sender, instance, created, **kwargs):
+def generate_code(
+    sender: type[NixpkgsIssue], instance: NixpkgsIssue, created: bool, **kwargs: Any
+) -> None:
     if created:
         number = sender.objects.filter(
             created__year=instance.created.year, pk__lte=instance.pk

--- a/src/website/shared/models/nix_evaluation.py
+++ b/src/website/shared/models/nix_evaluation.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
-def text_length(choices: type[models.TextChoices]):
+def text_length(choices: type[models.TextChoices]) -> int:
     return max(map(len, choices.values))
 
 

--- a/src/website/shared/models/nix_evaluation.py
+++ b/src/website/shared/models/nix_evaluation.py
@@ -1,11 +1,9 @@
-from typing import Type
-
 from django.contrib.postgres import fields
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
-def text_length(choices: Type[models.TextChoices]):
+def text_length(choices: type[models.TextChoices]):
     return max(map(len, choices.values))
 
 

--- a/src/website/shared/utils.py
+++ b/src/website/shared/utils.py
@@ -1,6 +1,5 @@
 import logging
 from os import environ as env
-from typing import Optional
 
 from github import Auth, Github
 
@@ -14,7 +13,7 @@ def get_gh() -> Github:
 
     credentials_dir = env.get("CREDENTIALS_DIRECTORY")
 
-    gh_auth: Optional[Auth.Auth] = None
+    gh_auth: Auth.Auth | None = None
 
     if credentials_dir is None:
         logger.warn("No credentials directory available, using unauthenticated API.")

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -1,5 +1,7 @@
-import re
+from typing import Any
 
+from django.db.models import Model
+from django.db.models.manager import BaseManager
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView, ListView, TemplateView
 from shared.models import Container, CveRecord, NixpkgsIssue
@@ -42,5 +44,5 @@ class NixpkgsIssueListView(ListView):
     template_name = "issue_list.html"
     model = NixpkgsIssue
 
-    def get_queryset(self):
+    def get_queryset(self) -> BaseManager[NixpkgsIssue]:
         return NixpkgsIssue.objects.all()


### PR DESCRIPTION
This is very recommended for large code bases and mixed teams. It can replace integration tests in some places. I used Any in a few places here. However note that this is still better than using no type because it will than type check this function as well.

Depends on https://github.com/Nix-Security-WG/nix-security-tracker/pull/103