### PR TITLE
fix: Clear failure reason when an eval succeeds

### DIFF
--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -243,6 +243,7 @@ async def evaluation_entrypoint(
                     await NixEvaluation.objects.filter(id=evaluation.pk).aupdate(
                         state=NixEvaluation.EvaluationState.COMPLETED,
                         elapsed=elapsed,
+                        failure_reason=None,
                         updated_at=timezone.now(),
                     )
     except Exception as e:


### PR DESCRIPTION
Fixes #663