### PR TITLE
refactor: use name and version from `pyproject.toml`

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,6 +1,7 @@
 final: _prev:
 let
   sources = import ../npins;
+  meta = with builtins; fromTOML (readFile ../src/pyproject.toml);
 in
 {
   # go through the motions to make a flake-incompat project use the build
@@ -15,8 +16,8 @@ in
   };
 
   web-security-tracker = final.python3.pkgs.buildPythonPackage rec {
-    pname = "web-security-tracker";
-    version = "0.0.1";
+    pname = meta.project.name;
+    inherit (meta.project) version;
     pyproject = true;
 
     src = final.nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ../src;


### PR DESCRIPTION
I originally made this change because I considered bumping the version before production deployment, but then dropped the idea because it's additional process for little user value at the moment. Were, not writing a changelog, and even if we did, SemVer would likely not be the right thing for what's primarily a web UI.