### PR TITLE
fix: move teams configuration to staging deployment

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -147,9 +147,6 @@ in
         LOCAL_NIXPKGS_CHECKOUT = mkDefault "/var/lib/web-security-tracker/nixpkgs-repo";
         CVE_CACHE_DIR = mkDefault "/var/lib/web-security-tracker/cve-cache";
         ACCOUNT_DEFAULT_HTTP_PROTOCOL = mkDefault (with cfg; if production then "https" else "http");
-        GH_ORGANIZATION = "Nix-Security-WG";
-        GH_SECURITY_TEAM = "sectracker-dev-security";
-        GH_COMMITTERS_TEAM = "sectracker-dev-nixpkgs-committers";
       };
 
       nginx.enable = true;

--- a/staging/sectracker.nix
+++ b/staging/sectracker.nix
@@ -58,7 +58,12 @@ in
   services.web-security-tracker = {
     enable = true;
     domain = "sectracker.nixpkgs.lahfa.xyz";
-    settings.DEBUG = true;
+    settings = {
+      DEBUG = true;
+      GH_ORGANIZATION = "Nix-Security-WG";
+      GH_SECURITY_TEAM = "sectracker-dev-security";
+      GH_COMMITTERS_TEAM = "sectracker-dev-nixpkgs-committers";
+    };
     secrets = {
       SECRET_KEY = config.age.secrets.django-secret-key.path;
       GH_CLIENT_ID = config.age.secrets.gh-client.path;


### PR DESCRIPTION
The defaults live in tracker/settings.py, which should be overridden through the deployment configuration file.