### PR TITLE
fix: update reset script commands

### DIFF
--- a/contrib/reset.sh
+++ b/contrib/reset.sh
@@ -30,5 +30,6 @@ createdb nix-security-tracker
 manage migrate
 manage createsuperuser --username admin  # prompts for password
 manage ingest_bulk_cve --subset 100
-manage fetch_all_channels
+manage initiate_checkout   # Checkout based on LOCAL_NIXPKGS_CHECKOUT
+manage fetch_all_channels  # Fails if LOCAL_NIXPKGS_CHECKOUT is not set
 manage ingest_manual_evaluation cd17fb8b3bfd63bf4a54512cfdd987887e1f15eb nixos-unstable $DIR/contrib/evaluation.jsonl --subset 100

--- a/default.nix
+++ b/default.nix
@@ -86,6 +86,9 @@ let
       pkgs.mkShell {
         DATA_CACHE_DIRECTORY = toString ./. + "/.data_cache";
         REDIS_SOCKET_URL = "unix:///run/redis/redis.sock";
+        # `./src/website/tracker/settings.py` by default looks for LOCAL_NIXPKGS_CHECKOUT
+        # in the root of the repo. Make it the default here for local development.
+        LOCAL_NIXPKGS_CHECKOUT = toString ./. + "/nixpkgs";
 
         packages = [
           manage


### PR DESCRIPTION
I decided to reset the dev environment and ran into issues with the default setup. This PR solves the inconsistencies found so that `./contrib/reset.sh` works again.

Ideally, we should converge the behaviour of the ingestion through the listener and the manual ingestion so it's clear how to do it as a one-shot operation.