### PR TITLE
fix: Fix 500 error on issues view

### DIFF
--- a/src/shared/listeners/__init__.py
+++ b/src/shared/listeners/__init__.py
@@ -2,3 +2,4 @@ import shared.listeners.nix_channels  # noqa
 import shared.listeners.nix_evaluation  # noqa
 import shared.listeners.automatic_linkage  # noqa
 import shared.listeners.cache_suggestions  # noqa
+import shared.listeners.cache_issues #noqa


### PR DESCRIPTION
The pgpubsub trigger for caching issues wasn't imported and thus didn't run in the past.

Opening this as draft, as I want to move issue processing to a separate worker