### PR TITLE
fix: Properly handle case sensitive GH usernames

### DIFF
--- a/src/webview/views.py
+++ b/src/webview/views.py
@@ -577,11 +577,13 @@ class AddMaintainerView(TemplateView):
             # Try to fetch maintainer info from GitHub API and create if found
             gh_user = fetch_user_info(new_maintainer_github_handle)
             if gh_user:
-                maintainer = NixMaintainer.objects.create(
+                maintainer, created = NixMaintainer.objects.update_or_create(
                     github_id=gh_user["id"],
-                    github=gh_user["login"],
-                    name=gh_user.get("name"),
-                    email=gh_user.get("email"),
+                    defaults={
+                        "github": gh_user["login"],
+                        "name": gh_user.get("name"),
+                        "email": gh_user.get("email"),
+                    },
                 )
             else:
                 return self.render_to_response(


### PR DESCRIPTION
Before this the GitHub usernames had to be written in a case sensitive manner otherwise a 500 would occur when trying to add the maintainer. This also prevents ingestion of packages if a user has switched GitHub accounts (and thus GH IDs) but is re-using the same GitHub username (we had such a case in Nixpkgs recently).