### PR TITLE
feat: add status change error component

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -358,6 +358,7 @@
   --automatic-suggestion: lightblue;
   --dismissed-suggestion: #acb3c8;
   --draft-suggestion: #7bca7b;
+  --error-suggestion: #ffabab;
   --affected: #ffabab;
   --unaffected: #bfb;
 }
@@ -587,6 +588,10 @@ article .suggestion.state-changed .state-identifier.accepted {
 
 article .suggestion.state-changed .state-identifier.published {
   background: var(--draft-suggestion);
+}
+
+article .suggestion.state-changed .state-identifier.error {
+  background: var(--error-suggestion);
 }
 
 article .suggestion.state-changed h2 {

--- a/src/website/webview/templates/components/suggestion_state_error.html
+++ b/src/website/webview/templates/components/suggestion_state_error.html
@@ -1,0 +1,9 @@
+<article class="suggestion state-changed">
+  <div class="state-identifier error"></div>
+  <h2>
+    {{ title }}
+  </h2>
+  <div>
+    Error: unable to change status of this suggestion to {{ target_status }}
+  </div>
+</article>

--- a/src/website/webview/templates/components/suggestion_state_error_wrapper.html
+++ b/src/website/webview/templates/components/suggestion_state_error_wrapper.html
@@ -1,0 +1,13 @@
+<!--
+  This component packs up an error message with the original suggestion view. By
+  default, the suggestion modification form replaces the original suggestion by
+  the status change component: indeed, when a status changes, the suggestion
+  shouldn't appear in the current view anymore. However, upon error, we do want
+  to keep the suggestion here. It turns out conditional swapping in HTMX isn't
+  entirely trivial. It is simpler to unconditionally swap the original
+  suggestion and put it back upon error, which is precisely what this component
+  does.
+-->
+{% include "components/suggestion_state_error.html" with title=suggestion_state_error.title target_status=suggestion_state_error.target_status %}
+
+{% include "components/suggestion.html" with suggestion=suggestion.suggestion cached_suggestion=suggestion.cached_suggestion activity_log=suggestion.activity_log status_filter=suggestion.status_filter user=suggestion.user page_obj=suggestion.page_obj csrf_token=suggestion.csrf_token %}


### PR DESCRIPTION
Follow-up of #516. This PR adds a small component, similar to the one handling state changes, to report errors during suggestion state transitions. More specifically here, the potentially fallible transition is to publish a GitHub issue, as this implies an external call to the GitHub API. In that case, if any step of the publication fails, the component will show that an error has occurred:

![image](https://github.com/user-attachments/assets/81071dd5-ee08-4468-9529-07f095d13e9a)

## TODO

- [x] The suggestion still disappears temporarily from the current view, which isn't desirable. It's still here if we refresh the page, but upon error, the suggestion shouldn't go anywhere in the first place.
