### PR TITLE
feat: add all_maintainers() property to cached suggestions

### DIFF
--- a/src/website/shared/models/cached.py
+++ b/src/website/shared/models/cached.py
@@ -19,3 +19,28 @@ class CachedSuggestions(TimeStampMixin):
 
     # The exact format of this payload will change until it's properly defined.
     payload = models.JSONField(encoder=DjangoJSONEncoder)
+
+    @property
+    # TODO: for now we blindly list all maintainers of all affected packages,
+    # but in the future we might want to be able to edit this list before
+    # creating the GitHub issue. When that happens, this function will need to
+    # be updated (or the GitHub creation code should use a distinct
+    # `maintainers()` property, for example).
+    def all_maintainers(self) -> list[dict]:
+        """
+        Returns a deduplicated list (by GitHub ID) of all the maintainers of all
+        the affected packages linked to this suggestion.
+        """
+
+        seen = set()
+        result = []
+        all_maintainers = [
+            m for pkg in self.payload["packages"].values() for m in pkg["maintainers"]
+        ]
+
+        for m in all_maintainers:
+            if m["github_id"] not in seen:
+                seen.add(m["github_id"])
+                result.append(m)
+
+        return result


### PR DESCRIPTION
Split from #498. Add a property to a cached suggestions that retrieve all the maintainers from all the affected packages, deduplicated by GitHub ID. This will be used to ping maintainers in the final GitHub issue.