### PR TITLE
feat: the delta CVE ingester can replace the bulk CVE ingester

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -16,6 +16,7 @@ let
     mkDefault
     concatStringsSep
     recursiveUpdate
+    optionalString
     ;
   inherit (pkgs) writeScriptBin writeShellApplication stdenv;
   cfg = config.services.web-security-tracker;
@@ -104,6 +105,18 @@ in
     secrets = mkOption {
       type = types.attrsOf types.path;
       default = { };
+    };
+    cve.startDate = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      defaultText = "the application default: January 1st of the prior year";
+      description = ''
+        The ingestion start date for CVE, most operators will care about CVEs of their last year until now.
+        Hence, this is the default.
+
+        If you need to obtain older CVEs for any reason, change this value.
+      '';
+      example = "2024-11-01";
     };
     maxJobProcessors = mkOption {
       description = ''
@@ -270,7 +283,9 @@ in
           serviceConfig.Type = "oneshot";
 
           script = ''
-            wst-manage ingest_delta_cve "$(date --date='yesterday' --iso)"
+            wst-manage ingest_delta_cve "$(date --date='yesterday' --iso)" ${
+              optionalString (cfg.cve.startDate != null) "--default-start-ingestion ${cfg.cve.startDate}"
+            }
           '';
 
           # Start at 03h so that the data will have been published

--- a/src/website/shared/fetchers.py
+++ b/src/website/shared/fetchers.py
@@ -15,11 +15,9 @@ def make_organization(
     if uuid is None:
         return None
 
-    org, _ = models.Organization.objects.get_or_create(uuid=uuid)
-
-    if org.short_name is None:
-        org.short_name = short_name
-        org.save()
+    org, _ = models.Organization.objects.get_or_create(
+        uuid=uuid, defaults={"short_name": short_name}
+    )
 
     return org
 

--- a/src/website/shared/management/commands/ingest_delta_cve.py
+++ b/src/website/shared/management/commands/ingest_delta_cve.py
@@ -4,6 +4,7 @@ import json
 import logging
 import tempfile
 import zipfile
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from glob import glob
 from typing import Any
 
@@ -18,6 +19,13 @@ from shared.models import CveIngestion
 from shared.utils import get_gh
 
 logger = logging.getLogger(__name__)
+
+
+def get_past_january_first() -> datetime.date:
+    today = datetime.date.today()
+    past_year = today.year - 1
+    # Take the day before.
+    return datetime.date(past_year, 1, 1) - datetime.timedelta(days=1)
 
 
 class NoReleaseError(Exception):
@@ -64,30 +72,70 @@ def ingest_day(repo: Repository, day: datetime.datetime) -> CveIngestion:
             z_arc.extractall(path=tmp_dir)
 
         # Open a single transaction for the db
-        with transaction.atomic():
-            # Traverse the tree and import cves
-            cve_list = glob(f"{tmp_dir}/deltaCves/*.json")
-            logger.info(f"{len(cve_list)} CVEs to ingest.")
+        # Traverse the tree and import cves
+        cve_list = glob(f"{tmp_dir}/deltaCves/*.json")
+        logger.info(f"{len(cve_list)} CVEs to ingest.")
 
-            for j_cve in cve_list:
-                with open(j_cve) as fc:
-                    data = json.load(fc)
-                    cve_id = data["cveMetadata"]["cveId"]
+        for j_cve in cve_list:
+            with open(j_cve) as fc:
+                data = json.load(fc)
+                cve_id = data["cveMetadata"]["cveId"]
 
+                with transaction.atomic():
                     make_cve(
                         data,
                         record=models.CveRecord.objects.filter(cve_id=cve_id).first(),
                     )
 
-            # Record the ingestion
-            logger.info(f"Saving the ingestion valid up to {day}")
+        # Record the ingestion
+        logger.info(f"Saving the ingestion valid up to {day}")
 
-            # This needs to be tucked _in_ the atomic transaction.
-            return CveIngestion.objects.create(valid_to=day, delta=True)
+        return CveIngestion.objects.create(valid_to=day, delta=True)
+
+
+def process_day(repo: Repository, day: datetime.datetime) -> None:
+    """Wrapper function to process a single day."""
+    try:
+        ingest_day(repo, day)
+    except NoReleaseError:
+        logger.exception(
+            f"CVE ingestion on day {day} is impossible as there's no release, continuing for the next days"
+        )
+
+
+def parallel_ingestion(
+    repo: Repository,
+    next_ingestion: datetime.datetime,
+    date: datetime.datetime,
+    num_processes: int,
+) -> None:
+    """
+    Parallel ingestion of CVE data.
+
+    :param repo: Repository to ingest data from.
+    :param next_ingestion: The starting date for ingestion.
+    :param date: The end date for ingestion.
+    :param num_processes: Number of parallel processes.
+    """
+    days = [
+        next_ingestion + datetime.timedelta(days=x)
+        for x in range((date - next_ingestion).days + 1)
+    ]
+
+    with ProcessPoolExecutor(max_workers=num_processes) as executor:
+        # Submit tasks to the executor
+        futures = {executor.submit(process_day, repo, day): day for day in days}
+
+        for future in as_completed(futures):
+            day = futures[future]
+            try:
+                future.result()
+            except Exception as e:
+                logger.exception(f"An error occurred while processing day {day}: {e}")
 
 
 class Command(BaseCommand):
-    help = "Ingest CVEs in bulk using the Mitre CVE repo"
+    help = "Ingest CVEs day per day using the MITRE CVE repo"
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -95,9 +143,31 @@ class Command(BaseCommand):
             type=datetime.date.fromisoformat,
             help="End date until which we will download all the missing deltas.",
         )
+        # A good default is to collect all CVEs from (current year - 1) so that
+        # we can operate over "modern" software CVEs and potentially still
+        # active ones.
+        parser.add_argument(
+            "--default-start-ingestion",
+            type=datetime.date.fromisoformat,
+            help="Default start ingestion date if there is no CVE ingestion record in database",
+            default=get_past_january_first(),
+        )
+        parser.add_argument(
+            "--num-parallel-processes",
+            type=int,
+            help="Number of parallel processes for the ingestion",
+            default=1,
+        )
 
     def handle(self, *args: Any, **kwargs: Any) -> None:
         date = kwargs["date"]
+        default_start_ingestion = kwargs["default_start_ingestion"]
+        num_processes = kwargs["num_parallel_processes"]
+
+        if num_processes > 1:
+            logger.warning(
+                "Do not run with more than one process if you do not know what you are doing, the ingestion layer is not ready yet."
+            )
 
         if CveIngestion.objects.filter(valid_to__gte=date).exists():
             logger.warning(
@@ -113,14 +183,14 @@ class Command(BaseCommand):
         )
 
         if last_ingestion is None:
-            logger.error(
-                "The database contains no initial ingestion record, please perform a first bulk import for initialization."
+            logger.warning(
+                "The database contains no initial ingestion record, normally, it should be initialized via bulk ingestion. It will be initialized now via delta ingestion. This will incur more traffic to GitHub servers."
             )
 
-            return
-
         # Determine the next ingestion in our calendar.
-        next_ingestion = last_ingestion + datetime.timedelta(days=1)
+        next_ingestion = (
+            last_ingestion or default_start_ingestion
+        ) + datetime.timedelta(days=1)
 
         # Initialize a GitHub connection
         g = get_gh()
@@ -128,14 +198,4 @@ class Command(BaseCommand):
         # Select the CVEList repository
         repo = g.get_repo("CVEProject/cvelistV5")
 
-        # We need to retrieve all daily releases from last_ingestion up to date now.
-        for day in (
-            next_ingestion + datetime.timedelta(days=x)
-            for x in range((date - next_ingestion).days + 1)
-        ):
-            try:
-                ingest_day(repo, day)
-            except NoReleaseError:
-                logger.exception(
-                    f"CVE ingestion on day {day} is impossible as there's no release, continuing for the next days"
-                )
+        parallel_ingestion(repo, next_ingestion, date, num_processes)


### PR DESCRIPTION
It supports parallelism but `make_cve` does not.

This will result in many deadlocks and issues during the transaction if
it's run with more than one process.

Signed-off-by: Raito Bezarius <masterancpp@gmail.com>