### PR TITLE
fix: refresh suggestion cache entry on derivations update

### DIFF
--- a/src/website/shared/listeners/cache_suggestions.py
+++ b/src/website/shared/listeners/cache_suggestions.py
@@ -114,7 +114,7 @@ def cache_new_suggestions(suggestion: CVEDerivationClusterProposal) -> None:
     # TODO: add format checking to avoid disasters in the frontend.
 
     _, created = CachedSuggestions.objects.update_or_create(
-        payload=dict(only_relevant_data), defaults={"proposal_id": suggestion.pk}
+        proposal_id=suggestion.pk, defaults={"payload": dict(only_relevant_data)}
     )
 
     if created:

--- a/src/website/shared/models/cached.py
+++ b/src/website/shared/models/cached.py
@@ -11,7 +11,10 @@ class CachedSuggestions(TimeStampMixin):
     """
 
     proposal = models.OneToOneField(
-        CVEDerivationClusterProposal, on_delete=models.CASCADE, primary_key=True
+        CVEDerivationClusterProposal,
+        related_name="cached",
+        on_delete=models.CASCADE,
+        primary_key=True,
     )
 
     # The exact format of this payload will change until it's properly defined.

--- a/src/website/shared/models/linkage.py
+++ b/src/website/shared/models/linkage.py
@@ -4,6 +4,7 @@ import pghistory
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+import shared.models.cached
 from shared.models.cve import CveRecord
 from shared.models.nix_evaluation import NixDerivation, TimeStampMixin
 
@@ -22,6 +23,8 @@ class CVEDerivationClusterProposal(TimeStampMixin):
         PENDING = "pending", _("pending")
         REJECTED = "rejected", _("rejected")
         ACCEPTED = "accepted", _("accepted")
+
+    cached: "shared.models.cached.CachedSuggestions"
 
     cve = models.ForeignKey(
         CveRecord, related_name="derivation_links_proposals", on_delete=models.CASCADE

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -585,7 +585,7 @@ def update_suggestion(
     title = request.POST.get("title")
     current_page = request.POST.get("page", "1")
     suggestion = get_object_or_404(CVEDerivationClusterProposal, id=suggestion_id)
-    cached_variant = get_object_or_404(CachedSuggestions, proposal_id=suggestion_id)
+    cached_suggestion = get_object_or_404(CachedSuggestions, proposal_id=suggestion_id)
 
     if filter:
         selected_derivations = [
@@ -609,12 +609,12 @@ def update_suggestion(
         # this seems to encourage to move the payload format to an dict of derivation id → derivation contents
         # this way, we already know which IDs to remove.
         # this is left as future work.
-        cached_payload = cached_variant.payload
-        new_derivation_set = [
-            d for d in cached_payload["derivations"] if d["id"] in selected_derivations
-        ]
-        cached_payload["derivations"] = new_derivation_set
-        cached_variant.payload = cached_payload
-        cached_variant.save()
+        new_packages = {
+            pname: v
+            for pname, v in cached_suggestion.payload["packages"].items()
+            if any(did in selected_derivations for did in v["derivation_ids"])
+        }
+        cached_suggestion.payload["packages"] = new_packages
+        cached_suggestion.save()
 
-    return (title, current_page, new_status, suggestion, cached_variant.payload)
+    return (title, current_page, new_status, suggestion, cached_suggestion.payload)


### PR DESCRIPTION
Couldn't sleep with having this problem in my head.

I had to switch the arguments for the update_or_create function because they were wrong: The proposal_id is used for the lookup and the payload is then used on update.

This is going to make updates very slow, but doesn't affect page load and I'd argue that it is important to have correct behaviour at first. With https://github.com/Nix-Security-WG/nix-security-tracker/pull/383 merged update times wouldn't even be noticable.