### PR TITLE
fix: Add 25.05 to MAJOR_CHANNELS, remove old ones

### DIFF
--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -322,7 +322,7 @@ class NixDerivation(models.Model):
 
 # Major channels are the important channels that a user wants to keep an eye on.
 # FIXME figure this out dynamically
-MAJOR_CHANNELS = ["23.11", "24.05", "24.11", "unstable"]
+MAJOR_CHANNELS = ["24.11", "25.05", "unstable"]
 
 
 # The major channel that a branch name (e.g. nixpkgs-24.05-darwin) belongs to


### PR DESCRIPTION
Looks like we're using a static list to track which channels are considered major and we're [ignoring the rest](https://github.com/Nix-Security-WG/nix-security-tracker/blob/1ad5409158e789b9de9d682687a09ccda2394a45/src/shared/listeners/cache_suggestions.py#L261) . This PR will at least add `25.05` to the list of major channels and remove older ones (23.11 and 24.05) that are EOL.