### PR TITLE
feat: add view for affected packages per channel

### DIFF
--- a/src/website/shared/templates/base.html
+++ b/src/website/shared/templates/base.html
@@ -52,6 +52,12 @@
     </article>
     {% endblock layout %}
 
+    {% if is_paginated %}
+      <nav id="pagination">
+        {% block pagination %} {% endblock %}
+      </nav>
+    {% endif %}
+
     <footer>
       <p>
         <a href="https://github.com/Nix-Security-WG/nix-security-tracker">Nixpkgs Security Tracker</a> is part of a project funded by the

--- a/src/website/webview/templates/affected_list.html
+++ b/src/website/webview/templates/affected_list.html
@@ -3,9 +3,12 @@
 
 {% block extra_head %}
   <style>
-    ul#tab-channels { display: flex; padding-left: 1em;  }
-    ul#tab-channels li { position: relative; display: inline-block; float: left; }
-    ul#tab-channels li + li:before { content: " | "; padding: 0 15px; }
+    ul#tab-channels { display: flex; flex-wrap: wrap; padding-left: 1em; list-style: none; padding: 0; margin: 0; }
+    ul#tab-channels li { float: left; border: 1px solid #bbb; border-bottom-width: 0; margin: 0; background: #eee; }
+    ul#tab-channels a {
+      font-size: 0.8em; text-decoration: none; display: block; background: #eee; padding: 0.24em 1em;
+			color: #00c; text-align: center; text-transform: uppercase;
+		}
     ul#tab-channels .current { font-weight: bold; }
 
     nav#pagination { background-color: white; justify-content: center; display: flex; gap: 10px; }

--- a/src/website/webview/templates/affected_list.html
+++ b/src/website/webview/templates/affected_list.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% load viewutils %}
+
+{% block extra_head %}
+  <style>
+    ul#tab-channels { display: flex; padding-left: 1em;  }
+    ul#tab-channels li { position: relative; display: inline-block; float: left; }
+    ul#tab-channels li + li:before { content: " | "; padding: 0 15px; }
+    ul#tab-channels .current { font-weight: bold; }
+
+    nav#pagination { background-color: white; justify-content: center; display: flex; gap: 10px; }
+    nav#pagination a { color: black; }
+    nav#pagination .current { font-weight: bold; }
+    nav#pagination ul { margin-left: unset; margin-right: 1em; }
+    nav#pagination li.index + li.index { margin-left: 0.1em; }
+    nav#pagination .count { color: dimgray; margin-left: unset; margin-right: auto; }
+
+    table { width: 100%; font-size: 0.875rem; text-align: left; border-collapse: collapse; }
+    table th, table td { padding: 5px; }
+    th { background-color: #f2f2f2; }
+    tr:nth-child(even){ background-color: #f2f2f2; }
+    tr:hover { background-color: #ddd; }
+  </style>
+{% endblock %}
+
+{% block title %}
+  Affected derivations per channel
+{% endblock title %}
+
+{% block content %}
+  <h2>Affected derivations per channel</h2>
+
+  <ul id="tab-channels" >
+    {% for channel in channels %}
+      <li class="{% if channel == current_channel %}current {% endif %}">
+        <a href="{% url 'webview:affected_list'%}{{channel|lower}}">{{channel}}</a>
+      </li>
+    {% endfor %}
+  </ul>
+
+  <table>
+    <thead>
+      <tr>
+        {% for header in headers %}
+          <th>{{header}}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+
+    <tbody>
+      {% for drv in affected_list %}
+        <tr>
+          {% comment %}
+          <td><a href="{% url 'webview:drv_detail' drv.drv_id %}">{{ drv.drv_id }}</a></td>
+          {% endcomment %}
+          <td>{{ drv|getdrvname }}</td>
+          <td>{{ drv.drv_system }}</td>
+          <td><a href="{% url 'webview:issue_detail' drv.issue_code %}">{{ drv.issue_code }}</a> </td>
+          <td>{{ drv.cve_code }}</td>{% comment %}drv.cve_id{% endcomment %}
+          <td>{{ drv.cve_state }}</td>
+        </tr>
+      {% endfor %}
+    <tbody>
+  </table>
+{% endblock content %}
+
+{% block pagination %}
+  <ul>
+    {% for page_number in adjusted_elided_page_range %}
+      <li class="index">
+        {% if page_number == paginator.ELLIPSIS %}
+        {{page_number}}
+        {% else %}
+        <a href="{{request.path}}?page={{page_number}}" class="{% if page_number == page_obj.number %}current{% endif %}">
+          {{page_number}}
+        </a>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+  <span class="count">{{paginator.count}} affected derivations</span>
+{% endblock %}

--- a/src/website/webview/templatetags/viewutils.py
+++ b/src/website/webview/templatetags/viewutils.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def getitem(dictionary: dict, key: str) -> Any | None:
+    return dictionary.get(key)
+
+
+@register.filter
+def getdrvname(drv: dict) -> str:
+    hash = drv["drv_path"].split("-")[0].split("/")[-1]
+    name = drv["drv_name"]
+    return f"{name} {hash[:8]}"

--- a/src/website/webview/urls.py
+++ b/src/website/webview/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
         NixderivationPerChannelView.as_view(),
         name="affected_list_per_channel",
     ),
+    # TODO: We may want to put an overview page here
     path(
         "affected/",
         RedirectView.as_view(url="nixos-unstable", permanent=True),

--- a/src/website/webview/urls.py
+++ b/src/website/webview/urls.py
@@ -1,7 +1,14 @@
 from django.urls import path, re_path
+from django.views.generic.base import RedirectView
 from shared.auth.github_webhook import handle_github_hook
 
-from webview.views import HomeView, NixpkgsIssueListView, NixpkgsIssueView, TriageView
+from webview.views import (
+    HomeView,
+    NixderivationPerChannelView,
+    NixpkgsIssueListView,
+    NixpkgsIssueView,
+    TriageView,
+)
 
 app_name = "webview"
 
@@ -16,4 +23,14 @@ urlpatterns = [
         name="issue_detail",
     ),
     path("github-webhook/", handle_github_hook, name="github_webhook"),
+    re_path(
+        "^affected/(?P<channel>nixos-.*)$",
+        NixderivationPerChannelView.as_view(),
+        name="affected_list_per_channel",
+    ),
+    path(
+        "affected/",
+        RedirectView.as_view(url="nixos-unstable", permanent=True),
+        name="affected_list",
+    ),
 ]

--- a/src/website/webview/urls.py
+++ b/src/website/webview/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     ),
     path("github-webhook/", handle_github_hook, name="github_webhook"),
     re_path(
-        "^affected/(?P<channel>nixos-.*)$",
+        "^affected/(?P<channel>(nixos|nixpkgs)-.*)$",
         NixderivationPerChannelView.as_view(),
         name="affected_list_per_channel",
     ),


### PR DESCRIPTION
Create a simple tabbed view for those derivations that appear in an issue marked as 'affected'.

The styles broke in weird ways when moved to the main `style.css`, so I leave them in the template document for the time being.