### PR TITLE
fix: render package description in a better way

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -494,6 +494,8 @@ article .nixpkgs-packages {
 
 .nixpkgs-package .package-description {
   flex-grow: 1;
+  font-family: "IBM Plex Sans";
+  color: var(--dark-grey);
 }
 
 .nixpkgs-package .channel-list {


### PR DESCRIPTION
Closes #333 

Good enough, will be refined with #209 anyways.
![tmp co2OdPp0za](https://github.com/user-attachments/assets/0c9fd725-0f04-4a98-9c4e-f5814534e352)
