### PR TITLE
feat(shared/apps): do not reload the github state via autoreloader

### DIFF
--- a/src/website/shared/apps.py
+++ b/src/website/shared/apps.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from django.apps import AppConfig
@@ -12,7 +13,7 @@ class SharedConfig(AppConfig):
 
         # This hook is called on any `manage` subcommand.
         # Only connect to GitHub when the server is started.
-        if "runserver" in sys.argv:
+        if os.environ.get("RUN_MAIN", None) is None and "runserver" in sys.argv:
             from shared.auth.github_state import GithubState
 
             self.github_state = GithubState()


### PR DESCRIPTION
Autoreloader restarts the child process with `RUN_MAIN` as an environment variable.

This is undocumented but can be known by reading Django source code.

Fixes #285.