### PR TITLE
feat: add link to all published security issues on GitHub

### DIFF
--- a/src/webview/templates/components/issue.html
+++ b/src/webview/templates/components/issue.html
@@ -3,23 +3,17 @@
 <article class="rounded-box column gap" id="issue-{{ issue.code }}">
 
   <div class="row gap spread">
-    <div class="uppercase bold">{{ issue.code }}</div>
-    <div>published on {{ issue.created }}</div>
+    <div class="uppercase bold">
+      {{ issue.code }}
+    </div>
+    <div>
+      {% if github_issue %}
+        <a href="{{ github_issue }}" target="_blank" class="permalink">GitHub issue</a>
+      {% endif %}
+      published on {{ issue.created }}
+    </div>
   </div>
 
   {% suggestion suggestion_context %}
-
-  <div class="row gap spread">
-    {% if show_permalink %}
-      <a href="/issues/{{ issue.code }}" class="permalink">Permalink</a>
-    {% else %}
-      <div></div>
-    {% endif %}
-    {% if github_issue %}
-      <a href="{{ github_issue }}" target="_blank" class="permalink">GitHub issue</a>
-    {% else %}
-      <div></div>
-    {% endif %}
-  </div>
 
 </article>

--- a/src/webview/templates/issue_list.html
+++ b/src/webview/templates/issue_list.html
@@ -5,6 +5,12 @@
 
 <h1 class="page-title row gap-small centered">{% status_icon "published" %}Published issues</h1>
 
+<div class="prose">
+  <p>
+    All published security issues are <a href="https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%221.severity%3A%20security%22" target="_blank">tracked and resolved on GitHub</a>.
+  </p>
+</div>
+
 <div class="column gap">
     {% for object in object_list %}
       {% issue object object.suggestion_context github_issue=object.github_issue show_permalink=True %}

--- a/src/webview/views.py
+++ b/src/webview/views.py
@@ -64,6 +64,7 @@ class NixpkgsIssueView(DetailView):
 
         # Fetch suggestion_context
         context["suggestion_context"] = get_suggestion_context(issue.suggestion)
+        context["suggestion_context"].show_status = False
         github_issue_opened = NixpkgsEvent.objects.filter(
             issue=issue,
             event_type=EventType.ISSUE | EventType.OPENED,
@@ -107,6 +108,8 @@ class NixpkgsIssueListView(ListView):
             # FIXME(@fricklerhandwerk): We're assigning an object field that doesn't exist.
             # The horrible thing is that it still works, because somewhere in the template processing it does the equivalent of `object.__dict__` and there the key shows up again.
             issue.suggestion_context = get_suggestion_context(issue.suggestion)
+
+            issue.suggestion_context.show_status = False
             github_issue_opened = issue.events.first()
             issue.github_issue = (
                 github_issue_opened.url if github_issue_opened else None


### PR DESCRIPTION
Also save some space by removing redundant information on published issues.

<img width="1208" height="273" alt="image" src="https://github.com/user-attachments/assets/0899dbbc-7f53-44d8-811c-ca93207d7f79" />
