### PR TITLE
fix(evaluation): crash pending evaluations at worker restart

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -236,6 +236,7 @@ in
 
           script = ''
             # Before starting, crash all the in-progress evaluations.
+            # This will prevent them from being stalled forever, since workers would not pick up evaluations marked as in-progress.
             wst-manage crash_all_evaluations
             wst-manage listen --processes ${toString cfg.maxJobProcessors}
           '';

--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -235,6 +235,8 @@ in
           wantedBy = [ "multi-user.target" ];
 
           script = ''
+            # Before starting, crash all the in-progress evaluations.
+            wst-manage crash_all_evaluations
             wst-manage listen --processes ${toString cfg.maxJobProcessors}
           '';
         };

--- a/src/website/shared/management/commands/crash_all_evaluations.py
+++ b/src/website/shared/management/commands/crash_all_evaluations.py
@@ -1,0 +1,21 @@
+from argparse import ArgumentParser
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from shared.models import NixEvaluation
+
+
+class Command(BaseCommand):
+    help = "Transition all in-progress evaluations to the crashed state"
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        pass
+
+    def handle(self, *args: Any, **kwargs: Any) -> str | None:
+        # Look for all evaluations with a created_at time bigger than 24 hours.
+        crashed = NixEvaluation.objects.filter(
+            state=NixEvaluation.EvaluationState.IN_PROGRESS
+        ).update(state=NixEvaluation.EvaluationState.CRASHED)
+        print(
+            f"{crashed} evaluations were transitioned to a crash state as a leftover of the previous worker"
+        )

--- a/src/website/shared/management/commands/crash_all_evaluations.py
+++ b/src/website/shared/management/commands/crash_all_evaluations.py
@@ -12,7 +12,6 @@ class Command(BaseCommand):
         pass
 
     def handle(self, *args: Any, **kwargs: Any) -> str | None:
-        # Look for all evaluations with a created_at time bigger than 24 hours.
         crashed = NixEvaluation.objects.filter(
             state=NixEvaluation.EvaluationState.IN_PROGRESS
         ).update(state=NixEvaluation.EvaluationState.CRASHED)

--- a/src/website/shared/models/nix_evaluation.py
+++ b/src/website/shared/models/nix_evaluation.py
@@ -237,7 +237,7 @@ class NixEvaluation(TimeStampMixin):
             "IN_PROGRESS",
             _("In progress"),
         )
-        # Crash means resource exhaustion or unexpected crash of the worker
+        # Crash means resource exhaustion, unexpected crash, or forced shutdown of the worker
         CRASHED = (
             "CRASHED",
             _("Crashed"),

--- a/src/website/shared/models/nix_evaluation.py
+++ b/src/website/shared/models/nix_evaluation.py
@@ -237,7 +237,7 @@ class NixEvaluation(TimeStampMixin):
             "IN_PROGRESS",
             _("In progress"),
         )
-        # Crash means resource exhaustion
+        # Crash means resource exhaustion or unexpected crash of the worker
         CRASHED = (
             "CRASHED",
             _("Crashed"),


### PR DESCRIPTION
This way, it's not possible to have leftovers not taken care until the next worker restart.

Now, "pending" evaluations can happen only in-between two worker restarts.
For this, we can add a supervisor timer unit that will check if there's any evaluation taking far too long (> 24 hours) and will forcibly restart the worker.

With that, the loop is closed.

Counts towards #390.