### PR TITLE
fix: mixed up clone URL and repository path

### DIFF
--- a/src/shared/git.py
+++ b/src/shared/git.py
@@ -147,7 +147,7 @@ class GitRepo:
             while locking_problem:
                 # We need to acquire a shallow lock here.
                 # TODO: replace me by an async variant.
-                while os.path.exists(os.path.join(repo_clone_url, "shallow.lock")):
+                while os.path.exists(os.path.join(self.repo_path, "shallow.lock")):
                     await asyncio.sleep(1)
                 process = await self.execute_git_command(
                     f"git fetch --porcelain --depth=1 {repo_clone_url} {object_sha1}",


### PR DESCRIPTION
This bug did not surface because we were passing strings until the respective [settings got explicit types].

[settings got explicit types]: aafe5cfd436692eb30fc3df9579e67bb0e7ac984