### PR TITLE
fix: reject anything but POST requests on edit views

### DIFF
--- a/src/webview/suggestions/views/base.py
+++ b/src/webview/suggestions/views/base.py
@@ -103,6 +103,8 @@ class SuggestionBaseView(TemplateView, ABC):
 class SuggestionContentEditBaseView(SuggestionBaseView, ABC):
     """Base view for package and maintainers operations."""
 
+    http_method_names = ["post"]
+
     template_name = "suggestions/components/suggestion.html"
 
     class ForbiddenOperationError(Exception):

--- a/src/webview/suggestions/views/status.py
+++ b/src/webview/suggestions/views/status.py
@@ -24,6 +24,8 @@ from .base import (
 class UpdateSuggestionStatusView(SuggestionBaseView):
     """Handle suggestion status changes (accept/reject/publish)."""
 
+    http_method_names = ["post"]
+
     template_name = "suggestions/components/suggestion.html"
 
     def post(self, request: HttpRequest, suggestion_id: int) -> HttpResponse:


### PR DESCRIPTION
This is a band-aid to address a [review comment](https://github.com/NixOS/nix-security-tracker/pull/714/changes#r2745620014) we chose to ignore in order to deploy a feature and unblock further development.
Curious observers were poking the endpoints and produced 500s.