### PR TITLE
Add link to the deployed tracker to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nixpkgs Security Tracker
 
-The **Nixpkgs Security Tracker** is a web service for managing information on vulnerabilities in software distributed through Nixpkgs.
+The [**Nixpkgs Security Tracker**](https://tracker.security.nixos.org/) is a web service for managing information on vulnerabilities in software distributed through Nixpkgs.
 
 This tool is eventually supposed to be used by the Nixpkgs community to effectively work through security advisories.
 We identified three interest groups that the tool is going to address:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Nixpkgs Security Tracker
 
-The [**Nixpkgs Security Tracker**](https://tracker.security.nixos.org/) is a web service for managing information on vulnerabilities in software distributed through Nixpkgs.
+The **Nixpkgs Security Tracker** is a web service for managing information on vulnerabilities in software distributed through Nixpkgs.
+
+This software is currently in prototype stage.
+A demo deployment is available at <https://tracker.security.nixos.org>.
 
 This tool is eventually supposed to be used by the Nixpkgs community to effectively work through security advisories.
 We identified three interest groups that the tool is going to address:


### PR DESCRIPTION
It took me some time to find out that there was a deployed tracker, because it's in the _about_ section of the project, which I personally almost never read or notice. This PR adds the link to the deployed tracker to the README, which is usually the first thing you read when arriving on the repo page (as a bonus, people cloning the repo without using the GitHub interface will also get the link now).