### PR TITLE
fix(staging/worker): apply automatic recovery for locked notifications

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: ./src/website/manage.py runserver
-workers: ./src/website/manage.py listen -v3 --processes 3
+workers: ./src/website/manage.py listen -v3 --recover --processes 3

--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -235,7 +235,7 @@ in
           wantedBy = [ "multi-user.target" ];
 
           script = ''
-            wst-manage listen --processes ${toString cfg.maxJobProcessors}
+            wst-manage listen --recover --processes ${toString cfg.maxJobProcessors}
           '';
         };
 


### PR DESCRIPTION
This ensures that at restart, locked notifications that did not terminate are resumed.

Count towards #390.