### PR TITLE
infra: Optimise the nix store by default

### DIFF
--- a/infra/sectracker.nix
+++ b/infra/sectracker.nix
@@ -89,4 +89,6 @@ in
     gh-app-private-key.file = ./secrets/nixpkgs-security-tracker.2024-12-09.private-key.pem.age;
     gh-app-installation-id.file = ./secrets/gh-app-installation-id.age;
   };
+
+  nix.optimise.automatic = true;
 }


### PR DESCRIPTION
Automatically [optimise the nix store](https://wiki.nixos.org/wiki/Storage_optimization#Automatic) by using a timer. We could argue that this should be set in `nix/web-security-tracker.nix`, but I don't want to "force" this on all installations and I think its best to allow admins to make this decision themselves. This reasoning shall be documented in #594.