### PR TITLE
feat: display meta.description for package in suggestion list

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -405,7 +405,17 @@ article .nixpkgs-packages {
   margin-left: auto;
 }
 
+.nixpkgs-package .package-meta {
+  display: flex;
+  flex-direction: row;
+}
+
+.nixpkgs-package .package-description {
+  flex-grow: 1;
+}
+
 .nixpkgs-package .channel-list {
+  flex-grow: 0;
   list-style-type: none;
   padding-left: 0;
   margin: 0;

--- a/src/website/webview/templates/components/nixpkgs_package_list.html
+++ b/src/website/webview/templates/components/nixpkgs_package_list.html
@@ -3,9 +3,9 @@
     <article class="nixpkgs-package">
       <h3><span class="pkgs">pkgs.</span>{{ attribute }}</h3>
       <div class="package-meta">
-        <div class="package-description">
+        <p class="package-description">
           {{ pdata.description }}
-        </div>
+        </p>
         <ul class="channel-list">
           {% for major_channel, val in pdata.versions %}
             <li>

--- a/src/website/webview/templates/components/nixpkgs_package_list.html
+++ b/src/website/webview/templates/components/nixpkgs_package_list.html
@@ -1,29 +1,34 @@
 <div class="nixpkgs-packages">
-  {% for attribute, nixos_channels in packages.items %}
+  {% for attribute, pdata in packages.items %}
     <article class="nixpkgs-package">
       <h3><span class="pkgs">pkgs.</span>{{ attribute }}</h3>
-      <ul class="channel-list">
-        {% for major_channel, val in nixos_channels %}
-          <li>
-            <details {% if val.uniform_versions %}open{% endif %}>
-              <summary>
-                <span class="branch-major">
-                  <span class="branch-name">{{ major_channel }}</span>
-                  <span class="version">{% if val.major_version %}{{ val.major_version }}{% else %}???{% endif %}</span>
-                </span>
-              </summary>
-              <ul class="channel-list">
-              {% for branch_name, version in val.sub_branches %}
-                <li class="branch-minor">
-                  <span class="branch-name">{{ branch_name }}</span>
-                  <span class="version">{{ version }}</span>
-                </li>
-              {% endfor %}
-              </ul>
-            </details>
-          </li>
-        {% endfor %}
-      </ul>
+      <div class="package-meta">
+        <div class="package-description">
+          {{ pdata.description }}
+        </div>
+        <ul class="channel-list">
+          {% for major_channel, val in pdata.versions %}
+            <li>
+              <details {% if val.uniform_versions %}open{% endif %}>
+                <summary>
+                  <span class="branch-major">
+                    <span class="branch-name">{{ major_channel }}</span>
+                    <span class="version">{% if val.major_version %}{{ val.major_version }}{% else %}???{% endif %}</span>
+                  </span>
+                </summary>
+                <ul class="channel-list">
+                {% for branch_name, version in val.sub_branches %}
+                  <li class="branch-minor">
+                    <span class="branch-name">{{ branch_name }}</span>
+                    <span class="version">{{ version }}</span>
+                  </li>
+                {% endfor %}
+                </ul>
+              </details>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
     </article>
   {% endfor %}
 </div>


### PR DESCRIPTION
Old code that I should have pushed long ago.

Addresses https://github.com/Nix-Security-WG/nix-security-tracker/issues/333 but doesn't close it yet, as it is blocked by #338.

I needed to introduce the flexbox again, but I think it is fine, as the versions block has a fixed width? Shouldn't be too hard to make it look right.

![tmp 9UPmnPjbS4](https://github.com/user-attachments/assets/3ca8bbbc-90a2-45af-9d17-0950193ff5b2)

This change is invisible actually, as there is no data to display yet.