### PR TITLE
infra: Export Postgres and SQL metrics

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -34,3 +34,9 @@ Reading the [Agenix tutorial](https://github.com/ryantm/agenix#tutorial) is reco
 To add or edit a secret, you don't need to have access to the private keys.
 You only have to make sure that the file for the secret you want to edit doesn't exist, (i.e. delete `secrets/name_of_secret.age` if it already exists) and then run `agenix -e secrets/name_of_secret.age` from the directory that `secrets.nix` is in.
 Then commit `secrets/name_of_secret.age` as usual.
+
+## Metrics
+
+A [Prometheus Node Exporter](https://github.com/prometheus/node_exporter) is running exposing host specfic metrics. These are scraped by the nixos.org [Prometheus](https://prometheus.nixos.org/graph) and are also available under [Grafana](https://grafana.nixos.org/).
+
+Moreover, a [Postgres Exporter](https://github.com/prometheus-community/postgres_exporter) and a [SQL exporter](https://github.com/justwatchcom/sql_exporter) run in the host exposing Postgres and application specific metrics.

--- a/infra/configuration.nix
+++ b/infra/configuration.nix
@@ -114,5 +114,33 @@ in
     openFirewall = true;
   };
 
+  services.prometheus.exporters.postgres = {
+    enable = true;
+    openFirewall = true;
+  };
+
+  services.prometheus.exporters.sql = {
+    enable = true;
+    openFirewall = true;
+    configuration.jobs.sectracker = {
+      queries = {
+        users = {
+          query = "select count(*) from auth_user;";
+          values = [ "count" ];
+        };
+        delta = {
+          query = "select extract(EPOCH from timestamp) AS unix_timestamp from shared_cveingestion where delta = 't' order by timestamp desc limit 1;";
+          values = [ "unix_timestamp" ];
+        };
+        matching = {
+          query = "select extract(EPOCH from created_at) AS unix_timestamp from shared_cvederivationclusterproposal order by created_at desc limit 1;";
+          values = [ "unix_timestamp" ];
+        };
+      };
+      connections = [ "postgres://postgres@/web-security-tracker?host=/run/postgresql" ];
+      interval = "1h";
+    };
+  };
+
   system.stateVersion = "24.05";
 }


### PR DESCRIPTION
Related to #345, this PR adds two prometheus exporters to the deployment, one for generic postgres metrics and one to run custom queries. The custom queries exposed currently are:
1) Number of registered users
2) Unix timestamp since the last matching
3) Unix timestamp since the last delta