### PR TITLE
fix: Show input drvs with nix-eval-jobs

### DIFF
--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -46,6 +46,7 @@ async def perform_evaluation(
     nixpkgs_config = "{ config = { allowUnfree = true; inHydra = false; allowInsecurePredicate = (_: true); scrubJobs = false; }; };"
     evaluation_wrapper = f"(import <nixpkgs/pkgs/top-level/release.nix> {{ nixpkgsArgs = {nixpkgs_config} }})"
     arguments = [
+        "--show-input-drvs",
         "--force-recurse",
         "--meta",
         "--repair",


### PR DESCRIPTION
Since version [v2.26.0 nix-eval-jobs doesn't export input drvs by default](https://github.com/nix-community/nix-eval-jobs/pull/325/commits/0cafa1bf787dbc496c674be275301531c3e79732), so we need to add this flag to re-enable this behaviour.

We upgraded to the latest nix-eval-jobs after #586 on tracker.security.nixos.org, which means that all evals since then have been marked as `CRASHED` because they failed due to this. I've applied this patch on tracker.security.nixos.org and I'm running an eval now that seems to be working fine.

Log entries of such a crash:
```
 2025-07-24 04:00:20,689 INFO Nix evaluation requested: 1744f3daf87f5bb4b2b08f6298a55b6a88ea8308, expecting to finish in 1074.436200 seconds
 ERROR 2025-07-24 04:00:49,117 nix_evaluation 1299468 140545912928064 Failed to run the `nix-eval-job` on revision '1744f3daf87f5bb4b2b08f6298a55b6a88ea8308', marking job as crashed...
 Traceback (most recent call last):
   File "/nix/store/h2dil7jg2xzk67nqz4z75pfhw9rxpadv-python3.13-web-security-tracker-0.0.1/lib/python3.13/site-packages/shared/listeners/nix_evaluation.py", line 215, in evaluation_entrypoint
     await realtime_batch_process_attributes(
         evaluation, [line.decode("utf8") for line in lines]
     )
   File "/nix/store/h2dil7jg2xzk67nqz4z75pfhw9rxpadv-python3.13-web-security-tracker-0.0.1/lib/python3.13/site-packages/shared/listeners/nix_evaluation.py", line 80, in realtime_batch_process_attributes
     partial_eval = parse_evaluation_result(attribute)
   File "/nix/store/h2dil7jg2xzk67nqz4z75pfhw9rxpadv-python3.13-web-security-tracker-0.0.1/lib/python3.13/site-packages/shared/evaluation.py", line 150, in parse_evaluation_result
     evaluation=parse_total_evaluation(raw) if raw.get("error") is None else None,
                ~~~~~~~~~~~~~~~~~~~~~~^^^^^
   File "/nix/store/h2dil7jg2xzk67nqz4z75pfhw9rxpadv-python3.13-web-security-tracker-0.0.1/lib/python3.13/site-packages/shared/evaluation.py", line 141, in parse_total_evaluation
     return EvaluatedAttribute.from_dict(raw)
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
   File "<string>", line 35, in cls_fromdict
 dataclass_wizard.errors.MissingFields: `EvaluatedAttribute.__init__()` missing required fields.
   Provided: ['attr', 'attr_path', 'drv_path', 'meta', 'name', 'outputs', 'system']
   Missing: ['input_drvs']
   error: EvaluatedAttribute.__init__() missing 1 required positional argument: 'input_drvs'
 2025-07-24 04:00:49,117 ERRO Failed to run the `nix-eval-job` on revision '1744f3daf87f5bb4b2b08f6298a55b6a88ea8308', marking job as crashed...
```