### PR TITLE
Reuse package list view for issues

### DIFF
--- a/src/website/shared/models/cached.py
+++ b/src/website/shared/models/cached.py
@@ -51,6 +51,7 @@ class CachedNixpkgsIssuePayload(BaseModel):
     description: str
     vulnerabilities: list[Vulnerability]
     related_derivations: list[RelatedDerivation]
+    packages: dict
 
 
 class CachedNixpkgsIssue(models.Model):

--- a/src/website/webview/templates/components/issue.html
+++ b/src/website/webview/templates/components/issue.html
@@ -32,16 +32,9 @@
 
   {% if issue.cached_payload.related_derivations %}
   <details class="related-derivations">
-    <summary>Related derivations</summary>
+    <summary>Related packages</summary>
     <div class="derivation-list">
-      {% for drv in issue.cached_payload.related_derivations %}
-        <div class="derivation">
-          <div class="derivation-name">{{ drv.name }}</div>
-          {% if drv.maintainers %}
-            {% maintainers_list drv.maintainers %}
-          {% endif %}
-        </div>
-      {% endfor %}
+      {% nixpkgs_package_list issue.cached_payload.packages %}
     </div>
   </details>
   {% endif %}


### PR DESCRIPTION
Fixes #574 

This is a draft and very naive adaptation (not ready for merge) of reusing the package list component from suggestions for issues. It needs to adapt the content of the cached issues.

![2025-06-11 15-52-07](https://github.com/user-attachments/assets/56df7794-ef2a-4e89-9276-e748cf77cb6f)
