### PR TITLE
fix(github): use AppAuth with an installation ID

### DIFF
--- a/src/website/shared/utils.py
+++ b/src/website/shared/utils.py
@@ -1,8 +1,6 @@
 import logging
-import time
 from os import environ as env
 
-import jwt
 from github import Auth, Github
 from tracker.settings import get_secret
 
@@ -34,12 +32,9 @@ def get_gh(per_page: int = 30) -> Github:
 
         try:
             with open(f"{credentials_dir}/GH_APP_PRIVATE_KEY", encoding="utf-8") as f:
-                payload = {
-                    "iat": int(time.time()),
-                    "exp": int(time.time()) + 600,
-                    "iss": get_secret("GH_CLIENT_ID"),
-                }
-                gh_auth = Auth.Token(jwt.encode(payload, f.read(), algorithm="RS256"))
+                gh_auth = Auth.AppAuth(
+                    get_secret("GH_CLIENT_ID"), f.read()
+                ).get_installation_auth(int(get_secret("GH_APP_INSTALLATION_ID")))
         except FileNotFoundError:
             logger.warning(
                 "No token available in the credentials directory, "

--- a/staging/secrets.nix
+++ b/staging/secrets.nix
@@ -10,6 +10,7 @@ in
   "secrets/gh-client.age".publicKeys = admins ++ [ staging ];
   "secrets/gh-secret.age".publicKeys = admins ++ [ staging ];
   "secrets/gh-webhook-secret.age".publicKeys = admins ++ [ staging ];
+  "secrets/gh-app-installation-id.age".publicKeys = admins ++ [ staging ];
   "secrets/dev-nixpkgs-security-tracker.2024-10-04.private-key.pem.age".publicKeys = admins ++ [
     staging
   ];

--- a/staging/secrets/gh-app-installation-id.age
+++ b/staging/secrets/gh-app-installation-id.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 +qVung w9BInx3r8YXBDbQjrRMPE04R9QuECzWRpPKblsJ5Ghw
+cr8Ta4lg1HvAUFeQSlgVyCPLycnF8nxeHy7B3U+CQvw
+-> ssh-ed25519 XJ1kNQ XovzLe2FvqODUYCNkFIWXrdv5FQrKyh6EzaTGn6yKho
+PTxnnbN2aoz9DID/QTE2HqIWQ1Vlx5C3jGov3QAkYDQ
+--- eR64n4zZM4AvWfqZR7L/LXBk5//3Avknv9r4+MM85i0
+|jìFÄà‘4˜}Ö†1IŠkôX¹·jâ:EùÉVÞ@â?î@åµ™

--- a/staging/sectracker.nix
+++ b/staging/sectracker.nix
@@ -65,6 +65,7 @@ in
       GH_SECRET = config.age.secrets.gh-secret.path;
       GH_WEBHOOK_SECRET = config.age.secrets.gh-webhook-secret.path;
       GH_APP_PRIVATE_KEY = config.age.secrets.gh-app-private-key.path;
+      GH_APP_INSTALLATION_ID = config.age.secrets.gh-app-installation-id.path;
       GLITCHTIP_DSN = config.age.secrets.glitchtip-dsn.path;
     };
     maxJobProcessors = 3;
@@ -76,6 +77,7 @@ in
     gh-secret.file = ./secrets/gh-secret.age;
     gh-webhook-secret.file = ./secrets/gh-webhook-secret.age;
     gh-app-private-key.file = ./secrets/dev-nixpkgs-security-tracker.2024-10-04.private-key.pem.age;
+    gh-app-installation-id.file = ./secrets/gh-app-installation-id.age;
     glitchtip-dsn.file = ./secrets/glitchtip-dsn.age;
   };
 }


### PR DESCRIPTION
It's not sufficient to just obtain a JWT, it's also required to use an installation ID to access things from the org attached to the installation ID.