### PR TITLE
fix: return to same page after change state

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -436,16 +436,12 @@ article .nixpkgs-packages {
 .suggestion .change-issue-state {
   display: flex;
   justify-content: space-between;
+  flex-direction: row-reverse;
   margin-top: 0.8em;
   font-weight: 500;
 }
 
-.suggestion .dismissed {
-  justify-content: right;
-  gap: 1em;
-}
-
-.suggestion .change-issue-state form button {
+.suggestion .change-issue-state button {
   padding: 0.5em;
   border: none;
   border-radius: 0.3em;

--- a/src/website/webview/templates/components/suggestion_state_button.html
+++ b/src/website/webview/templates/components/suggestion_state_button.html
@@ -1,8 +1,0 @@
-<form method="post" action="">
-  {% csrf_token %}
-  <input type="hidden" name="suggestion_id" value="{{ suggestion_id }}">
-  <input type="hidden" name="new_status" value="{{ state }}">
-  <button class="{{ style }}">
-    {{ label }}
-  </button>
-</form>

--- a/src/website/webview/templates/dismissed_list.html
+++ b/src/website/webview/templates/dismissed_list.html
@@ -12,23 +12,34 @@ These automatic suggestions were dimissed after initial triaging. <a href="/sugg
 <div id="suggestion-list">
   {% for object in object_list %}
     <article class="suggestion">
+
       <div class="row1">
         <a class="cve-id" href="https://nvd.nist.gov/vuln/detail/{{ object.cve.cve_id | urlencode }}">
           {{ object.cve.cve_id }}
         </a>
         {% severity_badge object.base_severity %}
       </div>
+
       <h2>{{ object.package_name }}</h2>
+
       <details class="description">
         <summary>
             {% if object.title %}{{ object.title }}{% else %}{{ object.description|truncatewords:10 }}{% endif %}
         </summary>
         <p class="description-long as-details">{{ object.description }}</p>
       </details>
+
       {% nixpkgs_package_list object.packages %}
-      <div class="change-issue-state dismissed">
-        {% suggestion_state_button suggestion_id=object.id state="ACCEPTED" label="Restore" style="red-button" %}
-      </div>
+
+      <form class="change-issue-state" method="post" action="">
+        {% csrf_token %}
+        <input type="hidden" name="suggestion_id" value="{{ object.id }}">
+        <input type="hidden" name="page" value="{{ page_obj.number }}">
+
+        <button type="submit" name="new_status" value="ACCEPTED" class="red-button">
+          Restore
+        </button>
+      </form>
     </article>
   {% endfor %}
 </div>

--- a/src/website/webview/templates/draft_list.html
+++ b/src/website/webview/templates/draft_list.html
@@ -12,25 +12,37 @@
 <div id="suggestion-list">
   {% for object in object_list %}
     <article class="suggestion">
+
       <div class="row1">
         <a class="cve-id" href="https://nvd.nist.gov/vuln/detail/{{ object.cve.cve_id | urlencode }}">
           {{ object.cve.cve_id }}
         </a>
         {% severity_badge object.base_severity %}
+
       </div>
       <h2>{{ object.package_name }}</h2>
-      <!-- XXX: just another idea how to do it -->
+
       <details class="description">
         <summary>
             {% if object.title %}{{ object.title }}{% else %}{{ object.description|truncatewords:10 }}{% endif %}
         </summary>
         <p class="description-long as-details">{{ object.description }}</p>
       </details>
+
       {% nixpkgs_package_list object.packages %}
-      <div class="change-issue-state">
-        {% suggestion_state_button suggestion_id=object.id state="REJECTED" label="Dismiss" style="red-button" %}
-        {% suggestion_state_button suggestion_id=object.id state="ACCEPTED" label="C̶̖͆r̶͍̚e̵͈̐ă̷̖t̷̄͜e̶͓̓ ̴̟̏d̵̳̅r̸̮̐a̵͍͑f̵̙̋t̴̹̃" style="green-button" %}
-      </div>
+
+      <form class="change-issue-state" method="post" action="">
+        {% csrf_token %}
+        <input type="hidden" name="suggestion_id" value="{{ object.id }}">
+        <input type="hidden" name="page" value="{{ page_obj.number }}">
+
+        <button type="submit" name="new_status" value="ACCEPTED" class="green-button">
+          C̶̖͆r̶͍̚e̵͈̐ă̷̖t̷̄͜e̶͓̓ ̴̟̏d̵̳̅r̸̮̐a̵͍͑f̵̙̋t̴̹̃
+        </button>
+        <button type="submit" name="new_status" value="REJECTED" class="red-button">
+          Dismiss
+        </button>
+      </form>
     </article>
   {% endfor %}
 </div>

--- a/src/website/webview/templates/suggestion_list.html
+++ b/src/website/webview/templates/suggestion_list.html
@@ -12,24 +12,37 @@
 <div id="suggestion-list">
   {% for object in object_list %}
     <article class="suggestion">
+
       <div class="row1">
         <a class="cve-id" href="https://nvd.nist.gov/vuln/detail/{{ object.cve.cve_id | urlencode }}">
           {{ object.cve.cve_id }}
         </a>
         {% severity_badge object.base_severity %}
       </div>
+
       <h2>{{ object.package_name }}</h2>
+
       <details class="description">
         <summary>
             {% if object.title %}{{ object.title }}{% else %}{{ object.description|truncatewords:10 }}{% endif %}
         </summary>
         <p class="description-long as-details">{{ object.description }}</p>
       </details>
+
       {% nixpkgs_package_list object.packages %}
-      <div class="change-issue-state">
-        {% suggestion_state_button suggestion_id=object.id state="REJECTED" label="Dismiss" style="red-button" %}
-        {% suggestion_state_button suggestion_id=object.id state="ACCEPTED" label="Select" style="green-button" %}
-      </div>
+
+      <form class="change-issue-state" method="post" action="">
+        {% csrf_token %}
+        <input type="hidden" name="suggestion_id" value="{{ object.id }}">
+        <input type="hidden" name="page" value="{{ page_obj.number }}">
+
+        <button type="submit" name="new_status" value="ACCEPTED" class="green-button">
+          Select
+        </button>
+        <button type="submit" name="new_status" value="REJECTED" class="red-button">
+          Dismiss
+        </button>
+      </form>
     </article>
   {% endfor %}
 </div>

--- a/src/website/webview/templatetags/viewutils.py
+++ b/src/website/webview/templatetags/viewutils.py
@@ -77,15 +77,3 @@ def nixpkgs_package_list(packages: PackageDict) -> PackageListContext:
         {% package_list package_dict %}
     """
     return {"packages": packages}
-
-
-@register.inclusion_tag("components/suggestion_state_button.html")
-def suggestion_state_button(
-    suggestion_id: str, state: str, label: str, style: str
-) -> SuggestionStateButtonContext:
-    return {
-        "suggestion_id": suggestion_id,
-        "state": state,
-        "label": label,
-        "style": style,
-    }

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -525,13 +525,14 @@ class SuggestionListView(ListView):
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         suggestion_id = request.POST.get("suggestion_id")
         new_status = request.POST.get("new_status")
+        current_page = request.POST.get("page", "1")
         suggestion = get_object_or_404(CVEDerivationClusterProposal, id=suggestion_id)
         if new_status == "REJECTED":
             suggestion.status = CVEDerivationClusterProposal.Status.REJECTED
         elif new_status == "ACCEPTED":
             suggestion.status = CVEDerivationClusterProposal.Status.ACCEPTED
         suggestion.save()
-        return redirect("/suggestions")
+        return redirect(f"{request.path}?page={current_page}")
 
 
 class DismissedListView(ListView):
@@ -578,11 +579,12 @@ class DismissedListView(ListView):
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         suggestion_id = request.POST.get("suggestion_id")
         new_status = request.POST.get("new_status")
+        current_page = request.POST.get("page", "1")
         suggestion = get_object_or_404(CVEDerivationClusterProposal, id=suggestion_id)
         if new_status == "ACCEPTED":
             suggestion.status = CVEDerivationClusterProposal.Status.ACCEPTED
         suggestion.save()
-        return redirect("/dismissed")
+        return redirect(f"{request.path}?page={current_page}")
 
 
 class DraftListView(ListView):
@@ -628,8 +630,9 @@ class DraftListView(ListView):
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         suggestion_id = request.POST.get("suggestion_id")
         new_status = request.POST.get("new_status")
+        current_page = request.POST.get("page", "1")
         suggestion = get_object_or_404(CVEDerivationClusterProposal, id=suggestion_id)
         if new_status == "REJECTED":
             suggestion.status = CVEDerivationClusterProposal.Status.REJECTED
         suggestion.save()
-        return redirect("/selected")
+        return redirect(f"{request.path}?page={current_page}")


### PR DESCRIPTION
previously if changing a suggestion state, one would get redirected to
the first page.

this also removes the templatetag for the buttons, as it adds an extra
interface that doesn't make the overall code shorter.