### PR TITLE
feat: signify a package to be removed by crossing through its name

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -419,6 +419,7 @@ article .nixpkgs-packages {
 
 .nixpkgs-package-container input:not(:checked) ~ article h3 {
   color: var(--grey);
+  text-decoration: line-through;
 }
 
 .nixpkgs-package-container input:not(:checked) ~ article h3 ~ * {


### PR DESCRIPTION
An idea I just had because I felt the fact the the package is (about to) removed isn't clear enough yet.

![tmp 25rzEv8hZW](https://github.com/user-attachments/assets/eda028b3-2398-423e-a98c-98de51853e28)
