### PR TITLE
feat: support GlitchTip integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,3 +283,15 @@ If you have your SSH keys set up on the staging environment (and can connect thr
 ### Adding SSH keys
 
 Add your SSH keys to `./staging/configuration.nix` and let existing owners deploy them.
+
+## Operators guidance
+
+### Using a Sentry-like collector
+
+Sentry-like collectors are endpoints where we ship error information from the Python application with its stack-local variables for all the traceback, you can use [Sentry](https://sentry.io/welcome/) or [GlitchTip](https://glitchtip.com/) as a collector.
+
+Collectors are configured using [a DSN, i.e. a data source name.](https://docs.sentry.io/concepts/key-terms/dsn-explainer/) in Sentry parlance, this is where events are sent to.
+
+You can set `GLITCHTIP_DSN` as a credential secret with a DSN and this will connect to a Sentry-like endpoint via your DSN.
+
+We don't use Sentry but we run GlitchTip on staging.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -51,6 +51,7 @@ in
       daphne
       channels
       aiofiles
+      sentry-sdk
     ];
 
     postInstall = ''

--- a/src/website/tracker/settings.py
+++ b/src/website/tracker/settings.py
@@ -16,6 +16,8 @@ from os import environ as env
 from pathlib import Path
 
 import dj_database_url
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -35,6 +37,16 @@ def get_secret(name: str, encoding: str = "utf-8") -> str:
 
     return secret
 
+
+## GlitchTip setup
+
+if "GLITCHTIP_DSN" in env:
+    sentry_sdk.init(
+        dsn=get_secret("GLITCHTIP_DSN"),
+        integrations=[DjangoIntegration()],
+        auto_session_tracking=False,
+        traces_sample_rate=0,
+    )
 
 ## Channel setup
 CHANNEL_LAYERS = {

--- a/staging/secrets.nix
+++ b/staging/secrets.nix
@@ -13,4 +13,5 @@ in
   "secrets/dev-nixpkgs-security-tracker.2024-10-04.private-key.pem.age".publicKeys = admins ++ [
     staging
   ];
+  "secrets/glitchtip-dsn.age".publicKeys = admins ++ [ staging ];
 }

--- a/staging/secrets/glitchtip-dsn.age
+++ b/staging/secrets/glitchtip-dsn.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 +qVung zxfviIjbdDk6YZAkhWP0TVd1V/4+AO9m+0eKM8lvLG4
+cA1C2O9l1GlVd6MsDrotBicxpJFvnEzkWXIJrn41Eso
+-> ssh-ed25519 XJ1kNQ eb861j59sw6svafeVuJSouzfniw8tjiRgbMcJTq+SQs
+NpAgvEQGg8sv/0YVX3jnX0nOIwOaMOznzt3S+T6ixy4
+--- rZKnseOtBq9hCGlbSHY3QBivjjvJEKI9k8nVdj3h6uQ
+ŠB‡s]IŸ‚ûg‹gÏ‰_#INghv¬Vıq­j»‹¬ÓÛ£¢w­Õ×¿ıûÁ½¤ãZİ—MŠÌ0’:ƒŠDÚŸ¯OùiêÖNy	'L×2ÎV`Œ©öZß„

--- a/staging/sectracker.nix
+++ b/staging/sectracker.nix
@@ -65,6 +65,7 @@ in
       GH_SECRET = config.age.secrets.gh-secret.path;
       GH_WEBHOOK_SECRET = config.age.secrets.gh-webhook-secret.path;
       GH_APP_PRIVATE_KEY = config.age.secrets.gh-app-private-key.path;
+      GLITCHTIP_DSN = config.age.secrets.glitchtip-dsn.path;
     };
     maxJobProcessors = 3;
   };
@@ -75,5 +76,6 @@ in
     gh-secret.file = ./secrets/gh-secret.age;
     gh-webhook-secret.file = ./secrets/gh-webhook-secret.age;
     gh-app-private-key.file = ./secrets/dev-nixpkgs-security-tracker.2024-10-04.private-key.pem.age;
+    glitchtip-dsn.file = ./secrets/glitchtip-dsn.age;
   };
 }


### PR DESCRIPTION
Via Sentry SDK, we configure a GLITCHTIP_DSN as provided by GlitchTip.

One per environment.

Depends on #261.
Fixes #229.