### PR TITLE
fix: error rendering GitHub issue

### DIFF
--- a/src/shared/github.py
+++ b/src/shared/github.py
@@ -96,7 +96,7 @@ def create_gh_issue(
 
         for attribute_name, pkg in cached_suggestion.payload["packages"].items():
             versions = []
-            for major_channel, version_data in pkg["versions"]:
+            for major_channel, version_data in pkg["channels"].items():
                 if version_data["major_version"]:
                     versions.append(f"{version_data['major_version']}@{major_channel}")
 

--- a/src/webview/tests/test_issues.py
+++ b/src/webview/tests/test_issues.py
@@ -46,6 +46,7 @@ def test_publish_gh_issue_empty_title(
                 "suggestion_id": suggestion.pk,
                 "new_status": "published",
                 "comment": "",  # Empty comment
+                "attribute": suggestion.cached.payload["packages"].keys(),
             },
         )
         mock.assert_called()
@@ -87,6 +88,7 @@ def test_publish_gh_issue_empty_description(
                 "suggestion_id": suggestion.pk,
                 "new_status": "published",
                 "comment": "",  # Empty comment
+                "attribute": suggestion.cached.payload["packages"].keys(),
             },
         )
         mock.assert_called()


### PR DESCRIPTION
The problem was that the way the test was written, the broken code didn't get exercised.
One needs to keep the packages to retain "checked", i.e. contained in the POST request.

The error itself was introduced during refactoring of suggestion caching.