### PR TITLE
docs: update instructions to obtain a database dump

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,13 +142,13 @@ Or set up [`nix-direnv`](https://github.com/nix-community/nix-direnv) on your sy
 ### Set up a local database
 
 Currently only [PostgreSQL](https://www.postgresql.org/) is supported as a database.
-You can set up a database on NixOS like this:
+Assuming you have a local checkout of this repository at `~/src/nix-security-tracker`, in your NixOS configuration, add the following entry to `imports` and rebuild your system:
 
 ```nix
 { ... }:
 {
   imports = [
-    (import nix-security-tracker { }).dev-setup
+    (import ~/src/nix-security-tracker { }).dev-setup
   ];
 
   nix-security-tracker-dev-environment = {
@@ -172,12 +172,13 @@ hivemind
 
 ### Resetting the database
 
-In order to start over you need SSH access to the staging environment.
+In order to start over you need SSH [access to the staging environment](./infra/README.md#adding-ssh-keys).
+Tools for the following are available in the development shell.
 Delete the database and recreate it, then restore it from a dump, and (just in case the dump is behind the code) run migrations:
 
 ```bash
 dropdb nix-security-tracker
-ssh root@tracker-staging.security.nixos.org "sudo -u postgres pg_dump --create web-security-tracker | zstd" | zstdcat | sed 's|web-security-tracker|nix-security-tracker|g' | pv | psql
+ssh root@tracker-staging.security.nixos.org "sudo -u postgres pg_dump --create nix-security-tracker | zstd" | zstdcat | pv | psql
 manage migrate
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -13,8 +13,8 @@ rec {
 
   # For exports.
   overlays = [ overlay ];
-  package = pkgs.web-security-tracker;
-  module = import ./nix/web-security-tracker.nix;
+  package = pkgs.nix-security-tracker;
+  module = import ./nix/configuration.nix;
   dev-container = import ./infra/container.nix;
   dev-setup = import ./nix/dev-setup.nix;
 
@@ -97,7 +97,7 @@ rec {
         pkgs.nix-eval-jobs
         pkgs.npins
         pkgs.hivemind
-        pkgs.awscli
+        pkgs.pv
         (import sources.agenix { inherit pkgs; }).agenix
         format
       ]

--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -28,7 +28,7 @@ graph TB
 
 	  subgraph Storage["**Storage**"]
 		  PostgreSQL["**PostgreSQL**<br/>*CVE Records<br/>Channels<br/>Users<br/>Issues*"]
-		  LocalGitCheckout["**Local Git Repo**<br/>*nixpkgs clone /var/lib/web-security-tracker/nixpkgs-repo*"]
+		  LocalGitCheckout["**Local Git Repo**<br/>*nixpkgs clone /var/lib/nix-security-tracker/nixpkgs-repo*"]
 		  NixStore["**Nix store**"]
 	  end
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -28,6 +28,13 @@ If in the future we need to create more VMs and do it in a declarative way, we c
 Deployments happen automatically via GitHub Actions. Whenever a merge happens on the `main` branch, a GitHub Action runs that updates the staging deployment of the tracker (tracker-staging.security.nixos.org).
 Similarly, merges on the `production` branch get automatically applied to tracker.security.nixos.org.
 
+## Adding SSH keys
+
+To request access to the staging or production environment, open a pull request with:
+
+- Your SSH public key added to the [`keys`][./keys] directory
+- An addition to `user.users.<name>.openssh.authorizedKeys.keyFiles` in the respective environment ([staging](./staging.nix), [production](./production.nix), or [both](./common.nix)).
+
 ## Secrets
 
 Secrets are managed using [Agenix](https://github.com/ryantm/agenix).

--- a/infra/common.nix
+++ b/infra/common.nix
@@ -45,14 +45,20 @@ in
   };
 
   users.mutableUsers = false;
-  users.users.root = {
-    openssh.authorizedKeys.keyFiles =
-      with lib;
-      map (n: ./keys/${n}) (attrNames (builtins.readDir ./keys));
-    # We're using both keys and keyFiles here in order to keep some alignment
-    # with github:nixos/infra
-    openssh.authorizedKeys.keys = (import "${sources.infra}/ssh-keys.nix").infra;
-  };
+  users.users.root =
+    let
+      keys = with lib; mapAttrs (n: _: ./keys/${n}) (builtins.readDir ./keys);
+    in
+    {
+      openssh.authorizedKeys.keyFiles = with keys; [
+        fricklerhandwerk
+        erethon
+        security-tracker-gh-actions
+      ];
+      # We're using both keys and keyFiles here in order to keep some alignment
+      # with github:nixos/infra
+      openssh.authorizedKeys.keys = (import "${sources.infra}/ssh-keys.nix").infra;
+    };
 
   environment.systemPackages = with pkgs; [
     curl
@@ -142,7 +148,7 @@ in
           values = [ "count" ];
         };
       };
-      connections = [ "postgres://postgres@/web-security-tracker?host=/run/postgresql" ];
+      connections = [ "postgres://postgres@/nix-security-tracker?host=/run/postgresql" ];
       interval = "1h";
     };
   };

--- a/infra/container.nix
+++ b/infra/container.nix
@@ -18,11 +18,11 @@ in
 
     The container can be managed at runtime with [`nixos-container`](https://nixos.org/manual/nixos/unstable/#sec-imperative-containers).
   */
-  users.users.web-security-tracker = {
+  users.users.nix-security-tracker = {
     isSystemUser = true;
-    group = "web-security-tracker";
+    group = "nix-security-tracker";
   };
-  users.groups.web-security-tracker = { };
+  users.groups.nix-security-tracker = { };
   systemd.services."container@nix-security-tracker" = {
     serviceConfig = {
       TimeoutStartSec = lib.mkForce "15m";
@@ -56,7 +56,7 @@ in
         # which almost certainly won't be the same as the user under which the service runs
         boot.postBootCommands = ''
           cp -r ${secretsGuestPath}/* ${secretsPath}
-          chown web-security-tracker ${secretsPath}
+          chown nix-security-tracker ${secretsPath}
         '';
         networking.firewall.allowedTCPPorts = map (forward: forward.containerPort) (
           lib.filter (forward: forward.protocol == "tcp") cfg.forwardPorts
@@ -67,7 +67,7 @@ in
         imports = [
           sectracker.module
         ];
-        services.web-security-tracker = {
+        services.nix-security-tracker = {
           enable = true;
           domain = "sectracker.local";
           production = false;

--- a/infra/production.nix
+++ b/infra/production.nix
@@ -9,7 +9,7 @@ in
 {
   imports = [
     sectracker.module
-    ./configuration.nix
+    ./common.nix
   ];
   networking.hostName = "sectracker";
 
@@ -83,7 +83,7 @@ in
     80
     443
   ];
-  services.web-security-tracker = {
+  services.nix-security-tracker = {
     enable = true;
     production = true;
     domain = "tracker.security.nixos.org";

--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -9,7 +9,7 @@ in
 {
   imports = [
     sectracker.module
-    ./configuration.nix
+    ./common.nix
   ];
 
   networking.hostName = "sectracker-staging";
@@ -85,7 +85,7 @@ in
     80
     443
   ];
-  services.web-security-tracker = {
+  services.nix-security-tracker = {
     enable = true;
     production = true;
     domain = "tracker-staging.security.nixos.org";

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -44,7 +44,7 @@
 
       pyright =
         let
-          pyEnv = pkgs.python3.withPackages (_: pkgs.web-security-tracker.propagatedBuildInputs);
+          pyEnv = pkgs.python3.withPackages (_: pkgs.nix-security-tracker.propagatedBuildInputs);
           wrappedPyright = pkgs.runCommand "pyright" { nativeBuildInputs = [ pkgs.makeWrapper ]; } ''
             makeWrapper ${pkgs.pyright}/bin/pyright $out \
               --set PYTHONPATH ${pyEnv}/${pyEnv.sitePackages} \

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -24,7 +24,7 @@ in
     isFlakes = false;
   };
 
-  web-security-tracker = final.python3.pkgs.buildPythonPackage rec {
+  nix-security-tracker = final.python3.pkgs.buildPythonPackage rec {
     pname = meta.project.name;
     inherit (meta.project) version;
     pyproject = true;

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -5,7 +5,7 @@
 }:
 let
   # TODO: specify project/service name globally
-  application = "web-security-tracker";
+  application = "nix-security-tracker";
   defaults = {
     documentation.enable = lib.mkDefault false;
 

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "web-security-tracker"
+name = "nix-security-tracker"
 version = "0.0.1"
 
 [tool.setuptools]


### PR DESCRIPTION
Align database names between remote and local databases.
Add `pv` to development shell so one doesn't have to wrap everything in an extra shell for the occasion.
Add instructions for getting SSH access to staging and production, make access explicit.

> [!WARNING]
>   This requires downtime and manual steps for deployment!
>   - Move the state directory with the Nixpkgs checkout
>   - Rename the database

Closes https://github.com/NixOS/nix-security-tracker/issues/242
