### PR TITLE
fix: Add a worker only for issue creation

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -284,6 +284,21 @@ in
           '';
         };
 
+        web-security-tracker-worker-issues = {
+          description = "Web security tracker - background issues processor";
+          after = [
+            "network.target"
+            "postgresql.service"
+            "web-security-tracker-server.service"
+          ];
+          requires = [ "postgresql.service" ];
+          wantedBy = [ "multi-user.target" ];
+
+          script = ''
+            wst-manage listen --recover --channels shared.channels.NixpkgsIssueChannel
+          '';
+        };
+
         web-security-tracker-fetch-all-channels = {
           description = "Web security tracker - refresh all channels and start nixpkgs evaluation";
 


### PR DESCRIPTION
Issues need to be cached quickly for the issue view to work, but the worker might be busy with other tasks. This PR adds a second listener only for issue creation, so they don't get stuck in a queue behind other tasks.