### PR TITLE
feat: published status in the view

### DIFF
--- a/src/website/webview/templates/components/suggestion.html
+++ b/src/website/webview/templates/components/suggestion.html
@@ -65,7 +65,7 @@
           Restore
         </button>
       {% elif status_filter == "accepted" %}
-        <button type="submit" name="create-draft-not-implemented" class="draft-color" disabled>
+        <button type="submit" name="new_status" value="published" class="draft-color">
           Publish issue
         </button>
         {% if cached_suggestion.packages %}

--- a/src/website/webview/templates/components/suggestion_state_changed.html
+++ b/src/website/webview/templates/components/suggestion_state_changed.html
@@ -8,8 +8,13 @@
     <input type="hidden" name="undo-status-change">
     {% csrf_token %}
     <input type="hidden" name="suggestion_id" value="{{ suggestion_id }}">
+    <!-- We can't undo publication -->
+    {% if status != "published" %}
     <button type="submit" name="new_status" value="{{ old_status }}" title="Undo">
       ↺
     </button>
+    {% else %}
+    <a href="{{ gh_issue_link }}">GitHub issue</a>
+    {% endif %}
   </form>
 </article>


### PR DESCRIPTION
Split off from #498. Adds a "Publish issue" button to update a suggestion from accepted to published. Update the status change component to link to the opened Github issue (instead of the undo button). Note that this commit doesn't actually implement any backend logic, so the button has no effect currently: it's purely a view thing.