### PR TITLE
fix: Add setuptools to dependencies

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -54,6 +54,7 @@ in
       sentry-sdk
       django-pghistory
       django-pgtrigger
+      setuptools
     ];
 
     postInstall = ''


### PR DESCRIPTION
Sorry if I'm missing something obvious here, I discovered I need this change in order to build this on a minimal NixOS installation.