### PR TITLE
feat: also match derivations against affected products

### DIFF
--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -1,4 +1,4 @@
-from enum import STRICT, IntFlag, auto
+from enum import STRICT, IntFlag
 from typing import Any
 
 import pghistory
@@ -181,6 +181,7 @@ def track_maintainers_edit_delete(
 
 class ProvenanceFlags(IntFlag, boundary=STRICT):
     PACKAGE_NAME_MATCH = 1
+    PRODUCT_MATCH = 7
     VERSION_CONSTRAINT_INRANGE = 2
     VERSION_CONSTRAINT_OUTOFRANGE = 3
     NO_SOURCE_VERSION_CONSTRAINT = 4

--- a/src/shared/tests/fixtures.py
+++ b/src/shared/tests/fixtures.py
@@ -38,7 +38,8 @@ def make_container(db: None) -> Callable[..., Container]:
         title: str = "Dummy Title",
         description: str = "Test description",
         affected_version: str = "1.0",
-        package_name: str = "foo",
+        package_name: str | None = "foo",
+        product: str | None = "bar",
     ) -> Container:
         org = Organization.objects.create(uuid=1, short_name="test-org")
         cve = CveRecord.objects.create(
@@ -50,7 +51,10 @@ def make_container(db: None) -> Callable[..., Container]:
         version = Version.objects.create(
             status=Version.Status.AFFECTED, version=affected_version
         )
-        affected = AffectedProduct.objects.create(package_name=package_name)
+        affected = AffectedProduct.objects.create(
+            package_name=package_name,
+            product=product,
+        )
         affected.versions.add(version)
 
         container = cve.container.create(provider=org, title=title)


### PR DESCRIPTION
This should greatly increase the number of suggestions

Some of the next obvious things to take from here are
- https://github.com/NixOS/nix-security-tracker/issues/302
- https://github.com/NixOS/nix-security-tracker/issues/190
- https://github.com/NixOS/nix-security-tracker/issues/391

But to make full use of the improvements we also should
- https://github.com/NixOS/nix-security-tracker/issues/722