### PR TITLE
chore: Block /admin/ endpoint in Nginx

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -60,39 +60,46 @@ in
 lib.mapAttrs (name: test: pkgs.testers.runNixOSTest (test // { inherit name defaults; })) {
   basic = {
     nodes.server = _: { imports = [ ./web-security-tracker.nix ]; };
-    testScript = ''
-      server.wait_for_unit("${application}-server.service")
-      server.wait_for_unit("${application}-worker.service")
+    testScript =
+      { nodes, ... }:
+      ''
+        server.wait_for_unit("${application}-server.service")
+        server.wait_for_unit("${application}-worker.service")
 
-      with subtest("Application tests"):
-        ${
-          ""
-          /*
-            XXX(@fricklerhandwerk): `pytest` searches in the working directory.
-            In this environment it can't discover what's needed on its own.
-            It's easiest to list the modules under test explicitly, which are found through `$PYTHONPATH`.
-          */
-        }server.succeed("wst-manage test -- --pyargs shared")
-        ${
-          ""
-          /*
-            XXX(@fricklerhandwerk): We must test modules in separate invocations.
-            Importing fixtures from one module in another doesn't work in one invocation of `pytest`.
-            This is because `conftest.py` files are discovered from the provided module names and registered globally.
-          */
-        }server.succeed("wst-manage test -- --pyargs webview")
+        with subtest("Application tests"):
+          ${
+            ""
+            /*
+              XXX(@fricklerhandwerk): `pytest` searches in the working directory.
+              In this environment it can't discover what's needed on its own.
+              It's easiest to list the modules under test explicitly, which are found through `$PYTHONPATH`.
+            */
+          }server.succeed("wst-manage test -- --pyargs shared")
+          ${
+            ""
+            /*
+              XXX(@fricklerhandwerk): We must test modules in separate invocations.
+              Importing fixtures from one module in another doesn't work in one invocation of `pytest`.
+              This is because `conftest.py` files are discovered from the provided module names and registered globally.
+            */
+          }server.succeed("wst-manage test -- --pyargs webview")
 
-      with subtest("Check that stylesheet is served"):
-        machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/reset.css")
-        machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/font.css")
-        machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/colors.css")
-        machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/utility.css")
-        machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/cvss-tags.css")
-        machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/page-layout.css")
-        machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/icons/style.css")
+        with subtest("Check that stylesheet is served"):
+          machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/reset.css")
+          machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/font.css")
+          machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/colors.css")
+          machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/utility.css")
+          machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/cvss-tags.css")
+          machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/page-layout.css")
+          machine.succeed("curl --fail -H 'Host: example.org' http://localhost/static/icons/style.css")
 
-      with subtest("Check that admin interface is served"):
-        server.succeed("curl --fail -L -H 'Host: example.org' http://localhost/admin")
-    '';
+        with subtest("Check that admin interface is served in the app"):
+          server.succeed("curl --fail -L -H 'Host: example.org' http://localhost:${
+            toString nodes.server.config.services.${application}.wsgi-port
+          }/admin")
+
+        with subtest("Check that admin interface is blocked on nginx"):
+          server.succeed("test $(curl -L -o /dev/null -w '%{http_code}' -H 'Host: example.org' http://localhost/admin) -eq 403")
+      '';
   };
 }

--- a/nix/web-security-tracker.nix
+++ b/nix/web-security-tracker.nix
@@ -194,6 +194,7 @@ in
           locations = {
             "/".proxyPass = "http://localhost:${toString cfg.wsgi-port}";
             "/static/".alias = cfg.settings.STATIC_ROOT;
+            "/admin/".return = 403;
           };
         }
         // lib.optionalAttrs cfg.production {


### PR DESCRIPTION
We don't use the admin dashboard in production, so it's better to not expose it at all in proper deployments. You can still use it on development if needed.