### PR TITLE
Revert "feat(shared/apps): run github sync state in production"

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -199,13 +199,8 @@ in
           ];
           requires = [ "postgresql.service" ];
           wantedBy = [ "multi-user.target" ];
-          serviceConfig = {
-            Restart = cfg.restart;
-            TimeoutStartSec = lib.mkDefault "10m";
-            Environment = [
-              "SYNC_GITHUB_STATE_AT_STARTUP=true"
-            ];
-          };
+          serviceConfig.Restart = cfg.restart;
+          serviceConfig.TimeoutStartSec = lib.mkDefault "10m";
           preStart = ''
             # Auto-migrate on first run or if the package has changed
             versionFile="/var/lib/web-security-tracker/package-version"

--- a/src/website/shared/apps.py
+++ b/src/website/shared/apps.py
@@ -13,11 +13,7 @@ class SharedConfig(AppConfig):
 
         # This hook is called on any `manage` subcommand.
         # Only connect to GitHub when the server is started.
-        # TODO: run this as a separate service, as this is almost exclusively a deployment concern
-        if os.environ.get("RUN_MAIN", None) is None and (
-            "runserver" in sys.argv
-            or os.environ.get("SYNC_GITHUB_STATE_AT_STARTUP", False)
-        ):
+        if os.environ.get("RUN_MAIN", None) is None and "runserver" in sys.argv:
             from shared.auth.github_state import GithubState
 
             self.github_state = GithubState()


### PR DESCRIPTION
Reverts Nix-Security-WG/nix-security-tracker#394

This breaks staging deployment without https://github.com/Nix-Security-WG/nix-security-tracker/issues/398. @alejandrosame please revert the revert once the GitHub setup is in place.