### PR TITLE
CI: run CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - src/website/shared/migrations

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,30 @@
+name: "CodeQL"
+
+on:
+  pull_request:
+  push:
+    branches: main
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v29
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: "python"
+          queries: security-and-quality
+          config-file: .github/codeql/codeql-config.yaml
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Context

I am experimenting with GitHub's [CodeQL](https://codeql.github.com/) static analyzer and this project is a good target, because it manipulates user input (in URLs).

## How to trust this PR

Look at the vulnerabilities found on my fork: https://github.com/smelc/nix-security-tracker/security/code-scanning IMHO most of the reports are good:

![image](https://github.com/user-attachments/assets/1e54b0ad-85b4-484a-82e7-d8b9888260d4)

By default this check is non intrusive, because this new pipeline only blocks merging when a new _error_, _critical_, or _high_ severity is found in code changed by the PR (see [corresponding doc](https://docs.github.com/en/enterprise-server@3.13/code-security/code-scanning/managing-code-scanning-alerts/triaging-code-scanning-alerts-in-pull-requests#code-scanning-results-check-failures)). As visible in the image above, all existing alerts are below this treshold.

If we want the check to forbid merging PRs on lower severities it is also possible: https://docs.github.com/en/enterprise-server@3.13/code-security/code-scanning/managing-your-code-scanning-configuration/editing-your-configuration-of-default-setup#defining-the-alert-severities-that-cause-a-check-failure-for-a-pull-request, here (not in the branch protection rule, which is why I'm highlighting it here):

![image](https://github.com/user-attachments/assets/aa28db2e-462d-4b80-82ca-304eca091d62)

Note that I disabled analyzing `src/website/shared/migrations` as it seemed to me those files had been generated.

We'll also want to check this in the branch protection settings of the repo: 

![image](https://github.com/user-attachments/assets/cbdc9366-a605-4db8-8d7c-f67004972340)

so that malicious users cannot turn CodeQL off/things don't get green if CodeQL is silent

## Maintenance

I will be available to maintain this pipeline in the foreseeable future, so this shouldn't be an additional burden on the team. Maintaining this will be part of my learning path on CodeQL.