### PR TITLE
style: don't use flex in package element

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -368,6 +368,7 @@ article .suggestion h3 {
 
 article .nixpkgs-packages {
   margin-top: 0.5rem;
+  display: flex;
   flex-direction: column;
   row-gap: 0.8rem;
   font-family: "IBM Plex Mono";
@@ -376,8 +377,6 @@ article .nixpkgs-packages {
 .nixpkgs-package {
   border: 1px solid var(--grey);
   border-radius: 5px;
-  display: flex;
-  flex-direction: row;
 }
 
 .nixpkgs-package h3 {


### PR DESCRIPTION
This led to janky behaviour, this one takes a bit more space but is easier to reason about.

Also introduce flex on the list of packages, so that we can use row-gap