### PR TITLE
fix: Properly render issue publication in activity log

### DIFF
--- a/src/webview/templates/components/suggestion_activity_log.html
+++ b/src/webview/templates/components/suggestion_activity_log.html
@@ -81,6 +81,8 @@
             <span class="suggestion-status-dismissed">dismissed</span>
           {% elif "pending" in log_entry.status_value %}
             <span class="suggestion-status-automatic">marked as untriaged</span>
+          {% elif "published" in log_entry.status_value %}
+            <span class="suggestion-status-automatic">published on GitHub</span>
           {% else %}
             {{ log_entry.action }}
           {% endif %}
@@ -111,6 +113,8 @@
             <i class="icon-bin"></i>
           {% elif "pending" in log_entry.status_value %}
             <i class="icon-inbox"></i>
+          {% elif "published" in log_entry.status_value %}
+            <i class="icon-github"></i>
           {% else %}
             {{ log_entry.action }}
           {% endif %}


### PR DESCRIPTION
Following #694, this fixes rendering publication correctly in the activity log. Since suggestions were no longer seen after publication, this was never actually implemented. Now that we remind of the suggestion within the issue view, this becomes relevant.

## Before

<img width="1833" height="347" alt="2025-12-22 18-34-44" src="https://github.com/user-attachments/assets/38f76266-2c20-4a53-b415-ce3375ada8b0" />

## After

<img width="1833" height="347" alt="2025-12-22 18-35-08" src="https://github.com/user-attachments/assets/962cbd4b-0d0b-4219-a038-3687beefa1e1" />
