### PR TITLE
chore: Fix a typo when raising an error

### DIFF
--- a/src/shared/models/issue.py
+++ b/src/shared/models/issue.py
@@ -101,8 +101,7 @@ def generate_code(
             except IntegrityError:
                 continue
         raise RuntimeError(
-            "Failed to generate unique issue code for '%s'",
-            instance.suggestion.cve.cve_id,
+            f"Failed to generate unique issue code for '{instance.suggestion.cve.cve_id}'"
         )
 
 


### PR DESCRIPTION
Running pylint against the codebase highlighted this error [raising-format-tuple](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/raising-format-tuple.html). It's not major, but it would mess up the log formatting a bit.

This check isn't yet implemented in Ruff according to the [tracking issue](https://github.com/astral-sh/ruff/issues/970).