### PR TITLE
feat: export packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
 }:
 let
   self = rec {
+    inherit pkgs;
     inherit (pkgs) python3;
     localPythonPackages = import ./pkgs { inherit pkgs python3; };
 


### PR DESCRIPTION
this way one can deploy the service as a container and rest assured that
it will work. otherwise there will almost certainly be conflicts with
the host system's Nixpkgs version.

Example:

```nix
{ config, ... }:
let
  sectracker = import ~/src/nix-security-tracker { };
in
{
  containers.nix-security-tracker = {
    # ...
    config = { ... }: {
      nixpkgs = {
        inherit (sectracker) pkgs overlays;
      };
      imports = [
        sectracker.module
      ];
      # ...
    };
  };
}
```