### PR TITLE
fix: handling of empty parsed CVSS fields

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -59,6 +59,7 @@ in
       django-pgtrigger
       pytest
       pytest-django
+      cvss
     ];
 
     postInstall = ''

--- a/src/shared/github.py
+++ b/src/shared/github.py
@@ -55,22 +55,15 @@ def create_gh_issue(
             return f"`@{maintainer}`"
 
     def cvss_details() -> str:
-        severity = severity_badge(cached_suggestion.payload["metrics"])
-        if severity:
-            metric = severity["metric"]
+        metric = severity_badge(cached_suggestion.payload["metrics"])
+        if metric:
+            metrics = "\n".join([f"- {k}: {v}" for k, v in metric["metrics"].items()])
             return f"""
 <details>
 <summary>CVSS {metric["vectorString"]}</summary>
 
 - CVSS version: {metric["version"]}
-- Attack vector (AV): {metric["attackVector"]}
-- Attack complexity (AC): {metric["attackComplexity"]}
-- Privileges required (PR): {metric["privilegesRequired"]}
-- User interaction (UI): {metric["userInteraction"]}
-- Scope (S): {metric["scope"]}
-- Confidentiality impact (C): {metric["confidentialityImpact"]}
-- Integrity impact (I): {metric["integrityImpact"]}
-- Availability impact (A): {metric["availabilityImpact"]}
+{metrics}
 </details>"""
         else:
             return ""


### PR DESCRIPTION
Closes https://github.com/NixOS/nix-security-tracker/issues/734

The logic to render severity metrics was flawed:
It assumed that if there's a `raw_cvss_json` field, it would also have parsed values.
This isn't true for 1/3 of the records though.

As a quick fix, we now parse the `vectorString` field and display human-readable labels with a library.
Note that this doesn't check CVSS versions and omits modified metrics.