### PR TITLE
fix: display for channel summaries

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -393,9 +393,15 @@ article .nixpkgs-packages {
   color: var(--grey);
 }
 
+.nixpkgs-package summary {
+  width: 19.5em; /* .version + .branch-name + 1.5em for the unfold triangle */
+  margin-left: auto;
+}
+
 .nixpkgs-package .channel-list {
   list-style-type: none;
   padding-left: 0;
+  margin: 0;
 }
 
 .nixpkgs-package .branch-minor {


### PR DESCRIPTION
Apparently https://github.com/Nix-Security-WG/nix-security-tracker/pull/304 didn't exactly do what I intended, no idea how that screenshot in https://github.com/Nix-Security-WG/nix-security-tracker/pull/304#issuecomment-2450565850 came together.