### PR TITLE
feat: Set a default server block for nginx

### DIFF
--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -182,6 +182,11 @@ in
 
       nginx.enable = true;
       nginx.virtualHosts = {
+        "_" = {
+          default = true;
+          rejectSSL = true;
+          locations."/".return = 200;
+        };
         ${cfg.domain} = {
           locations = {
             "/".proxyPass = "http://localhost:${toString cfg.wsgi-port}";


### PR DESCRIPTION
This prevents connections from making it to the Django application without a proper host header.

You can test this on staging where it's already applied by running:
```
curl -k -v https://188.245.41.195
*   Trying 188.245.41.195:443...
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* SSL Trust: peer verification disabled
* TLSv1.3 (IN), TLS alert, unrecognized name (624):
* TLS connect error: error:0A000458:SSL routines::tlsv1 unrecognized name
* closing connection #0
curl: (35) TLS connect error: error:0A000458:SSL routines::tlsv1 unrecognized name
```

Same thing on production succeeds and you get a reply from the Django application:
```
curl -k https://91.99.31.214

<!doctype html>
<html lang="en">
<head>
  <title>Bad Request (400)</title>
</head>
<body>
  <h1>Bad Request (400)</h1><p></p>
</body>
</html>
```