### PR TITLE
fix: swallow stderr on `git cat-files`

### DIFF
--- a/src/website/shared/git.py
+++ b/src/website/shared/git.py
@@ -133,7 +133,10 @@ class GitRepo:
         repo_clone_url = settings.GIT_CLONE_URL
         exists = (
             await (
-                await self.execute_git_command(f"git cat-file commit {object_sha1}")
+                await self.execute_git_command(
+                    f"git cat-file commit {object_sha1}",
+                    stderr=asyncio.subprocess.PIPE,
+                )
             ).wait()
             == 0
         )


### PR DESCRIPTION
the error message doesn't matter since we only care about the return
code. but it's confusing (and will probaby spam logs) when it appears,
since it looks like there's something wrong while everything is alright.