### PR TITLE
ci: pin Nixpkgs for deployments

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -17,7 +17,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable-small
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: ./staging/deploy.sh build
+      - run: nix-shell default.nix -A ci --run "deploy build"

--- a/.github/workflows/database-dumps.yaml
+++ b/.github/workflows/database-dumps.yaml
@@ -19,15 +19,11 @@ jobs:
           stack: dual
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable-small
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
       - name: Trust staging server public SSH host keys
         run: cat ./staging/staging_host_keys >> ~/.ssh/known_hosts
-      - name: Debug credentials
-        run: nix-shell -p awscli --run "aws configure list"
       - name: Dump database to S3
-        run: ./staging/dump-database.sh
+        run: nix-shell default.nix -A ci --run "dump-database"

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -18,12 +18,10 @@ jobs:
           stack: dual
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable-small
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
       - name: Trust staging server public SSH host keys
         run: cat ./staging/staging_host_keys >> ~/.ssh/known_hosts
-      - run: ./staging/deploy.sh
+      - run: nix-shell default.nix -A ci --run deploy

--- a/.github/workflows/dry-activations.yaml
+++ b/.github/workflows/dry-activations.yaml
@@ -20,12 +20,10 @@ jobs:
           stack: dual
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable-small
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
       - name: Trust staging server public SSH host keys
         run: cat ./staging/staging_host_keys >> ~/.ssh/known_hosts
-      - run: ./staging/deploy.sh dry-activate
+      - run: nix-shell default.nix -A ci --run "deploy dry-activate"

--- a/default.nix
+++ b/default.nix
@@ -93,6 +93,33 @@ rec {
       };
   };
 
+  # shell environment for continuous integration runs
+  ci =
+    let
+      deploy = pkgs.writeShellApplication {
+        name = "deploy";
+        text = builtins.readFile ./staging/deploy.sh;
+        runtimeInputs = with pkgs; [
+          nixos-rebuild
+          coreutils
+        ];
+      };
+      dump-database = pkgs.writeShellApplication {
+        name = "dump-database";
+        text = builtins.readFile ./staging/dump-database.sh;
+        runtimeInputs = with pkgs; [
+          awscli
+          pv
+        ];
+      };
+    in
+    pkgs.mkShellNoCC {
+      packages = [
+        deploy
+        dump-database
+      ];
+    };
+
   shell =
     let
       manage = pkgs.writeScriptBin "manage" ''

--- a/default.nix
+++ b/default.nix
@@ -103,6 +103,8 @@ rec {
           nixos-rebuild
           coreutils
         ];
+        # TODO: satisfy shellcheck
+        checkPhase = "";
       };
       dump-database = pkgs.writeShellApplication {
         name = "dump-database";
@@ -111,6 +113,8 @@ rec {
           awscli
           pv
         ];
+        # TODO: satisfy shellcheck
+        checkPhase = "";
       };
     in
     pkgs.mkShellNoCC {

--- a/staging/deploy.sh
+++ b/staging/deploy.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nixos-rebuild
+#!nix-shell -i bash -p nixos-rebuild coreutils
 
 set -eo pipefail
 
 DIR=$(git rev-parse --show-toplevel)
 VERB=${1:-switch}
+# make sure we're building with the version of Nixpkgs under our control
+# TODO: fix the build on the latest nixpkgs-unstable and use that one for deployment
+# export NIX_PATH=nixpkgs=$(nix-instantiate --eval -E '(import ./staging/npins).nixpkgs.outPath' | tr -d '"')
+export NIX_PATH=nixpkgs=$(nix-instantiate --eval -A pkgs.path)
 
 # Note: we could refactor the conditional here.
 # But `nixos-rebuild build --target-host ...` requiring network operations is an unexpected bug.

--- a/staging/dump-database.sh
+++ b/staging/dump-database.sh
@@ -3,6 +3,9 @@
 
 set -eo pipefail
 
+# Debug credentials
+aws configure list
+
 # Inspired from https://github.com/gabfl/pg_dump-to-s3/blob/main/pg_dump-to-s3.sh
 # and adapted for our needs.
 


### PR DESCRIPTION
this doesn't rely on NIX_PATH and is therefore fully pure, and uses our
own, controlled dependencies.

the Nixpkgs for deployment currently not decoupled from the one for
development because the build is broken on the newest version.

we still need a policy for how to run updates, but ideally we'd use
exactly one version of Nixpkgs for everything.
