### PR TITLE
Add license metadata

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,18 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: nix local security scanner
+Upstream-Contact: Dylan Green <dylan.green@obsidian.systems>, Arnout Engelen <arnout@bzzt.net>
+Source: https://github.com/Nix-Security-WG/nix-security-tracker/tree/local-security-scanner
+
+Files: .envrc .gitignore flake.lock
+Copyright: Respective Contributors
+License: CC0-1.0
+
+# https://github.com/fsfe/reuse-tool/issues/882
+Files: LocalSecurityScanner.cabal
+Copyright: 2023 Dylan Green <dylan.green@obsidian.systems>, Arnout Engelen <arnout@bzzt.net>
+License: MIT
+
+Files: tests/resources/CVE-*
+Copyright: Respective Contributors
+# https://www.nist.gov/oism/copyrights
+License: CC0-1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Revision history for LocalSecurityScanner
-
-## 0.1.0.0 -- YYYY-mm-dd
-
-* First version. Released on an unsuspecting world.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+
+SPDX-License-Identifier: MIT
+-->
+
 To get all development prerequisites enter `nix develop`.
 
 Then run the process for a given derivation path with:

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LocalSecurityScanner.cabal
+++ b/LocalSecurityScanner.cabal
@@ -5,12 +5,12 @@ version:            0.1.0.0
 -- description:
 license:            MIT
 license-file:       LICENSE
-author:             cidkidnix
-maintainer:         dylan.green@obsidian.systems
--- copyright:
+author:             cidkidnix, raboof
+maintainer:         dylan.green@obsidian.systems, arnout@bzzt.net
+copyright:          2023 Dylan Green, Arnout Engelen
 category:           Security
 build-type:         Simple
-extra-doc-files:    CHANGELOG.md
+-- extra-doc-files:
 -- extra-source-files:
 
 common warnings

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+
+SPDX-License-Identifier: MIT
+-->
+
 # Nix local security scanner
 
 Reports on which security advisories may be relevant for a given system or derivation.

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+# SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+#
+# SPDX-License-Identifier: MIT
+
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/src/LocalSecurityScanner/CVE.hs
+++ b/src/LocalSecurityScanner/CVE.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}

--- a/src/LocalSecurityScanner/Examples.hs
+++ b/src/LocalSecurityScanner/Examples.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
 module LocalSecurityScanner.Examples where

--- a/src/LocalSecurityScanner/Matching.hs
+++ b/src/LocalSecurityScanner/Matching.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/src/LocalSecurityScanner/NVD.hs
+++ b/src/LocalSecurityScanner/NVD.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -285,6 +290,8 @@ loadNVDCVEsFromCache = do
 
 loadNVDCVEs :: LogT m ann => ReaderT Parameters m [NVDCVE]
 loadNVDCVEs = do
+  -- https://nvd.nist.gov/developers/terms-of-use
+  logMessage $ WithSeverity Informational $ "This product uses the NVD API but is not endorsed or certified by the NVD."
   cacheStatus <- liftIO loadCacheStatus
   env <- ask
   let debug' = debug env

--- a/src/LocalSecurityScanner/SBOM.hs
+++ b/src/LocalSecurityScanner/SBOM.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}

--- a/src/LocalSecurityScanner/Types.hs
+++ b/src/LocalSecurityScanner/Types.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/LocalSecurityScanner/Utils.hs
+++ b/src/LocalSecurityScanner/Utils.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}

--- a/src/LocalSecurityScanner/WebData.hs
+++ b/src/LocalSecurityScanner/WebData.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,3 +1,8 @@
+-- SPDX-FileCopyrightText: 2023 Arnout Engelen <arnout@bzzt.net>
+-- SPDX-FileCopyrightText: 2023 Dylan Green <dylan.green@obsidian.systems>
+--
+-- SPDX-License-Identifier: MIT
+
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 


### PR DESCRIPTION
So it now passes 'reuse lint' (https://reuse.software)