### PR TITLE
feat: display a security disclaimer when being run in debug mode to warn staging users

### DIFF
--- a/src/website/shared/templates/base.html
+++ b/src/website/shared/templates/base.html
@@ -45,6 +45,12 @@
         {% endblock %}
       </ul>
     </nav>
+    {% if debug %}
+      <div id="testing-disclaimer">
+        <em>⚠️ You are using a <b>publicly accessible</b> testing environment.
+        Don’t enter secrets into this system, especially not by reusing passwords for your user account.</em>
+      </div>
+    {% endif %}
 
     {% block layout %}
     <article>

--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -263,6 +263,12 @@ nav a:visited {
   margin: 0;
 }
 
+#testing-disclaimer {
+  text-align: center;
+  background: #f2f1ac;
+  padding: 0.2em;
+}
+
 article {
   padding: 1em;
 }


### PR DESCRIPTION
Afair we don't really track wether the software runs as staging. I figured just determining wether it's running in debug mode would be enough as a heuristic.

Closes https://github.com/Nix-Security-WG/nix-security-tracker/issues/279

![tmp 2KliF3G2EB](https://github.com/user-attachments/assets/116d9098-06d6-4a01-9b90-525a0a6fc740)
