### PR TITLE
ci: auto-update pins for staging

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   # Only put untrusted jobs here.
   development:
+    if: github.head_ref != 'npins-auto-update'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   # Only put untrusted jobs here.
   development:
+    # TODO: no exception
     if: github.head_ref != 'npins-auto-update'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: main
+  # allow "manual" triggering from automatic PRs
+  workflow_dispatch:
 jobs:
   # Only put untrusted jobs here.
   development:

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -8,8 +8,6 @@ on:
 jobs:
   # Only put untrusted jobs here.
   development:
-    # TODO: no exception
-    if: github.head_ref != 'npins-auto-update'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -7,6 +7,10 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+env:
+  ACTIONS_RUNNER_DEBUG: true
+  ACTIONS_STEP_DEBUG: true
+
 jobs:
   update-npins:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -13,12 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable-small
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: |
-          cd ./staging
-          nix-shell -p npins --run "npins update"
+          nix-shell --run "npins -d ./staging update"
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -29,5 +29,4 @@ jobs:
             Automatic npins update performed by GitHub Actions
           branch: npins-auto-update
           delete-branch: true
-          # TODO: change back to main
-          base: auto-npins-update
+          base: main

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable-small
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: |
           cd ./staging

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -2,9 +2,9 @@ name: Weekly npins update
 
 on:
   schedule:
-    # Runs at 00:00 UTC every Monday
+    # run at 00:00 UTC every Monday
     - cron: "0 0 * * 1"
-  # Allow manual trigger
+  # allow manual trigger
   workflow_dispatch:
 
 permissions:
@@ -23,7 +23,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: npins update for staging"
+          commit-message: "chore: npins update"
           title: "chore: weekly npins update"
           body: |
             Automatic npins update performed by GitHub Actions

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: cachix/install-nix-action@v29
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: |
-          nix-shell --run "npins -d ./staging update"
+          nix-shell default.nix -A ci --run "npins -d ./staging/npins update"
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -29,4 +29,5 @@ jobs:
             Automatic npins update performed by GitHub Actions
           branch: npins-auto-update
           delete-branch: true
-          base: main
+          # TODO: change back to main
+          base: auto-npins-update

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,29 @@
+name: Weekly npins update
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every Monday
+    - cron: "0 0 * * 1"
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  update-npins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v29
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: |
+          cd ./staging
+          nix-shell -p npins --run "npins update"
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: npins update for staging"
+          title: "chore: weekly npins update"
+          body: |
+            Automatic npins update performed by GitHub Actions
+          branch: npins-auto-update
+          delete-branch: true
+          base: main

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -7,9 +7,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-env:
-  ACTIONS_RUNNER_DEBUG: true
-  ACTIONS_STEP_DEBUG: true
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update-npins:

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -1,0 +1,25 @@
+name: npins update helper
+on:
+  pull_request_target:
+    branches: [main]
+
+jobs:
+  trigger-build:
+    if: github.head_ref == 'npins-auto-update'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # here we trust our supply chain not to mess up
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'builds.yaml',
+              ref: '${{ github.event.pull_request.head.ref }}',
+            });

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -1,10 +1,13 @@
 name: npins update helper
 on:
   pull_request_target:
+    # TODO: only opened
     types: [opened, reopened]
-    branches: [main]
+    # TODO: change back to main
+    branches: [auto-npins-update]
 
 jobs:
+  # TODO: remove debugging
   debug-trigger:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -1,6 +1,7 @@
 name: npins update helper
 on:
   pull_request_target:
+    types: [opened, reopened]
     branches: [main]
 
 jobs:

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -1,25 +1,10 @@
 name: npins update helper
 on:
   pull_request_target:
-    # TODO: only opened
-    types: [opened, reopened]
-    # TODO: change back to main
-    branches: [auto-npins-update]
+    types: [opened]
+    branches: [main]
 
 jobs:
-  # TODO: remove debugging
-  debug-trigger:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug Event
-        env:
-          EVENT_CONTEXT: ${{ toJSON(github.event) }}
-        run: |
-          echo "Event type: ${{ github.event_name }}"
-          echo "Head ref: ${{ github.head_ref }}"
-          echo "Base ref: ${{ github.base_ref }}"
-          echo "Full event context:"
-          echo "$EVENT_CONTEXT"
   trigger-build:
     if: github.head_ref == 'npins-auto-update'
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -5,6 +5,18 @@ on:
     branches: [main]
 
 jobs:
+  debug-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug Event
+        env:
+          EVENT_CONTEXT: ${{ toJSON(github.event) }}
+        run: |
+          echo "Event type: ${{ github.event_name }}"
+          echo "Head ref: ${{ github.head_ref }}"
+          echo "Base ref: ${{ github.base_ref }}"
+          echo "Full event context:"
+          echo "$EVENT_CONTEXT"
   trigger-build:
     if: github.head_ref == 'npins-auto-update'
     runs-on: ubuntu-latest

--- a/default.nix
+++ b/default.nix
@@ -119,6 +119,7 @@ rec {
     in
     pkgs.mkShellNoCC {
       packages = [
+        pkgs.npins
         deploy
         dump-database
       ];
@@ -131,7 +132,7 @@ rec {
       '';
       deploymentSources = import ./staging/npins;
     in
-    pkgs.mkShell {
+    pkgs.mkShellNoCC {
       env = {
         REDIS_SOCKET_URL = "unix:///run/redis/redis.sock";
         DATABASE_URL = "postgres://nix-security-tracker@/nix-security-tracker";


### PR DESCRIPTION
we can extend this easily to also update the development pins. I suggest we keep them in sync, so there's no room for divergence, because breaking builds will hold up everything anyway, so we may just fix them for all outputs at once.