### PR TITLE
fix: escaping of JSON in environment variable

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -31,6 +31,7 @@ let
         GH_ISSUES_REPO = "dummy";
         GH_COMMITTERS_TEAM = "dummy-committers";
         GH_SECURITY_TEAM = "dummy-security";
+        GH_ISSUES_LABELS = [ "label with spaces" ];
       };
       secrets =
         let

--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -79,9 +79,9 @@ let
       --property "Group=web-security-tracker" \
       --property "WorkingDirectory=/var/lib/web-security-tracker" \
       ${concatStringsSep "\n" (map (cred: "--property 'LoadCredential=${cred}' \\") credentials)}
-      --property "Environment=${
+      --property 'Environment=${
         toString (lib.mapAttrsToList (name: value: "${name}=${value}") environment)
-      }" \
+      }' \
       "${wstManageScript}/bin/wst-manage" "$@"
   '';
 in


### PR DESCRIPTION
Without it, the GitHub issue label with a space in it caused management commands to fail.