### PR TITLE
fix: ingest newest CVEs, not oldest CVEs

### DIFF
--- a/src/website/shared/management/commands/ingest_delta_cve.py
+++ b/src/website/shared/management/commands/ingest_delta_cve.py
@@ -179,7 +179,7 @@ class Command(BaseCommand):
         last_ingestion = (
             CveIngestion.objects.order_by("-valid_to")
             .values_list("valid_to", flat=True)
-            .last()
+            .first()
         )
 
         if last_ingestion is None:


### PR DESCRIPTION
This explains why we were never catching up, we were always restarting from scratch.