### PR TITLE
Rename `Restore` to `Convert to draft` in dismissed issues view

### DIFF
--- a/src/webview/templates/components/suggestion.html
+++ b/src/webview/templates/components/suggestion.html
@@ -74,7 +74,7 @@
         </button>
       {% elif status_filter == "rejected" %}
         <button type="submit" name="new_status" value="accepted" class="draft-color">
-          Restore
+          Convert to draft
         </button>
       {% elif status_filter == "accepted" %}
         <button type="submit" name="new_status" value="published" class="draft-color">


### PR DESCRIPTION
~When restoring an issue from a dismissed state it should go back to untriaged, not drafts.~

After the discussion in this issue I believe renaming this button is closer to the expected flow.