### PR TITLE
fix: remaining URL patterns breaking on package name containing `/`

### DIFF
--- a/src/webview/suggestions/urls.py
+++ b/src/webview/suggestions/urls.py
@@ -57,33 +57,33 @@ urlpatterns = [
     ),
     # Package operations
     path(
-        "by-id/<int:suggestion_id>/packages/<str:package_attr>/ignore/",
+        "by-id/<int:suggestion_id>/package/ignore/<path:package_attr>/",
         IgnorePackageView.as_view(),
         name="ignore_package",
     ),
     path(
-        "by-id/<int:suggestion_id>/packages/<str:package_attr>/restore/",
+        "by-id/<int:suggestion_id>/package/restore/<path:package_attr>/",
         RestorePackageView.as_view(),
         name="restore_package",
     ),
     # Maintainers operations
     path(
-        "by-id/<int:suggestion_id>/maintainers/<int:github_id>/ignore/",
+        "by-id/<int:suggestion_id>/maintainer/ignore/<int:github_id>/",
         IgnoreMaintainerView.as_view(),
         name="ignore_maintainer",
     ),
     path(
-        "by-id/<int:suggestion_id>/maintainers/<int:github_id>/delete/",
+        "by-id/<int:suggestion_id>/maintainer/delete/<int:github_id>/",
         DeleteMaintainerView.as_view(),
         name="delete_maintainer",
     ),
     path(
-        "by-id/<int:suggestion_id>/maintainers/<int:github_id>/restore/",
+        "by-id/<int:suggestion_id>/maintainer/restore/<int:github_id>/",
         RestoreMaintainerView.as_view(),
         name="restore_maintainer",
     ),
     path(
-        "by-id/<int:suggestion_id>/maintainers/add/",
+        "by-id/<int:suggestion_id>/maintainer/add/",
         AddMaintainerView.as_view(),
         name="add_maintainer",
     ),

--- a/src/webview/tests/test_search.py
+++ b/src/webview/tests/test_search.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 
 from django.urls import reverse
 from playwright.sync_api import Page, expect
@@ -105,7 +105,7 @@ def test_status_filters(
     """Test only the suggestions of the targeted status are shown on by-status pages"""
 
     # Such package names exist, and we quote them the same way when linking in the templates.
-    drv = make_drv(pname=quote("nodePackages.@something/foo", safe=""))
+    drv = make_drv(pname="nodePackages.@something/foo")
     # Create suggestions, one in each status, all with the same package
     status_suggestion_map = {}
     for i, status in enumerate(CVEDerivationClusterProposal.Status, 1):


### PR DESCRIPTION
Due to a reasoning error the test was deceptive and not actually triggering the bug.

This change aligns the maintainer operation endpoints to follow the same new pattern, primarily for cosmetics.