### PR TITLE
fix: deployment actions

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
       - run: |
-          nix-shell default.nix -A ci --run "npins update"
+          nix-build -A ci
+          result/bin/npins update
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: generate-token
         with:

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -31,4 +31,6 @@ jobs:
       - name: Deploy to ${{ matrix.environment }}
         # Only deploy production when on production branch
         if: github.ref_name == matrix.branch
-        run: nix-shell default.nix -A ci --run "deploy switch ${{ matrix.host }}"
+        run: |
+          nix-build -A ci
+          result/bin/deploy switch ${{ matrix.host }}

--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ rec {
     '';
   };
 
-  # shell environment for continuous integration runs
+  # commands for CI actions
   ci =
     let
       deploy = pkgs.writeShellApplication {
@@ -40,15 +40,17 @@ rec {
         runtimeInputs = with pkgs; [
           nixos-rebuild
           coreutils
+          nix
         ];
         # TODO: satisfy shellcheck
         checkPhase = "";
       };
     in
-    pkgs.mkShellNoCC {
-      packages = [
-        pkgs.npins
+    pkgs.symlinkJoin {
+      name = "ci";
+      paths = [
         deploy
+        pkgs.npins
       ];
     };
 


### PR DESCRIPTION
Closes: https://github.com/NixOS/nix-security-tracker/issues/737

The problem was that Nix > 2.28 generates a long-ish `$TMPDIR` prefix for
each `nix-shell` instance. This resulted in `ControlPath too long`
due to the additional prefix created by `nixos-rebuild`.

We now avoid `nix-shell` by building and running the commands directly.