### PR TITLE
fix: don't show maintainers email when it is none

### DIFF
--- a/src/website/webview/templates/components/maintainers_list.html
+++ b/src/website/webview/templates/components/maintainers_list.html
@@ -8,7 +8,9 @@
         <li class="maintainer">
           <a class="github-id" href="https://github.com/{{ maintainer.github | urlencode }}">@{{ maintainer.github }}</a>
           {{ maintainer.name }}
-          &lt;<a class="email" href="mailto:{{maintainer.email | urlencode}}">{{ maintainer.email }}</a>&gt;
+          {% if maintainer.email %}
+            &lt;<a class="email" href="mailto:{{maintainer.email | urlencode}}">{{ maintainer.email }}</a>&gt;
+          {% endif %}
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
![tmp FnVpuzRe9t](https://github.com/user-attachments/assets/427bed85-dd90-425b-85fd-1330fdcacb19)
![tmp VyexHp35DM](https://github.com/user-attachments/assets/48b5e148-ee6c-4097-9c7c-0c3799d6bfb7)
