### PR TITLE
fix: render state changes back to automatic suggestion in the activity log

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -963,6 +963,11 @@ button:hover {
   color: var(--dismissed-suggestion);
 }
 
+.suggestion-status-automatic {
+  font-weight: bold;
+  color: var(--automatic-suggestion);
+}
+
 /* Desktop */
 @media (min-width: 50em) {
 }

--- a/src/website/webview/templates/components/suggestion_activity_log.html
+++ b/src/website/webview/templates/components/suggestion_activity_log.html
@@ -57,6 +57,8 @@
             <span class="suggestion-status-draft">accepted as draft</span>
           {% elif "rejected" in log_entry.status_value %}
             <span class="suggestion-status-dismissed">dismissed</span>
+          {% elif "pending" in log_entry.status_value %}
+            <span class="suggestion-status-automatic">marked as untriaged</span>
           {% else %}
             {{ log_entry.action }}
           {% endif %}


### PR DESCRIPTION
This is a bandaid, a nicer solution would be to fold pairs of state changes into nothing, if they are only a few minutes apart and nothing else happened inbetween.

Fixes #455 

![tmp k2MZFUODMZ](https://github.com/user-attachments/assets/6fc03aa3-7249-4695-a715-c8bff8923f04)
