### PR TITLE
refactor: add GH_ISSUES_PING_MAINTAINERS setting

### DIFF
--- a/src/website/tracker/settings.py
+++ b/src/website/tracker/settings.py
@@ -336,6 +336,12 @@ DB_SECURITY_TEAM = "security_team"
 
 GH_WEBHOOK_SECRET = get_secret("GH_WEBHOOK_SECRET")
 
+# When set to False, the application will escape package maintainers' name when
+# mentioning them in the issue body to avoid actually pinging them. This is used
+# as a safety measure during development. When the GitHub issue story is ironed
+# out, this should be set to True in production.
+GH_ISSUES_PING_MAINTAINERS = False
+
 TEST_RUNNER = "tracker.test_runner.CustomTestRunner"
 
 # Make history log immutable by default

--- a/src/website/tracker/settings.py
+++ b/src/website/tracker/settings.py
@@ -45,6 +45,11 @@ class Settings(BaseSettings):
             of Nixpkgs maintainers in the evaluation database.
             """
         )
+        # When set to False, the application will escape package maintainers' name when
+        # mentioning them in the issue body to avoid actually pinging them. This is used
+        # as a safety measure during development. When the GitHub issue story is ironed
+        # out, this should be set to True in production.
+        GH_ISSUES_PING_MAINTAINERS: bool = False
 
     DJANGO_SETTINGS: DjangoSettings
 
@@ -335,12 +340,6 @@ DB_COMMITTERS_TEAM = "committers"
 DB_SECURITY_TEAM = "security_team"
 
 GH_WEBHOOK_SECRET = get_secret("GH_WEBHOOK_SECRET")
-
-# When set to False, the application will escape package maintainers' name when
-# mentioning them in the issue body to avoid actually pinging them. This is used
-# as a safety measure during development. When the GitHub issue story is ironed
-# out, this should be set to True in production.
-GH_ISSUES_PING_MAINTAINERS = False
 
 TEST_RUNNER = "tracker.test_runner.CustomTestRunner"
 


### PR DESCRIPTION
Split from #498: preliminary work adding a setting to escape maintainers' names when creating a GitHub issue to avoid pinging them while the feature isn't yet well tested.