### PR TITLE
fix: show actual commit hash in revision when repository is dirty

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -83,7 +83,7 @@ rec {
                 shallow = true;
               };
             in
-            if git ? dirtyRev then git.dirtyShortRev else git.shortRev;
+            if git ? dirtyRev then "${git.shortRev}-dirty" else git.shortRev;
         };
       };
 


### PR DESCRIPTION
Resolves #660 