### PR TITLE
feat: regenerate most recent suggestions' cached values first

### DIFF
--- a/src/shared/management/commands/regenerate_cached_suggestions.py
+++ b/src/shared/management/commands/regenerate_cached_suggestions.py
@@ -18,5 +18,9 @@ class Command(BaseCommand):
         deleted, _ = CachedSuggestions.objects.all().delete()
         print(f"Cleared {deleted} cached suggestions")
 
-        for suggestion in CVEDerivationClusterProposal.objects.all().iterator():
+        for suggestion in (
+            CVEDerivationClusterProposal.objects.all()
+            .order_by("-updated_at")
+            .iterator()
+        ):
             cache_new_suggestions(suggestion)


### PR DESCRIPTION
This is a hack to allow quicker turnaround when the schema for the cache changes.
We expect users to typically look at the most recent ones.
So even if the rest takes longer, the list views will already return something useful.