### PR TITLE
fix: Increase timeout and batch size for nix eval

### DIFF
--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -116,7 +116,7 @@ async def realtime_batch_process_attributes(
 
 
 async def drain_lines(
-    stream: asyncio.StreamReader, timeout: float = 0.25, max_batch_window: int = 10_000
+    stream: asyncio.StreamReader, timeout: float = 3.5, max_batch_window: int = 75_000
 ) -> AsyncGenerator[list[bytes]]:
     """
     This utility will perform an opportunistic line draining


### PR DESCRIPTION
After running some tests, these settings seem to perform about 100-200x times faster than the previous values, at the expense of more memory.

Original values we're getting ~1 attribute every 3 seconds with some exceptions:
```
Sep 17 20:58:16 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:16,367 INFO 1 attributes were ingested in 0.064309 seconds                                                    
Sep 17 20:58:20 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:20,107 INFO 1 attributes were ingested in 0.086749 seconds                                                    
Sep 17 20:58:21 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:21,303 INFO 1 attributes were ingested in 0.064423 seconds                                                    
Sep 17 20:58:21 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:21,704 INFO 3 attributes were ingested in 0.062850 seconds                                                    
Sep 17 20:58:24 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:24,760 INFO 1 attributes were ingested in 0.053967 seconds                                                    
Sep 17 20:58:28 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:28,668 INFO 1 attributes were ingested in 0.086924 seconds                                                    
Sep 17 20:58:29 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:29,457 INFO 1 attributes were ingested in 0.073036 seconds                                                    
Sep 17 20:58:29 nixos web-security-tracker-worker-start[20234]: 2025-09-17 20:58:29,877 INFO 1 attributes were ingested in 0.085220 seconds
```

With these new values:
```
Sep 17 21:09:45 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:09:45,977 INFO 6052 attributes were ingested in 51.348887 seconds
Sep 17 21:10:58 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:10:58,225 INFO 3290 attributes were ingested in 25.561116 seconds
Sep 17 21:11:18 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:11:18,507 INFO 211 attributes were ingested in 1.572250 seconds
Sep 17 21:11:22 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:11:22,130 INFO 1 attributes were ingested in 0.047971 seconds
Sep 17 21:11:29 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:11:29,400 INFO 152 attributes were ingested in 1.143473 seconds
Sep 17 21:13:15 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:13:15,129 INFO 2571 attributes were ingested in 16.635387 seconds
Sep 17 21:15:35 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:15:35,448 INFO 5500 attributes were ingested in 25.364185 seconds
Sep 17 21:16:20 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:16:20,744 INFO 1527 attributes were ingested in 9.952927 seconds
Sep 17 21:16:25 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:16:25,913 INFO 3 attributes were ingested in 0.063238 seconds
Sep 17 21:16:36 nixos web-security-tracker-worker-start[73821]: 2025-09-17 21:16:36,906 INFO 45 attributes were ingested in 0.423121 seconds
```