### PR TITLE
fix: increase timeout on the container

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -200,6 +200,7 @@ in
           requires = [ "postgresql.service" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig.Restart = cfg.restart;
+          serviceConfig.TimeoutStartSec = "10m";
           preStart = ''
             # Auto-migrate on first run or if the package has changed
             versionFile="/var/lib/web-security-tracker/package-version"

--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -200,7 +200,7 @@ in
           requires = [ "postgresql.service" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig.Restart = cfg.restart;
-          serviceConfig.TimeoutStartSec = "10m";
+          serviceConfig.TimeoutStartSec = lib.mkDefault "10m";
           preStart = ''
             # Auto-migrate on first run or if the package has changed
             versionFile="/var/lib/web-security-tracker/package-version"

--- a/staging/container.nix
+++ b/staging/container.nix
@@ -23,6 +23,11 @@ in
     group = "web-security-tracker";
   };
   users.groups.web-security-tracker = { };
+  systemd.services."container@nix-security-tracker" = {
+    serviceConfig = {
+      TimeoutStartSec = lib.mkForce "15m";
+    };
+  };
   containers.nix-security-tracker = {
     autoStart = true;
     privateNetwork = true;


### PR DESCRIPTION
since migrations may be quite expensive when the datase state diverges
enough, the container will get killed before it's ready even if
everything is alright. the logs are quite opaque in that case,
because, well, there's no failure.