### PR TITLE
Ignore results when there are multiple results present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 result
+result-*
 .direnv
 .pre-commit-config.yaml
 __pycache__


### PR DESCRIPTION
Copied from the nixpkgs .gitignore file. Especially because this repo uses derivations with multiple outputs.