### PR TITLE
fix: Fix a bug in POST requests to suggestions

### DIFF
--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -543,9 +543,9 @@ class SuggestionListView(ListView):
         new_status = request.POST.get("new_status")
         current_page = request.POST.get("page", "1")
         suggestion = get_object_or_404(CVEDerivationClusterProposal, id=suggestion_id)
-        activity_log = SuggestionActivityLog().get_dict(suggestion_ids=[suggestion.pk])[
-            suggestion.pk
-        ]
+        activity_log = SuggestionActivityLog().get_dict(suggestion_ids=[suggestion.pk]).get(
+            suggestion.pk, []
+        )
         cached_suggestion = get_object_or_404(
             CachedSuggestions, proposal_id=suggestion_id
         )


### PR DESCRIPTION
Return an empty list as there might not be an activity log and this will result in a key error and an HTTP 500 returned to the user.