### PR TITLE
feat: url endpoint to redirect to suggestion detail by cve id

### DIFF
--- a/src/webview/suggestions/urls.py
+++ b/src/webview/suggestions/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views.detail import SuggestionDetailView
+from .views.detail import SuggestionDetailByCveView, SuggestionDetailView
 from .views.lists import (
     AcceptedSuggestionsView,
     PublishedSuggestionsView,
@@ -21,6 +21,11 @@ app_name = "suggestion"
 urlpatterns = [
     # Individual suggestion detail page
     path("by-id/<int:suggestion_id>/", SuggestionDetailView.as_view(), name="detail"),
+    path(
+        "by-cve/<str:cve_id>/",
+        SuggestionDetailByCveView.as_view(),
+        name="detail_by_cve",
+    ),
     # Lists
     path(
         "untriaged/",

--- a/src/webview/suggestions/views/detail.py
+++ b/src/webview/suggestions/views/detail.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.views.generic import DetailView
+from django.views.generic import DetailView, View
 
 from shared.models.issue import NixpkgsIssue
 from shared.models.linkage import (
@@ -33,3 +33,15 @@ class SuggestionDetailView(DetailView, SuggestionBaseView):
                 reverse("webview:issue_detail", kwargs={"code": issue.code})
             )
         return super().get(request, suggestion_id)
+
+
+class SuggestionDetailByCveView(View):
+    """Redirect to suggestion detail by CVE ID."""
+
+    def get(self, request: HttpRequest, cve_id: str) -> HttpResponse:
+        suggestion = get_object_or_404(CVEDerivationClusterProposal, cve__cve_id=cve_id)
+        return redirect(
+            reverse(
+                "webview:suggestion:detail", kwargs={"suggestion_id": suggestion.pk}
+            )
+        )


### PR DESCRIPTION
Fix #177 

This is a very basic approach using redirection. We could also implement it as a regular view but I thought it made sense to have only one permalink of reference (suggestion id) per suggestion that people would copy paste from their address bar.