### PR TITLE
fix: Use correct security labels on issues created by the production instance

### DIFF
--- a/infra/production.nix
+++ b/infra/production.nix
@@ -94,7 +94,7 @@ in
       GH_ISSUES_REPO = "nixpkgs";
       GH_SECURITY_TEAM = "security";
       GH_COMMITTERS_TEAM = "nixpkgs-committers";
-      GH_ISSUES_LABELS = [ "1.severity:security" ];
+      GH_ISSUES_LABELS = [ "1.severity: security" ];
       GH_ISSUES_COMMITTERS_ONLY = true;
     };
 


### PR DESCRIPTION
A space is missing.

You can see the wrong label on this issue: https://github.com/NixOS/nixpkgs/issues/475110