### PR TITLE
Add extra maintainers from database or GitHub in issue drafts

### DIFF
--- a/src/shared/github.py
+++ b/src/shared/github.py
@@ -136,3 +136,20 @@ def get_maintainer_username(maintainer: dict, github: Github = get_gh()) -> str:
             f"Couldn't retrieve the GitHub username for maintainer {maintainer['github_id']}, fallback to {maintainer['github']}: {e}"
         )
         return maintainer["github"]
+
+
+def fetch_user_info(github_handle: str, github: Github = get_gh()) -> dict | None:
+    """
+    Fetch GitHub user info by handle.
+    """
+    try:
+        user = github.get_user(github_handle)
+        return {
+            "id": user.id,
+            "login": user.login,
+            "name": user.name,
+            "email": user.email,
+        }
+    except Exception as e:
+        logger.error(f"Could not fetch GitHub user '{github_handle}': {e}")
+        return None

--- a/src/webview/static/style.css
+++ b/src/webview/static/style.css
@@ -359,6 +359,8 @@
   --dismissed-suggestion: #acb3c8;
   --draft-suggestion: #7bca7b;
   --error-suggestion: #ffabab;
+  --maintainer-error: red;
+  --maintainer-add: #76b0e2;
   --affected: #ffabab;
   --unaffected: #bfb;
   --highlighted: #fcf9c4;
@@ -982,6 +984,63 @@ a:focus {
 .maintainer-container .maintainer-edit-add a {
   color: var(--grey);
   text-decoration: line-through;
+}
+
+.maintainer-add-container {
+  margin-top: .4em;
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+
+.maintainer-add-container>.subform {
+  display: flex;
+  align-items: stretch;
+}
+
+.maintainer-add-container>.subform>.spinner-container {
+  padding: 0 .2em;
+  border: 1px solid var(--maintainer-add);
+  border-left: none;
+  border-right: none;
+}
+
+.maintainer-add-container>.subform.error>.spinner-container {
+  border-color: var(--maintainer-error);
+}
+
+.maintainer-add-container>.subform>input {
+  padding: .2em .5em;
+  border: 1px solid var(--maintainer-add);
+  border-right: none;
+  border-radius: .3em 0 0 .3em;
+}
+
+.maintainer-add-container>.subform.error>input {
+  border-color: var(--maintainer-error);
+}
+
+.maintainer-add-container>.subform>button {
+  padding: .5em;
+  border: none;
+  border-radius: 0 .3em .3em 0;
+  color: white;
+  text-align: center;
+  border: 1px solid var(--maintainer-add);
+  background: var(--maintainer-add);
+  cursor: pointer;
+}
+
+.maintainer-add-container>.subform.error>button {
+  border-color: var(--maintainer-error);
+  background: var(--maintainer-error);
+}
+
+.maintainer-add-container .error-message {
+  display: flex;
+  align-items: center;
+  color: var(--maintainer-error);
+  flex-grow: 1;
 }
 
 .suggestion .change-issue-state {

--- a/src/webview/templates/components/add_maintainer.html
+++ b/src/webview/templates/components/add_maintainer.html
@@ -1,0 +1,29 @@
+{% load viewutils %}
+
+<div class="maintainer-add-container">
+  <div class="subform {%if error_msg %}error{% endif %}">
+    <input
+      type="text"
+      name="new_maintainer_github_handle"
+      placeholder="GitHub username"
+      autocomplete="off"
+    />
+    <div class="spinner-container">
+      <img class="state-change-indicator htmx-indicator" src="/static/spinner.svg">
+    </div>
+    <button
+      type="submit"
+      hx-post="{% url 'webview:add_maintainer' %}"
+      hx-swap="outerHTML"
+      hx-target="closest .maintainer-add-container"
+      hx-indicator=".state-change-indicator"
+    >
+      Add
+    </button>
+  </div>
+  {% if error_msg %}
+  <div class="error-message">
+    {{ error_msg }}
+  </div>
+  {% endif %}
+</div>

--- a/src/webview/templates/components/maintainers_list.html
+++ b/src/webview/templates/components/maintainers_list.html
@@ -1,7 +1,11 @@
 {% load viewutils %}
 
 {% if maintainers %}
-  <details class="maintainers">
+  <details
+    class="maintainers"
+    id="maintainers-list-{{ suggestion_id }}"
+    {% if oob_update %}hx-swap-oob="true" open{% endif %}
+  >
     <summary>
       {%if selectable %}
         Notify package maintainers:

--- a/src/webview/templates/components/maintainers_list.html
+++ b/src/webview/templates/components/maintainers_list.html
@@ -21,6 +21,9 @@
           {% endif %}
         </div>
       {% endfor %}
+      {% if selectable %}
+      {% add_maintainer %}
+      {% endif %}
     </div>
   </details>
 {% endif %}

--- a/src/webview/templates/components/suggestion.html
+++ b/src/webview/templates/components/suggestion.html
@@ -50,7 +50,7 @@
     {% endif %}
 
     {% if status_filter == "pending" or status_filter == "accepted" %}
-      {% selectable_maintainers_list cached_suggestion.maintainers %}
+      {% selectable_maintainers_list maintainers=cached_suggestion.maintainers suggestion_id=cached_suggestion.pk %}
     {% else %}
       {% maintainers_list cached_suggestion.maintainers %}
     {% endif %}

--- a/src/webview/templatetags/viewutils.py
+++ b/src/webview/templatetags/viewutils.py
@@ -70,6 +70,7 @@ class SelectableMaintainerContext(TypedDict):
     maintainer: Maintainer
     deleted: bool
 
+
 class AddMaintainerContext(TypedDict):
     error_msg: str | None
 
@@ -77,6 +78,13 @@ class AddMaintainerContext(TypedDict):
 class MaintainersListContext(TypedDict):
     maintainers: list[Maintainer]
     selectable: bool
+
+
+class EditableMaintainersListContext(TypedDict):
+    maintainers: list[Maintainer]
+    selectable: bool
+    suggestion_id: int
+    oob_update: bool
 
 
 @register.filter
@@ -242,10 +250,14 @@ def maintainers_list(
 @register.inclusion_tag("components/maintainers_list.html")
 def selectable_maintainers_list(
     maintainers: list[Maintainer],
-) -> MaintainersListContext:
+    suggestion_id: int,
+    oob_update: bool = False,
+) -> EditableMaintainersListContext:
     return {
         "maintainers": maintainers,
         "selectable": True,
+        "suggestion_id": suggestion_id,
+        "oob_update": oob_update,
     }
 
 
@@ -263,8 +275,9 @@ def selectable_maintainer(
 ) -> SelectableMaintainerContext:
     return {"maintainer": maintainer, "deleted": deleted}
 
+
 @register.inclusion_tag("components/add_maintainer.html")
 def add_maintainer(
     error_msg: str | None = None,
 ) -> AddMaintainerContext:
-    return { "error_msg": error_msg }
+    return {"error_msg": error_msg}

--- a/src/webview/templatetags/viewutils.py
+++ b/src/webview/templatetags/viewutils.py
@@ -70,6 +70,9 @@ class SelectableMaintainerContext(TypedDict):
     maintainer: Maintainer
     deleted: bool
 
+class AddMaintainerContext(TypedDict):
+    error_msg: str | None
+
 
 class MaintainersListContext(TypedDict):
     maintainers: list[Maintainer]
@@ -259,3 +262,9 @@ def selectable_maintainer(
     deleted: bool = False,
 ) -> SelectableMaintainerContext:
     return {"maintainer": maintainer, "deleted": deleted}
+
+@register.inclusion_tag("components/add_maintainer.html")
+def add_maintainer(
+    error_msg: str | None = None,
+) -> AddMaintainerContext:
+    return { "error_msg": error_msg }

--- a/src/webview/urls.py
+++ b/src/webview/urls.py
@@ -11,6 +11,7 @@ from webview.views import (
     NixpkgsIssueListView,
     NixpkgsIssueView,
     SelectableMaintainerView,
+    AddMaintainerView,
     SuggestionListView,
     TriageView,
 )
@@ -56,6 +57,11 @@ urlpatterns = [
         "edit_maintainers/",
         SelectableMaintainerView.as_view(),
         name="edit_maintainers",
+    ),
+    path(
+        "add_maintainer/",
+        AddMaintainerView.as_view(),
+        name="add_maintainer",
     ),
     path(
         "dismissed/",

--- a/src/webview/urls.py
+++ b/src/webview/urls.py
@@ -6,12 +6,12 @@ from shared.models.linkage import (
     CVEDerivationClusterProposal,
 )
 from webview.views import (
+    AddMaintainerView,
     HomeView,
     NixderivationPerChannelView,
     NixpkgsIssueListView,
     NixpkgsIssueView,
     SelectableMaintainerView,
-    AddMaintainerView,
     SuggestionListView,
     TriageView,
 )

--- a/src/webview/views.py
+++ b/src/webview/views.py
@@ -868,7 +868,7 @@ class AddMaintainerView(TemplateView):
 
         # Check if the maintainer is already part of the suggestion
         if any(
-            str(m["github_id"]) == new_maintainer_github_handle
+            str(m["github"]) == new_maintainer_github_handle
             for m in cached_suggestion.payload["maintainers"]
         ):
             return self.render_to_response(
@@ -888,7 +888,7 @@ class AddMaintainerView(TemplateView):
 
         with transaction.atomic():
             edit = suggestion.maintainers_edits.filter(
-                maintainer__github_id=new_maintainer_github_handle
+                maintainer__github=new_maintainer_github_handle
             )
             if edit.exists():
                 # NOTE We assume there is at most one edit for a given maintainer

--- a/src/webview/views.py
+++ b/src/webview/views.py
@@ -858,8 +858,6 @@ class AddMaintainerView(TemplateView):
             return HttpResponseForbidden()
 
 
-        time.sleep(2)
-
         if not new_maintainer_github_handle:
             logger.error("Missing new maintainer github handle in request for maintainer addition")
             return self.render_to_response(
@@ -868,8 +866,71 @@ class AddMaintainerView(TemplateView):
                         }
                     )
 
+        # Check if the maintainer is already part of the suggestion
+        if any(
+            str(m["github_id"]) == new_maintainer_github_handle
+            for m in cached_suggestion.payload["maintainers"]
+        ):
+            return self.render_to_response(
+                {
+                    "error_msg": "Already a maintainer",
+                }
+            )
+
+        maintainer = NixMaintainer.objects.filter(github=new_maintainer_github_handle).first()
+        if not maintainer:
+            # TODO Implement fetching information via the GitHub API
+            return self.render_to_response(
+                        {
+                            "error_msg": "Maintainer not found",
+                        }
+                    )
+
+        with transaction.atomic():
+            edit = suggestion.maintainers_edits.filter(
+                maintainer__github_id=new_maintainer_github_handle
+            )
+            if edit.exists():
+                # NOTE We assume there is at most one edit for a given maintainer
+                edit_object = edit.first()
+                maintainer = edit_object.maintainer
+                if edit_object.edit_type == MaintainersEdit.EditType.ADD:
+                    # The maintainer is already an extra maintainer, we return an error message for the user.
+                    return self.render_to_response(
+                                {
+                                    "error_msg": "Already added as an extra maintainer",
+                                }
+                            )
+                elif edit_object.edit_type == MaintainersEdit.EditType.REMOVE:
+                    # TODO The maintainer was removed in an edit, normally this means it is displayed on the web UI with a restore button next to it. Should we restore it as if clicked on the button or return an error?
+                    # NOTE An else would have sufficed but this is in case someday we have more than ADD and REMOVE edit types
+                    return self.render_to_response(
+                                {
+                                    "error_msg": "This maintainer may be restored via the undo delete button",
+                                }
+                            )
+                else:
+                    logger.error("Unexpected maintainer edit status")
+                    return HttpResponse(status=422)
+            else:
+                edit = MaintainersEdit(
+                    edit_type= MaintainersEdit.EditType.ADD,
+                    maintainer=maintainer,
+                    suggestion=suggestion,
+                )
+                edit.save()
+
+            # Recompute the maintainer list for the cached suggestion
+            cached_suggestion.payload["maintainers"] = maintainers_list(
+                cached_suggestion.payload["packages"],
+                suggestion.maintainers_edits.all(),
+            )
+            cached_suggestion.save()
+
+
+
+
         return self.render_to_response(
             {
-                "error_msg": "todo",
             }
         )


### PR DESCRIPTION
This addresses #418 and implements an input field for extra maintainers in issue drafts. When not found in database, it fetches the info from GitHub via user handle (exact match).