### PR TITLE
fix: typo in team name for local testing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -69,11 +69,11 @@ rec {
         DJANGO_SETTINGS = builtins.toJSON {
           DEBUG = true;
           PRODUCTION = false;
-          SYNC_GITHUB_STATE_AT_STARTUP = false;
+          SYNC_GITHUB_STATE_AT_STARTUP = true;
           GH_ISSUES_PING_MAINTAINERS = false;
           GH_ORGANIZATION = "Nix-Security-WG";
           GH_ISSUES_REPO = "sectracker-testing";
-          GH_SECURITY_TEAM = "setracker-testing-security";
+          GH_SECURITY_TEAM = "sectracker-testing-security";
           GH_COMMITTERS_TEAM = "sectracker-testing-committers";
           STATIC_ROOT = "${toString ./src/static}";
           REVISION =


### PR DESCRIPTION
This seems to have prevented GitHub team membership sync on startup in
local testing. It can now be used to manually check permissions by
toggling membership in the GitHub organisation used for testing.