### PR TITLE
chore: run on 25.11, don't run on 24.11

### DIFF
--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -323,7 +323,7 @@ class NixDerivation(models.Model):
 
 # Major channels are the important channels that a user wants to keep an eye on.
 # FIXME figure this out dynamically
-MAJOR_CHANNELS = ["24.11", "25.05", "unstable"]
+MAJOR_CHANNELS = ["25.05", "25.11", "unstable"]
 
 
 # The major channel that a branch name (e.g. nixpkgs-24.05-darwin) belongs to


### PR DESCRIPTION
Eventually this could probably use `lib.oldestSupportedRelease` or something. But for now, I think this is fine.