### PR TITLE
fix(ci/dumps): pass explicitly the required secrets

### DIFF
--- a/.github/workflows/database-dumps.yaml
+++ b/.github/workflows/database-dumps.yaml
@@ -27,3 +27,6 @@ jobs:
         run: cat ./staging/staging_host_keys >> ~/.ssh/known_hosts
       - name: Dump database to S3
         run: nix-shell default.nix -A ci --run "dump-database"
+        env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"


### PR DESCRIPTION
By default, GitHub won't load them if I don't ask for them.

Should fix #198.