### PR TITLE
feat: display a disclaimer on production

### DIFF
--- a/src/website/shared/templates/base.html
+++ b/src/website/shared/templates/base.html
@@ -59,6 +59,11 @@
         <em>⚠️ You are using a <b>publicly accessible</b> testing environment.
         Don’t enter secrets into this system, especially not by reusing passwords for your user account.</em>
       </div>
+    {% else %}
+      <div id="testing-disclaimer">
+        <em>⚠️ You are using a production deployment that is <b>still only suitable for demo purposes.</b>
+        Any work done in this might be wiped later without notice.</em>
+      </div>
     {% endif %}
 
     {% block layout %}


### PR DESCRIPTION
It is supposed to be removed once we can guarantee that we won't need to wipe the database later.

I just thought this would be important to have now to manage the expactions of those currently trying out the deployment on tracker.security.nixos.org.

Closes #472 


![tmp uWPfylaauJ](https://github.com/user-attachments/assets/3dd710e1-91d4-4a8d-a748-b98480d4f4bf)
