### PR TITLE
feat: attach labels to github issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ python3 -c 'import secrets; print(secrets.token_hex(100))' > .credentials/SECRET
     - In **Personal access tokens** approve the request under **Pending requests** if approval is required
     - In **Developer settings** GitHub Apps, create a new application
 
-      - In **Repository Permissions** select **Administration (read-only)** and **(Metadata: read-only)**.
+      - In **Repository Permissions** select **Administration (read-only)**, **Issues (read and write)** and **(Metadata: read-only)**.
       - In **Organization Permissions** select **Administration (read-only)** and **(Members: read-only)**.
 
       Store the **Client ID** in `.credentials/GH_CLIENT_ID`

--- a/src/website/shared/github.py
+++ b/src/website/shared/github.py
@@ -4,14 +4,16 @@ from urllib.parse import quote
 
 from github import Auth, Github
 from github.Issue import Issue as GithubIssue
-from shared.models import CachedSuggestions
 from tracker.settings import (
+    GH_ISSUES_LABELS,
     GH_ISSUES_PING_MAINTAINERS,
     GH_ISSUES_REPO,
     GH_ORGANIZATION,
     get_secret,
 )
 from webview.templatetags.viewutils import severity_badge
+
+from shared.models import CachedSuggestions
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +138,6 @@ def create_gh_issue(
 
     repo = github.get_repo(f"{GH_ORGANIZATION}/{GH_ISSUES_REPO}")
     title = cached_suggestion.payload["title"]
-    logger.error("all maintainers: %s", cached_suggestion.all_maintainers)
 
     body = f"""\
 - [{cached_suggestion.payload['cve_id']}](https://nvd.nist.gov/vuln/detail/{quote(cached_suggestion.payload['cve_id'])})
@@ -148,7 +149,7 @@ def create_gh_issue(
 {cvss_details()}
 {affected_nix_packages()}"""
 
-    return repo.create_issue(title, body)
+    return repo.create_issue(title=title, body=body, labels=GH_ISSUES_LABELS)
 
 
 def get_maintainer_username(maintainer: dict, github: Github = get_gh()) -> str:

--- a/src/website/tracker/settings.py
+++ b/src/website/tracker/settings.py
@@ -79,6 +79,16 @@ class Settings(BaseSettings):
             Set `nixpkgs-committers` for the production deployment.
             """
         )
+        GH_ISSUES_LABELS: list[str] = Field(
+            description="""
+            Labels to attach to Github issues created from the tracker, making
+            it easier to filter them on the nixpkgs repo.
+            """,
+            # It's always ok to operate with an empty list of labels both in
+            # production and in development mode. Override accordingly depending
+            # on the environment.
+            default=[],
+        )
 
     DJANGO_SETTINGS: DjangoSettings
 

--- a/src/website/tracker/settings.py
+++ b/src/website/tracker/settings.py
@@ -82,7 +82,7 @@ class Settings(BaseSettings):
         GH_ISSUES_LABELS: list[str] = Field(
             description="""
             Labels to attach to Github issues created from the tracker, making
-            it easier to filter them on the nixpkgs repo.
+            it easier to filter them on the target repository.
             """,
             # It's always ok to operate with an empty list of labels both in
             # production and in development mode. Override accordingly depending

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -59,6 +59,7 @@ from shared.models import (
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
 )
+
 from webview.forms import NixpkgsIssueForm
 from webview.paginators import CustomCountPaginator
 


### PR DESCRIPTION
Closes #501. The code looks fine but I have a permission issue to solve to properly test it; labels are just ignored currently, but if I try to add them manually on the created issue with `add_to_labels`, I get a proper 403, so something needs to be done (and documented) around GitHub access rights/PATs.