### PR TITLE
feat: display src file location next to the version for each derivation

### DIFF
--- a/src/website/shared/listeners/cache_suggestions.py
+++ b/src/website/shared/listeners/cache_suggestions.py
@@ -189,7 +189,11 @@ def get_src_position(derivation: NixDerivation) -> str | None:
         rev = urllib.parse.quote(derivation.parent_evaluation.commit_sha1)
         # position is something like `/tmp/tmpfh7ff2xs/pkgs/development/python-modules/qemu/default.nix:67`
         position_match = re.match(
-            r"/tmp/[^/]+/(.+):(\d+)", derivation.metadata.position
+            # FIXME the location of the eval store is going to be configurable in the future.
+            # https://github.com/Nix-Security-WG/nix-security-tracker/pull/451
+            # Ideally the position field is already relative to the location.
+            r"/tmp/[^/]+/(.+):(\d+)",
+            derivation.metadata.position,
         )
         if position_match:
             path = urllib.parse.quote(position_match.group(1))

--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -750,6 +750,10 @@ article .nixpkgs-packages {
   color: var(--dark-grey);
 }
 
+.nixpkgs-package .branch-minor .version {
+  color: var(--dark-grey);
+}
+
 .nixpkgs-package .branch-major {
   display: inline-flex;
   justify-content: flex-end;
@@ -764,6 +768,12 @@ article .nixpkgs-packages {
   min-width: 5em;
   display: inline-block;
   text-align: end;
+  text-decoration: none;
+  color: black;
+}
+
+.nixpkgs-package .version:hover {
+  text-decoration: underline;
 }
 
 .nixpkgs-package .version.affected {

--- a/src/website/webview/templates/components/nixpkgs_package.html
+++ b/src/website/webview/templates/components/nixpkgs_package.html
@@ -7,26 +7,31 @@
       {{ pdata.description }}
     </div>
     <ul class="channel-list">
-      {% for major_channel, val in pdata.versions %}
+      {% for major_channel, major_version in pdata.versions %}
         <li>
-          <details {% if val.uniform_versions %}open{% endif %}>
+          <details {% if major_version.uniform_versions %}open{% endif %}>
             <summary>
               <span class="branch-major">
                 <span class="branch-name">{{ major_channel }}</span>
-                <span class="version {{ val.status }}">
-                  {% if val.major_version %}
-                    {{ val.major_version }}
+                <a class="version {{ major_version.status }}" target="_blank" href="{{ major_version.src_position }}">
+                  {% if major_version.major_version %}
+                    {{ major_version.major_version }}
                   {% else %}
                     ???
                   {% endif %}
-                </span>
+                </a>
               </span>
             </summary>
             <ul class="channel-list">
-            {% for branch_name, vdata in val.sub_branches %}
+            {% for branch_name, minor_version in major_version.sub_branches %}
               <li class="branch-minor">
                 <span class="branch-name">{{ branch_name }}</span>
-                <span class="version {{ vdata.status }}">{{ vdata.version }}</span>
+                <a
+                  class="version {{ minor_version.status }}"
+                  target="_blank"
+                  href="{{ minor_version.src_position }}">
+                    {{ minor_version.version }}
+                </a>
               </li>
             {% endfor %}
             </ul>


### PR DESCRIPTION
Closes #440 

![tmp YSrXBRubZ0](https://github.com/user-attachments/assets/236a7bd9-8f60-48e7-af06-e33b89b18e30)

~~The code should be robust for e.g. `nixpkgs-darwin-24.11` and `nixos-24.11-small` to have different revisisions, though I never see any difference between these. Probably just because they evaluation did actually happen on the same commits?~~