### PR TITLE
Show current git revision on every page

### DIFF
--- a/src/website/shared/templates/base.html
+++ b/src/website/shared/templates/base.html
@@ -81,6 +81,7 @@
         <a href="https://github.com/Nix-Security-WG/nix-security-tracker">Nixpkgs Security Tracker</a> is part of a project funded by the
         <a href="https://sovereigntechfund.de/en/">Sovereign Tech Fund</a>.
       </p>
+      <p>Git revision: {{git_revision}}</p>
     </footer>
     <script src="/static/htmx.min.js"></script>
     <script>

--- a/src/website/tracker/git_revision.py
+++ b/src/website/tracker/git_revision.py
@@ -1,0 +1,25 @@
+import subprocess
+
+from django.conf import settings
+from django.core.cache import cache
+from django.http import HttpRequest
+
+
+def git_revision(request: HttpRequest) -> dict[str, str]:
+    revision = cache.get("git_revision")
+    if revision is None:
+        try:
+            project_root = settings.BASE_DIR
+            revision = (
+                subprocess.check_output(
+                    ["git", "rev-parse", "--short", "HEAD"],
+                    cwd=project_root,
+                    stderr=subprocess.DEVNULL,
+                )
+                .decode("utf-8")
+                .strip()
+            )
+        except Exception:
+            revision = "unknown"
+        cache.set("git_revision", revision, timeout=None)  # cache indefinitely
+    return {"git_revision": revision}

--- a/src/website/tracker/settings.py
+++ b/src/website/tracker/settings.py
@@ -307,6 +307,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "tracker.git_revision.git_revision",
             ],
         },
     },


### PR DESCRIPTION
This fixes #358. It mentions the current git revision in the footer of every page.