### PR TITLE
perf: use zram for tmpfs

### DIFF
--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -1,7 +1,6 @@
 {
   config,
   pkgs,
-  lib,
   ...
 }:
 let
@@ -25,30 +24,22 @@ in
   };
   swapDevices = [ { device = "/dev/disk/by-label/swap"; } ];
 
-  # Given 16G RAM, this should be enough at the time of writing:
-  # - Postgres needs ~1.5G RAM
-  # - The application server needs <1G RAM
+  # Given 16G RAM, this should be barely enough at the time of writing:
+  # - Postgres needs ~1.5G RAM idle
+  # - The application server needs <1G RAM idle
   # - An evaluation of Nixpkgs peaks at 6-7G of RAM.
   # - We run at most one instance of `nix-eval-jobs` concurrently.
   #   See `config.services.web-security-tracker.maxJobProcessors` to make sure.
-  # - We observe ~2M store paths in an active evaluation, taking ~5GB
+  # - We observe ~2M store paths in an active evaluation, taking ~6GB
+  # - Nixpkgs checkout in /tmp needs ~500MB
   # Adjust parameters (or get a bigger machine) if it doesn't work out.
-  systemd.mounts = [
-    {
-      what = "tmpfs";
-      where = "/tmp";
-      type = "tmpfs";
-      mountConfig.Options = lib.concatStringsSep "," [
-        "mode=1777"
-        "strictatime"
-        "rw"
-        "nosuid"
-        "nodev"
-        "size=37%"
-        "nr_inodes=4m"
-      ];
-    }
-  ];
+  boot.tmp = {
+    useZram = true;
+    zramSettings = {
+      zram-size = "ram * 0.35";
+      options = "X-mount.mode=1777,discard,nr_inodes=4000000";
+    };
+  };
 
   systemd.network.networks."10-wan" = {
     matchConfig.MACAddress = "96:00:03:d9:7c:85";

--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -5,6 +5,7 @@
 }:
 let
   sectracker = import ../. { inherit pkgs; };
+  zram-tmp = "/dev/zram-tmp";
 in
 {
   imports = [
@@ -22,6 +23,14 @@ in
     device = "/dev/disk/by-label/boot";
     fsType = "ext4";
   };
+  fileSystems."/tmp" = {
+    device = zram-tmp; # Use stable symlink
+    fsType = "tmpfs";
+    options = [
+      "mode=1777"
+      "nr_inodes=4000000"
+    ];
+  };
   swapDevices = [ { device = "/dev/disk/by-label/swap"; } ];
 
   # Given 16G RAM, this should be barely enough at the time of writing:
@@ -33,12 +42,31 @@ in
   # - We observe ~2M store paths in an active evaluation, taking ~6GB
   # - Nixpkgs checkout in /tmp needs ~500MB
   # Adjust parameters (or get a bigger machine) if it doesn't work out.
-  boot.tmp = {
-    useZram = true;
-    zramSettings = {
-      zram-size = "ram * 0.35";
-      options = "X-mount.mode=1777,discard,nr_inodes=4000000";
+  systemd.services.zram-tmp-setup = {
+    description = "Set up zram device for /tmp";
+    wantedBy = [ "local-fs-pre.target" ];
+    before = [
+      "local-fs-pre.target"
+      "tmp.mount"
+    ];
+    unitConfig = {
+      DefaultDependencies = false;
     };
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      # Create next zram device and get its number
+      NUM="$(cat /sys/class/zram-control/hot_add)"
+      DEV=/dev/zram"$NUM"
+
+      echo zstd > /sys/block/zram"$NUM"/comp_algorithm
+      echo 7G > /sys/block/zram"$NUM"/disksize
+
+      # Create symlink for tmp.mount to find
+      ln -sf "$DEV" ${zram-tmp}
+    '';
   };
 
   systemd.network.networks."10-wan" = {

--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -274,7 +274,9 @@ async def evaluation_entrypoint(
 @pgpubsub.post_insert_listener(NixEvaluationChannel)
 def run_evaluation_job(old: NixEvaluation, new: NixEvaluation) -> None:
     evaluation = NixEvaluation.objects.select_related("channel").get(pk=new.pk)
-    average_evaluation_time = NixEvaluation.objects.aggregate(
+    average_evaluation_time = NixEvaluation.objects.filter(
+        state=NixEvaluation.EvaluationState.COMPLETED,
+    ).aggregate(
         avg_eval_time=Avg("elapsed")
     )
     if average_evaluation_time is not None:


### PR DESCRIPTION
With the pervious setup evaluations ran into both full tmpfs and OOM.
Chances are, this setup will give us more RAM to work with and more space to keep store derivatons in memory.