### PR TITLE
feat(shared/apps): run github sync state in production

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -199,8 +199,13 @@ in
           ];
           requires = [ "postgresql.service" ];
           wantedBy = [ "multi-user.target" ];
-          serviceConfig.Restart = cfg.restart;
-          serviceConfig.TimeoutStartSec = lib.mkDefault "10m";
+          serviceConfig = {
+            Restart = cfg.restart;
+            TimeoutStartSec = lib.mkDefault "10m";
+            Environment = [
+              "SYNC_GITHUB_STATE_AT_STARTUP=true"
+            ];
+          };
           preStart = ''
             # Auto-migrate on first run or if the package has changed
             versionFile="/var/lib/web-security-tracker/package-version"

--- a/src/website/shared/apps.py
+++ b/src/website/shared/apps.py
@@ -13,6 +13,7 @@ class SharedConfig(AppConfig):
 
         # This hook is called on any `manage` subcommand.
         # Only connect to GitHub when the server is started.
+        # TODO: run this as a separate service, as this is almost exclusively a deployment concern
         if os.environ.get("RUN_MAIN", None) is None and (
             "runserver" in sys.argv
             or os.environ.get("SYNC_GITHUB_STATE_AT_STARTUP", False)

--- a/src/website/shared/apps.py
+++ b/src/website/shared/apps.py
@@ -13,7 +13,10 @@ class SharedConfig(AppConfig):
 
         # This hook is called on any `manage` subcommand.
         # Only connect to GitHub when the server is started.
-        if os.environ.get("RUN_MAIN", None) is None and "runserver" in sys.argv:
+        if os.environ.get("RUN_MAIN", None) is None and (
+            "runserver" in sys.argv
+            or os.environ.get("SYNC_GITHUB_STATE_AT_STARTUP", False)
+        ):
             from shared.auth.github_state import GithubState
 
             self.github_state = GithubState()


### PR DESCRIPTION
We just create a bespoke environment variable set by our packaging.

There's no other way as we cannot depend on any specific WSGI/ASGI
server argv0 here.

Fixes #239.

Depends on #392.
