### PR TITLE
Implement consistent views for published issues

### DIFF
--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -365,8 +365,8 @@
   --issue-unknown: #fcee92;
   --issue-affected: #99e87d;
   --issue-notaffected: #e8867d;
-  --issue-notforus: #e2e2e2
-  --issue-wontfix: #ccccdd
+  --issue-notforus: #e2e2e2;
+  --issue-wontfix: #ccccdd;
 }
 
 body {
@@ -484,7 +484,7 @@ article .issue {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: .5em;
+  gap: 0.5em;
   border: 1px solid var(--grey);
   border-radius: 5px;
   padding: 1rem;
@@ -492,7 +492,7 @@ article .issue {
 
 article .issue .status {
   font-weight: bold;
-  padding: .1em .5em;
+  padding: 0.1em 0.5em;
   text-transform: uppercase;
 }
 
@@ -520,7 +520,7 @@ article .issue .top-row {
   display: flex;
   font-size: 0.8rem;
   justify-content: space-between;
-  margin-bottom: .5em;
+  margin-bottom: 0.5em;
 }
 
 article .issue .creation-date {
@@ -537,13 +537,13 @@ article .issue .related-derivations .derivation-list {
   margin-left: 1em;
   display: flex;
   flex-direction: column;
-  gap: .3em;
+  gap: 0.3em;
 }
 
 article .issue .related-derivations .derivation-list .derivation {
   border: 1px solid var(--grey);
   border-radius: 5px;
-  padding: .5em;
+  padding: 0.5em;
 }
 
 article .issue .permalink {
@@ -729,7 +729,7 @@ details.description > summary {
 }
 
 details.description > summary:after {
-  margin-left: .5em;
+  margin-left: 0.5em;
   content: "Show\a0 more…";
   color: var(--dark-grey);
   cursor: pointer;

--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -480,15 +480,14 @@ nav.issue-pipeline ul {
 }
 
 article .issue {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: .5em;
   border: 1px solid var(--grey);
   border-radius: 5px;
-  align-items: start;
-  align-content: stretch;
-  justify-content: start;
   padding: 1rem;
-  flex-direction: column;
-  flex-wrap: nowrap;
-  flex-grow: 1;
 }
 
 article .issue .status {
@@ -528,12 +527,9 @@ article .issue .creation-date {
   font-style: italic;
 }
 
-article .issue .vulnerabilities {
-  margin: 1em auto;
-}
-
-article .issue .related-derivations {
-  margin: 1em auto;
+article .issue .vulnerabilities ul {
+  list-style-type: none;
+  margin: 0;
 }
 
 article .issue .related-derivations .derivation-list {
@@ -548,6 +544,10 @@ article .issue .related-derivations .derivation-list .derivation {
   border: 1px solid var(--grey);
   border-radius: 5px;
   padding: .5em;
+}
+
+article .issue .permalink {
+  align-self: flex-end;
 }
 
 article .vulnerabilities .cve-id {

--- a/src/website/webview/static/style.css
+++ b/src/website/webview/static/style.css
@@ -362,6 +362,11 @@
   --affected: #ffabab;
   --unaffected: #bfb;
   --highlighted: #fcf9c4;
+  --issue-unknown: #fcee92;
+  --issue-affected: #99e87d;
+  --issue-notaffected: #e8867d;
+  --issue-notforus: #e2e2e2
+  --issue-wontfix: #ccccdd
 }
 
 body {
@@ -467,6 +472,88 @@ nav.issue-pipeline ul {
   flex-direction: column;
 }
 
+#issue-list {
+  display: flex;
+  row-gap: 0.5rem;
+  padding: 0.5em;
+  flex-direction: column;
+}
+
+article .issue {
+  border: 1px solid var(--grey);
+  border-radius: 5px;
+  align-items: start;
+  align-content: stretch;
+  justify-content: start;
+  padding: 1rem;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+}
+
+article .issue .status {
+  font-weight: bold;
+  padding: .1em .5em;
+  text-transform: uppercase;
+}
+
+article .issue .status-unknown {
+  background: var(--issue-unknown);
+}
+
+article .issue .status-affected {
+  background: var(--issue-affected);
+}
+
+article .issue .status-notaffected {
+  background: var(--issue-notaffected);
+}
+
+article .issue .status-notforus {
+  background: var(--issue-notforus);
+}
+
+article .issue .status-wontfix {
+  background: var(--issue-wontfix);
+}
+
+article .issue .top-row {
+  display: flex;
+  font-size: 0.8rem;
+  justify-content: space-between;
+  margin-bottom: .5em;
+}
+
+article .issue .creation-date {
+  font-style: italic;
+}
+
+article .issue .vulnerabilities {
+  margin: 1em auto;
+}
+
+article .issue .related-derivations {
+  margin: 1em auto;
+}
+
+article .issue .related-derivations .derivation-list {
+  margin-top: 1em;
+  margin-left: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: .3em;
+}
+
+article .issue .related-derivations .derivation-list .derivation {
+  border: 1px solid var(--grey);
+  border-radius: 5px;
+  padding: .5em;
+}
+
+article .vulnerabilities .cve-id {
+  font-style: italic;
+}
+
 article .suggestion {
   position: relative;
   border: 1px solid var(--grey);
@@ -504,7 +591,7 @@ article .state-change-indicator {
   margin-top: 0.5em;
 }
 
-article .cve-id {
+article .suggestion .cve-id {
   color: var(--grey);
   padding: 0.2rem;
 }
@@ -642,6 +729,7 @@ details.description > summary {
 }
 
 details.description > summary:after {
+  margin-left: .5em;
   content: "Show\a0 more…";
   color: var(--dark-grey);
   cursor: pointer;

--- a/src/website/webview/templates/components/issue.html
+++ b/src/website/webview/templates/components/issue.html
@@ -38,10 +38,7 @@
         <div class="derivation">
           <div class="derivation-name">{{ drv.name }}</div>
           {% if drv.metadata.maintainers.all %}
-            <div class="maintainers">
-              (TODO maintainers)
-            </div>
-            <!-- TODO Reuse overhauled maintainer_list because for now it takes packages instead of maintainers -->
+            {% maintainers_list drv.metadata.maintainers.all %}
           {% endif %}
         </div>
       {% endfor %}

--- a/src/website/webview/templates/components/issue.html
+++ b/src/website/webview/templates/components/issue.html
@@ -1,0 +1,57 @@
+{% load viewutils %}
+
+<article class="issue" id="issue-{{ issue.code }}">
+
+  <div class="top-row">
+    <div class="status condensed status-{{ issue.status_string }}">{{ issue.status_string }}</div>
+    <div class="creation-date">created {{ issue.created }}</div>
+  </div>
+
+  <details class="description">
+    <summary>
+      {{ issue.code }}
+    </summary>
+    <p class="description-long as-details">{{ issue.description.value }}</p>
+  </details>
+
+
+  {% if issue.cve.all %}
+  <details class="vulnerabilities">
+    <summary>Vulnerabilities</summary>
+    <ul>
+      {% for cve in issue.cve.all %}
+      <li>
+        <a class="cve-id" href="https://nvd.nist.gov/vuln/detail/{{ cve.cve_id | urlencode }}">
+          {{ cve.cve_id }}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </details>
+  {% endif %}
+
+  {% if issue.derivations_with_cves %}
+  <details class="related-derivations">
+    <summary>Related derivations</summary>
+    <div class="derivation-list">
+      {% for drv in issue.derivations_with_cves %}
+        <div class="derivation">
+          <div class="derivation-name">{{ drv.name }}</div>
+          {% if drv.metadata.maintainers.all %}
+            <div class="maintainers">
+              (TODO maintainers)
+            </div>
+            <!-- TODO Reuse overhauled maintainer_list because for now it takes packages instead of maintainers -->
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  </details>
+  {% endif %}
+
+  {% if show_permalink %}
+    <a href="/issues/{{ issue.code }}" class="permalink">Permalink</a>
+  {% endif %}
+
+</article>
+

--- a/src/website/webview/templates/components/maintainers_list.html
+++ b/src/website/webview/templates/components/maintainers_list.html
@@ -3,7 +3,12 @@
 {% if maintainers %}
   <details class="maintainers">
     <summary>
-      Notify package maintainers: {{ maintainers | length }}
+      {%if selectable %}
+        Notify package maintainers:
+      {% else %}
+        Package maintainers:
+      {% endif %}
+      {{ maintainers | length }}
     </summary>
 
     <div class="maintainers-list">

--- a/src/website/webview/templates/issue_detail.html
+++ b/src/website/webview/templates/issue_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load viewutils %}
 
 {% block title %}
 {{ issue }}
@@ -6,54 +7,21 @@
 
 {% block content %}
 
-<h1>{{ object.code }}</h1>
+<header class="page-width">
+  <nav class="issue-pipeline centered-inline-list">
+    <ul>
+      <li><a href="/dismissed">Dismissed suggestions</a></li>
+      <li><a href="/suggestions">Untriaged suggestions</a></li>
+      <li><a href="/drafts">Draft issues</a></li>
+      <li><a href="/issues">Published issues</a></li>
+    </ul>
+  </nav>
+</header>
 
-<p>{{ object.description.value }}</p>
+<h1>Details of issue {{ object.code }}</h1>
 
-<dl>
-  <dt>Issue status</dt>
-    <dd>{{ object.status_string }}</dd>
-  <dt>Created</dt>
-    <dd>{{ object.created }}</dd>
-</dl>
-
-<h2>Vulnerabilities</h2>
-
-<ul>
-  {% for cve in object.cve.all %}
-    <li>{{ cve.cve_id }}</li>
-  {% endfor %}
-</ul>
-
-<h2>Related derivations</h2>
-<ul>
-    {% for drv in object.derivations_with_cves %}
-      <li>
-        {{ drv.name }} (<a href="{{drv.metadata.position}}">source</a>)
-        {% if drv.metadata.maintainers.all %}
-        <figure>
-          <figcaption>Maintainers</figcaption>
-          <ul>
-            {% for maintainer in drv.metadata.maintainers.all %}
-              <li><a href="https://github.com/{{ maintainer.github }}">@{{ maintainer.github }}</a></li>
-            {% endfor %}
-          </ul>
-        </figure>
-        {% endif %}
-
-        {% if drv.known_cves %}
-        <figure>
-          <figcaption>Known vulnerabilities</figcaption>
-          <ul>
-            {% for cve in drv.known_cves %}
-              <li>{{ cve.cve.cve_id }}</li>
-            {% endfor %}
-          </ul>
-        </figure>
-        {% endif %}
-
-      </li>
-    {% endfor %}
-</ul>
+<article class="page-width">
+  {% issue object %}
+</article>
 
 {% endblock content %}

--- a/src/website/webview/templates/issue_list.html
+++ b/src/website/webview/templates/issue_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load viewutils %}
 
 {% block content %}
 
@@ -14,9 +15,10 @@
 </header>
 
 <h1>Published issues</h1>
-<ul>
+
+<div id="issue-list" class="page-width">
     {% for object in object_list %}
-      <li><a href="{% url 'webview:issue_detail' object.code %}">{{ object.code }}</a></li>
+      {% issue object %}
     {% endfor %}
-</ul>
+</div>
 {% endblock content %}

--- a/src/website/webview/templates/issue_list.html
+++ b/src/website/webview/templates/issue_list.html
@@ -18,7 +18,7 @@
 
 <div id="issue-list" class="page-width">
     {% for object in object_list %}
-      {% issue object %}
+      {% issue object True %}
     {% endfor %}
 </div>
 {% endblock content %}

--- a/src/website/webview/templatetags/viewutils.py
+++ b/src/website/webview/templatetags/viewutils.py
@@ -160,10 +160,12 @@ def suggestion(
 @register.inclusion_tag("components/issue.html", takes_context=True)
 def issue(
     context: Context,
-    issue: NixpkgsIssue
+    issue: NixpkgsIssue,
+    show_permalink: bool = False,
 ) -> dict:
     return {
         "issue": issue,
+        "show_permalink": show_permalink,
         "page_obj": context.get("page_obj", None),
     }
 

--- a/src/website/webview/templatetags/viewutils.py
+++ b/src/website/webview/templatetags/viewutils.py
@@ -6,10 +6,7 @@ from django import template
 from django.template.context import Context
 from shared.auth import isadmin, ismaintainer
 from shared.listeners.cache_suggestions import parse_drv_name
-from shared.models.cve import (
-    AffectedProduct,
-    NixpkgsIssue
-)
+from shared.models.cve import AffectedProduct, NixpkgsIssue
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
 )
@@ -156,6 +153,7 @@ def suggestion(
         "page_obj": context["page_obj"],
         "user": context["user"],
     }
+
 
 @register.inclusion_tag("components/issue.html", takes_context=True)
 def issue(

--- a/src/website/webview/templatetags/viewutils.py
+++ b/src/website/webview/templatetags/viewutils.py
@@ -6,7 +6,10 @@ from django import template
 from django.template.context import Context
 from shared.auth import isadmin, ismaintainer
 from shared.listeners.cache_suggestions import parse_drv_name
-from shared.models.cve import AffectedProduct
+from shared.models.cve import (
+    AffectedProduct,
+    NixpkgsIssue
+)
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
 )
@@ -152,6 +155,16 @@ def suggestion(
         "status_filter": context["status_filter"],
         "page_obj": context["page_obj"],
         "user": context["user"],
+    }
+
+@register.inclusion_tag("components/issue.html", takes_context=True)
+def issue(
+    context: Context,
+    issue: NixpkgsIssue
+) -> dict:
+    return {
+        "issue": issue,
+        "page_obj": context.get("page_obj", None),
     }
 
 

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -60,7 +60,6 @@ from shared.models import (
     NixpkgsIssue,
 )
 from shared.models.linkage import CVEDerivationClusterProposal, MaintainersEdit
-
 from webview.forms import NixpkgsIssueForm
 from webview.paginators import CustomCountPaginator
 
@@ -693,7 +692,7 @@ class SuggestionListView(ListView):
                     if tracker_issue:
                         changed_suggestion_link = f"/issues/{tracker_issue.code}"
                     else:
-                        changed_suggestion_link = f"/issues"
+                        changed_suggestion_link = "/issues"
                 else:
                     changed_suggestion_link = f"{self.status_route_dict[suggestion.status]}#suggestion-{suggestion.pk}"
                 snippet = render_to_string(

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -433,7 +433,7 @@ class NixpkgsIssueListView(ListView):
     paginate_by = 10
 
     def get_queryset(self) -> BaseManager[NixpkgsIssue]:
-        return NixpkgsIssue.objects.all()
+        return NixpkgsIssue.objects.all().order_by("-created")
 
     def get_context_data(self, **kwargs: Any) -> Any:
         context = super().get_context_data(**kwargs)

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -431,9 +431,17 @@ class NixpkgsIssueView(DetailView):
 class NixpkgsIssueListView(ListView):
     template_name = "issue_list.html"
     model = NixpkgsIssue
+    paginate_by = 10
 
     def get_queryset(self) -> BaseManager[NixpkgsIssue]:
         return NixpkgsIssue.objects.all()
+
+    def get_context_data(self, **kwargs: Any) -> Any:
+        context = super().get_context_data(**kwargs)
+        context["adjusted_elided_page_range"] = context[
+            "paginator"
+        ].get_elided_page_range(context["page_obj"].number)
+        return context
 
 
 class NixderivationPerChannelView(ListView):

--- a/src/website/webview/views.py
+++ b/src/website/webview/views.py
@@ -580,6 +580,9 @@ class SuggestionListView(ListView):
         # true and `new_status = "published"`).
         gh_issue_link = None
 
+        # Issue on the tracker that is defined after publishing
+        tracker_issue = None
+
         def suggestion_view_context() -> dict:
             """
             Creates a proper context for the `suggestion` view. Since this is
@@ -686,6 +689,13 @@ class SuggestionListView(ListView):
                 )
                 return HttpResponse(snippet)
             elif status_change:
+                if suggestion.status == "published":
+                    if tracker_issue:
+                        changed_suggestion_link = f"/issues/{tracker_issue.code}"
+                    else:
+                        changed_suggestion_link = f"/issues"
+                else:
+                    changed_suggestion_link = f"{self.status_route_dict[suggestion.status]}#suggestion-{suggestion.pk}"
                 snippet = render_to_string(
                     "components/suggestion_state_changed.html",
                     {
@@ -693,7 +703,7 @@ class SuggestionListView(ListView):
                         "title": cached_suggestion.payload["title"],
                         "status": suggestion.status,
                         "old_status": self.status_filter,
-                        "changed_suggestion_link": f"{self.status_route_dict[suggestion.status]}#suggestion-{suggestion.pk}",
+                        "changed_suggestion_link": changed_suggestion_link,
                         "gh_issue_link": gh_issue_link,
                         "csrf_token": get_token(request),
                     },


### PR DESCRIPTION
This addresses #544 by implementing:
- a component for issues (as in `NixpkgsIssue`, which differ from "suggestions" that are listed in the other tabs, and is the reason why there was no view until now)
- a paginated list view of published issues (the landing page of "Published issues")
- a detailed view per issue, each having a URL

<details>
<summary>Screenshots</summary>

![2025-05-15 16-09-49](https://github.com/user-attachments/assets/8e69a882-dcc4-4d04-b8c5-af9057f25a87)

![2025-05-15 16-10-34](https://github.com/user-attachments/assets/4154d886-ce09-433c-b1ac-17f3f2f24a88)

</details>

### Remarks

- The `NixpkgsIssue` model and the `CveRecord` model do not carry the same info as suggestions used in other tabs, there is not the same degree of continuity as there is between the other tabs. Still, when publishing an issue from a draft, you can directly browse to the issue link.
- In the list view, the "related derivations" are not passed down to the view. This is a first draft only and I'm open to discussing this as I was a bit puzzled about how the info about related derivations is fetched for the detailed view and whether or how we want to lift that to reuse it in list view.
- [ ] As you can see, the maintainers are not yet displayed. There is absolutely no technical difficulty to do that. It just happens that @yannham worked on a refactor of the maintainers list component in a PR of his (the component weirdly takes a list of packages right now and yann is making it take a list of maintainers as expected), so once it is merged it can be reused here to avoid duplication.