### PR TITLE
feat: add create_nixpkgs_issue() to suggestions

### DIFF
--- a/src/website/shared/models/linkage.py
+++ b/src/website/shared/models/linkage.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 import shared.models.cached
-from shared.models.cve import CveRecord
+from shared.models.cve import CveRecord, Description, IssueStatus, NixpkgsIssue
 from shared.models.nix_evaluation import NixDerivation, TimeStampMixin
 
 
@@ -39,6 +39,27 @@ class CVEDerivationClusterProposal(TimeStampMixin):
     status = models.CharField(
         max_length=text_length(Status), choices=Status.choices, default=Status.PENDING
     )
+
+    def create_nixpkgs_issue(self) -> NixpkgsIssue:
+        """
+        Create a NixpkgsIssue from this suggestion and save it in the database. Note
+        that this doesn't create a corresponding GitHub issue; interaction with
+        GitHub is handled separately in `shared.github`.
+        """
+
+        issue = NixpkgsIssue.objects.create(
+            # By default we set the status to affected; a human might later
+            # change the status if it turns out we're not affected in the
+            # end.
+            status=IssueStatus.AFFECTED,
+            description=Description.objects.create(
+                value=self.cached.payload["description"]
+            ),
+        )
+        issue.cve.add(self.cve)
+        issue.derivations.set(self.derivations.all())
+        issue.save()
+        return issue
 
 
 class ProvenanceFlags(IntFlag, boundary=STRICT):


### PR DESCRIPTION
Split off from #498. Add a helper to suggestions (`CVEDerivationClusterProposal`) to create a new `NixpkgsIssue` object from its data. This is supposed to be the main way of creating new `NixpkgsIssue` in the final workflow: when clicking on "Publish Issue" for an accepted issue, a `NixpkgsIssue` will be created using this method, the status will be set to published and an actual GitHub issue will be opened on Nixpkgs.