### PR TITLE
ci: drop magic-nix-cache-action

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: |
           nix-shell default.nix -A ci --run "npins -d ./infra/npins update"
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -18,7 +18,6 @@ jobs:
           stack: dual
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}

--- a/.github/workflows/dry-activations.yaml
+++ b/.github/workflows/dry-activations.yaml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v29
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
it doesn't seem to be of use any more since the GitHub cache API was disabled