### PR TITLE
refactor(suggestions-log): implement as on db bulk aggregation query

### DIFF
--- a/src/website/webview/templates/components/suggestion_activity_log.html
+++ b/src/website/webview/templates/components/suggestion_activity_log.html
@@ -1,17 +1,19 @@
 {% load humanize %}
 {% load viewutils %}
 
-{% if not activity_log.updates|length_is:0 %}
+{% if not activity_log|length_is:0 %}
 <details class="activity-log"
          id="suggestion-activity-log-{{suggestion.id}}"
          data-relative=true
 >
   <summary class="main-summary">
     <span class="title-when-closed">
-      <span class="activity-log-timestamp">
-        updated {{ activity_log.updates|last_key|naturaltime }}
-      </span>
-      by&nbsp;<strong>@{{ activity_log.updates|last_user }}</strong>
+      {% with last_entry=activity_log|last_entry %}
+        <span class="activity-log-timestamp">
+          updated {{ last_entry.timestamp|naturaltime }}
+        </span>
+        by&nbsp;<strong>@{{ last_entry.username }}</strong>
+      {% endwith %}
     </span>
     <strong class="title-when-opened">Activity log</strong>
   </summary>
@@ -25,10 +27,9 @@
         {{ suggestion.created_at|naturaltime }}
       </span>
     </li>
-    {% for timestamp, log_entries in activity_log.updates.items %}
-    {% for log_entry in log_entries %}
+    {% for log_entry in activity_log %}
       <li class="activity-log-entry">
-        <strong>@{{ log_entry.user }}</strong>
+        <strong>@{{ log_entry.username }}</strong>
         {% if "derivations." in log_entry.action %}
         {# Package update entries #}
           {% if ".add" in log_entry.action %}
@@ -36,17 +37,15 @@
           {% else %}
             removed
           {% endif %}
-          {% if log_entry.target.items|length_is:1 %}
-            {% for packagename, derivations in log_entry.target.items %}
-              package <strong>{{ packagename }}</strong>
-            {% endfor %}
+          {% if log_entry.package_count == 1 %}
+            package <strong>{{ log_entry.package_names.0 }}</strong>
           {% else %}
             <details class="package-summary">
               <summary class="package-summary-title">
-                {{ log_entry.target.items|length }} packages
+                {{ log_entry.package_count }} packages
               </summary>
               <ul class="package-summary-listing">
-                {% for packagename, derivations in log_entry.target.items %}
+                {% for packagename in log_entry.package_names %}
                   <li>{{ packagename }}</li>
                 {% endfor %}
               </ul>
@@ -54,22 +53,21 @@
           {% endif %}
         {% else %}
           {# Status update entries #}
-          {% if "accepted" in log_entry.target  %}
+          {% if "accepted" in log_entry.status_value  %}
             <span class="suggestion-status-selected">selected</span>
-          {% elif "rejected" in log_entry.target %}
+          {% elif "rejected" in log_entry.status_value %}
             <span class="suggestion-status-dismissed">dismissed</span>
           {% else %}
             {{ log_entry.action }}
           {% endif %}
         {% endif %}
         <span class="activity-log-entry-timestamp"
-              data-timestamp-relative="{{ timestamp|naturaltime }}"
-              data-timestamp-iso="{{ timestamp|iso }}"
+              data-timestamp-relative="{{ log_entry.timestamp|naturaltime }}"
+              data-timestamp-iso="{{ log_entry.timestamp|iso }}"
         >
-          {{ timestamp|naturaltime }}
+          {{ log_entry.timestamp|naturaltime }}
         </span>
       </li>
-    {% endfor %}
     {% endfor %}
   </ul>
   <script>

--- a/src/website/webview/templatetags/viewutils.py
+++ b/src/website/webview/templatetags/viewutils.py
@@ -1,5 +1,4 @@
 import datetime
-from collections import OrderedDict
 from typing import Any, TypedDict
 
 from django import template
@@ -73,18 +72,9 @@ def iso(date: datetime.datetime) -> str:
 
 
 @register.filter
-def last_key(od: OrderedDict) -> Any | None:
+def last_entry(log: list) -> Any | None:
     try:
-        return next(reversed(od))
-    except StopIteration:
-        return None
-
-
-@register.filter
-def last_user(od: OrderedDict) -> str | None:
-    try:
-        _, entry = next(reversed(od.items()))
-        return entry[0]["user"]
+        return next(reversed(log))
     except StopIteration:
         return None
 

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -498,10 +498,16 @@ class SuggestionListView(ListView):
 
         context["status_filter"] = self.status_filter
 
+        suggestion_ids = [obj.proposal_id for obj in context["object_list"]]
+
+        grouped_activity_log = SuggestionActivityLog().get_dict(
+            suggestion_ids=suggestion_ids
+        )
+
         for obj in context["object_list"]:
-            obj.activity_log = SuggestionActivityLog(
-                suggestion=obj
-            ).get_structured_log()
+            obj.activity_log = []
+            if obj.proposal_id in grouped_activity_log:
+                obj.activity_log = grouped_activity_log[obj.proposal_id]
 
         context["adjusted_elided_page_range"] = context[
             "paginator"
@@ -525,7 +531,9 @@ class SuggestionListView(ListView):
         new_status = request.POST.get("new_status")
         current_page = request.POST.get("page", "1")
         suggestion = get_object_or_404(CVEDerivationClusterProposal, id=suggestion_id)
-        activity_log = SuggestionActivityLog(suggestion=suggestion).get_structured_log()
+        activity_log = SuggestionActivityLog().get_queryset(
+            suggestion_ids=[suggestion_id]
+        )
         cached_suggestion = get_object_or_404(
             CachedSuggestions, proposal_id=suggestion_id
         )


### PR DESCRIPTION
Closes #427

Some local benchmark comments:
    - From main, before refactor, running the queries in the selected page gave me: + CPU 3124ms DOMloading 4.23s.
    - After changing the query to a union an on db aggregation:
        + CPU 322ms DOM 638ms
    - After bulk filtering in the query (that is, adding pgh_obj_id__in filtering): + CPU 409ms DOM 831ms
    - After adding final dictionary aggregation:
        + CPU 308ms DOM 802ms

Therefore, with more data in the future, it can be reconsidered whether the bulk grouping is offering a good speedup tradeoff over filtering by single suggestion IDs.

The biggest speedup in this refactor was achieved by eliminating data roundtrips by using union and subqueries in the activity log fetch.