### PR TITLE
fix: Generate links with https when in production

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -146,6 +146,7 @@ in
         EVALUATION_LOGS_DIRECTORY = mkDefault "/var/log/web-security-tracker/evaluation";
         LOCAL_NIXPKGS_CHECKOUT = mkDefault "/var/lib/web-security-tracker/nixpkgs-repo";
         CVE_CACHE_DIR = mkDefault "/var/lib/web-security-tracker/cve-cache";
+        ACCOUNT_DEFAULT_HTTP_PROTOCOL = mkDefault (with cfg; if production then "https" else "http");
       };
 
       nginx.enable = true;


### PR DESCRIPTION
According to the [documentation](https://docs.allauth.org/en/dev/account/configuration.html) of django-allauth, `ACCOUNT_DEFAULT_HTTP_PROTOCOL` should be set to `https` in order to generate authentication links using https instead of http. This is currently needed in order to generate the correct callback URL for GitHub.