### PR TITLE
fix: Typo on an f-string in tests

### DIFF
--- a/src/shared/tests/fixtures.py
+++ b/src/shared/tests/fixtures.py
@@ -160,7 +160,7 @@ def make_drv(
 
         return NixDerivation.objects.create(
             attribute=attribute,
-            derivation_path="/nix/store/<hash>-{pname}-{version}.drv",
+            derivation_path=f"/nix/store/<hash>-{pname}-{version}.drv",
             name=f"{pname}-{version}",
             metadata=meta,
             system=system,


### PR DESCRIPTION
I believe the intention here was for this to be a f-string. Practically I don't think this changes much, since I don't see `derivation_path` being used elsewhere in tests, but let's fix it eitherway.