### PR TITLE
perf: don't check permissions for every button

### DIFF
--- a/src/webview/suggestions/context/builders.py
+++ b/src/webview/suggestions/context/builders.py
@@ -10,6 +10,7 @@ from webview.suggestions.context.types import (
 
 def get_package_list_context(
     suggestion: CVEDerivationClusterProposal,
+    can_edit: bool,
 ) -> PackageListContext:
     # Split packages into active and ignored
     all_packages = suggestion.cached.payload["original_packages"]
@@ -22,12 +23,14 @@ def get_package_list_context(
         active=active_packages,
         ignored=ignored_packages,
         editable=suggestion.is_editable,
+        can_edit=can_edit,
         suggestion_id=suggestion.pk,
     )
 
 
 def get_maintainer_list_context(
     suggestion: CVEDerivationClusterProposal,
+    can_edit: bool,
     maintainer_add_error_message: str | None = None,
 ) -> MaintainerListContext:
     # FIXME(@florent): There is a pydantic model for cached suggestions and
@@ -43,6 +46,7 @@ def get_maintainer_list_context(
         MaintainerContext(
             maintainer=maintainer,
             editable=editable,
+            can_edit=can_edit,
             status=MaintainerStatus.IGNORABLE,
             suggestion_id=suggestion.pk,
         )
@@ -53,6 +57,7 @@ def get_maintainer_list_context(
         MaintainerContext(
             maintainer=maintainer,
             editable=editable,
+            can_edit=can_edit,
             status=MaintainerStatus.RESTORABLE,
             suggestion_id=suggestion.pk,
         )
@@ -63,6 +68,7 @@ def get_maintainer_list_context(
         MaintainerContext(
             maintainer=maintainer,
             editable=editable,
+            can_edit=can_edit,
             status=MaintainerStatus.DELETABLE,
             suggestion_id=suggestion.pk,
         )
@@ -74,6 +80,7 @@ def get_maintainer_list_context(
         ignored=ignored_contexts,
         additional=additional_contexts,
         editable=editable,
+        can_edit=can_edit,
         suggestion_id=suggestion.pk,
         maintainer_add_context=MaintainerAddContext(
             suggestion.pk, maintainer_add_error_message

--- a/src/webview/suggestions/context/types.py
+++ b/src/webview/suggestions/context/types.py
@@ -15,6 +15,8 @@ class PackageListContext:
     active: dict
     ignored: dict
     editable: bool
+    # FIXME(@fricklerhandwerk): Arguably the same thing as `editable` if both views and template handle it right.
+    can_edit: bool
     suggestion_id: int
     # FIXME(@florentc): Add a state for whether to pre-open the "ignored
     # packages" list, in case it was already opened before component update
@@ -41,6 +43,8 @@ class MaintainerStatus(Enum):
 class MaintainerContext:
     maintainer: Maintainer
     editable: bool
+    # FIXME(@fricklerhandwerk): Arguably the same thing as `editable` if both views and template handle it right.
+    can_edit: bool
     status: MaintainerStatus
     suggestion_id: int
 
@@ -57,6 +61,8 @@ class MaintainerListContext:
     ignored: list[MaintainerContext]
     additional: list[MaintainerContext]
     editable: bool
+    # FIXME(@fricklerhandwerk): Arguably the same thing as `editable` if both views and template handle it right.
+    can_edit: bool
     suggestion_id: int
     maintainer_add_context: MaintainerAddContext
 
@@ -69,6 +75,7 @@ class SuggestionContext:
     suggestion: CVEDerivationClusterProposal
     package_list_context: PackageListContext
     maintainer_list_context: MaintainerListContext
+    can_edit: bool
     activity_log: list[FoldedEventType]
     show_status: bool = True
     suggestion_stub_context: SuggestionStubContext | None = None

--- a/src/webview/suggestions/views/base.py
+++ b/src/webview/suggestions/views/base.py
@@ -32,11 +32,15 @@ def fetch_activity_log(suggestion_id: int) -> list[FoldedEventType]:
 
 def get_suggestion_context(
     suggestion: CVEDerivationClusterProposal,
+    can_edit: bool,
 ) -> SuggestionContext:
     return SuggestionContext(
         suggestion=suggestion,
-        package_list_context=get_package_list_context(suggestion),
-        maintainer_list_context=get_maintainer_list_context(suggestion),
+        can_edit=can_edit,
+        package_list_context=get_package_list_context(suggestion, can_edit=can_edit),
+        maintainer_list_context=get_maintainer_list_context(
+            suggestion, can_edit=can_edit
+        ),
         activity_log=fetch_activity_log(suggestion.pk),
     )
 
@@ -124,7 +128,8 @@ class SuggestionContentEditBaseView(SuggestionBaseView, ABC):
 
         # Get suggestion context
         suggestion = fetch_suggestion(suggestion_id)
-        suggestion_context = get_suggestion_context(suggestion)
+        can_edit = can_publish_github_issue(self.request.user)
+        suggestion_context = get_suggestion_context(suggestion, can_edit=can_edit)
 
         # Validate that the suggestion status allows package editing
         if not suggestion.is_editable:

--- a/src/webview/suggestions/views/maintainers.py
+++ b/src/webview/suggestions/views/maintainers.py
@@ -49,7 +49,8 @@ class MaintainerOperationBaseView(SuggestionContentEditBaseView, ABC):
 
         # Refresh the maintainer list context and activity_log
         suggestion_context.maintainer_list_context = get_maintainer_list_context(
-            suggestion
+            suggestion,
+            can_edit=True,  # Prior permission checks enforce this.
         )
         suggestion_context.activity_log = fetch_activity_log(suggestion.pk)
 
@@ -354,8 +355,10 @@ class AddMaintainerView(SuggestionContentEditBaseView):
             suggestion.cached.save()
 
         # Refresh the maintainer list context and activity_log
+
         suggestion_context.maintainer_list_context = get_maintainer_list_context(
-            suggestion
+            suggestion,
+            can_edit=True,  # Prior permission checks enforce this.
         )
         suggestion_context.activity_log = fetch_activity_log(suggestion.pk)
 

--- a/src/webview/suggestions/views/packages.py
+++ b/src/webview/suggestions/views/packages.py
@@ -66,9 +66,13 @@ class PackageOperationBaseView(SuggestionContentEditBaseView, ABC):
             )
 
         # Refresh the package list context and activity log
-        suggestion_context.package_list_context = get_package_list_context(suggestion)
+        suggestion_context.package_list_context = get_package_list_context(
+            suggestion,
+            can_edit=True,  # Prior permission checks enforce this.
+        )
         suggestion_context.maintainer_list_context = get_maintainer_list_context(
-            suggestion
+            suggestion,
+            can_edit=True,  # Prior permission checks enforce this.
         )
         suggestion_context.activity_log = fetch_activity_log(suggestion.pk)
 

--- a/src/webview/suggestions/views/status.py
+++ b/src/webview/suggestions/views/status.py
@@ -30,12 +30,13 @@ class UpdateSuggestionStatusView(SuggestionBaseView):
 
     def post(self, request: HttpRequest, suggestion_id: int) -> HttpResponse:
         """Handle status change requests."""
-        if not request.user or not can_publish_github_issue(request.user):
+        can_edit = can_publish_github_issue(request.user)
+        if not request.user or not can_edit:
             return HttpResponseForbidden()
 
         # Get suggestion context
         suggestion = fetch_suggestion(suggestion_id)
-        suggestion_context = get_suggestion_context(suggestion)
+        suggestion_context = get_suggestion_context(suggestion, can_edit=can_edit)
 
         # Get form data
         new_status = request.POST.get("new_status")

--- a/src/webview/templates/suggestions/components/maintainer.html
+++ b/src/webview/templates/suggestions/components/maintainer.html
@@ -1,7 +1,7 @@
 {% load viewutils %}
 
 <div class="row gap centered">
-  {% if data.editable and user|is_maintainer_or_admin %}
+  {% if data.editable and data.can_edit %}
     <form
       class="contents"
       method="post"

--- a/src/webview/templates/suggestions/components/maintainers_list.html
+++ b/src/webview/templates/suggestions/components/maintainers_list.html
@@ -52,7 +52,7 @@
 
 
       <!-- Add maintainer section (only if editable) -->
-      {% if data.editable and user|is_maintainer_or_admin %}
+      {% if data.editable and data.can_edit %}
       {% maintainer_add data.maintainer_add_context %}
       {% endif %}
     </div>

--- a/src/webview/templates/suggestions/components/package_list.html
+++ b/src/webview/templates/suggestions/components/package_list.html
@@ -8,7 +8,7 @@
     <div id="suggestion-{{data.suggestion_id}}-active-packages" class="column dividers">
       {% for attribute, pdata in data.active.items %}
       <div class="package-{{attribute}} row gap">
-          {% if user|is_maintainer_or_admin and data.editable %}
+          {% if data.can_edit and data.editable %}
             <form
               class="contents"
               method="post"
@@ -46,7 +46,7 @@
       <div class="column dividers">
         {% for attribute, pdata in data.ignored.items %}
           <div class="package-{{attribute}} row gap">
-            {% if user|is_maintainer_or_admin and data.editable %}
+            {% if data.can_edit and data.editable %}
             <form
               class="contents"
               method="post"

--- a/src/webview/templates/suggestions/components/suggestion.html
+++ b/src/webview/templates/suggestions/components/suggestion.html
@@ -74,21 +74,21 @@
       autocomplete="off"
     >
       {% csrf_token %}
-      {% if not user|is_maintainer_or_admin or data.suggestion.status == "published" %}
+      {% if not data.can_edit or data.suggestion.status == "published" %}
         {% if data.suggestion.comment %}
           <pre class="rounded-box monospace highlight-nonempty">{{ data.suggestion.comment|default:"" }}</pre>
         {% endif %}
       {% else %}
-        <textarea 
+        <textarea
           class="rounded-box monospace highlight-nonempty"
-          name="comment" 
-          maxlength="1000" 
+          name="comment"
+          maxlength="1000"
           placeholder="Free comment: context, additional info, dismissal reason, etc."
           rows="3"
         >{{ data.suggestion.comment|default:"" }}</textarea>
       {% endif %}
 
-      {% if user|is_maintainer_or_admin and data.suggestion.status != "published" %}
+      {% if data.can_edit and data.suggestion.status != "published" %}
         <div class="row-reverse spread">
           {% if data.suggestion.status == "pending" %}
             <button type="submit" name="new_status" value="accepted" class="status-change-button btn btn-green row gap-small centered">

--- a/src/webview/templatetags/viewutils.py
+++ b/src/webview/templatetags/viewutils.py
@@ -9,7 +9,6 @@ from cvss.constants3 import METRICS_ABBREVIATIONS
 from django import template
 from django.template.context import Context
 
-from shared.auth import isadmin, ismaintainer
 from shared.listeners.cache_suggestions import CachedSuggestion, parse_drv_name
 from shared.logs.batches import FoldedEventType
 from shared.models.issue import NixpkgsIssue
@@ -167,26 +166,6 @@ def iso(date: datetime.datetime) -> str:
 def versioned_package_name(package_entry: dict[str, Any]) -> str:
     _, version = parse_drv_name(package_entry["name"])
     return f"pkgs.{package_entry['attribute']} {version}"
-
-
-def is_admin(user: Any) -> bool:
-    if user is None or user.is_anonymous:
-        return False
-    else:
-        return isadmin(user)
-
-
-@register.filter
-def is_maintainer(user: Any) -> bool:
-    if user is None or user.is_anonymous:
-        return False
-    else:
-        return ismaintainer(user)
-
-
-@register.filter
-def is_maintainer_or_admin(user: Any) -> bool:
-    return is_maintainer(user) or is_admin(user)
 
 
 @register.inclusion_tag("components/issue.html", takes_context=True)

--- a/src/webview/views.py
+++ b/src/webview/views.py
@@ -63,7 +63,9 @@ class NixpkgsIssueView(DetailView):
         issue = self.get_object()
 
         # Fetch suggestion_context
-        context["suggestion_context"] = get_suggestion_context(issue.suggestion)
+        context["suggestion_context"] = get_suggestion_context(
+            issue.suggestion, can_edit=False
+        )
         context["suggestion_context"].show_status = False
         github_issue_opened = NixpkgsEvent.objects.filter(
             issue=issue,
@@ -107,7 +109,9 @@ class NixpkgsIssueListView(ListView):
         for issue in context["object_list"]:
             # FIXME(@fricklerhandwerk): We're assigning an object field that doesn't exist.
             # The horrible thing is that it still works, because somewhere in the template processing it does the equivalent of `object.__dict__` and there the key shows up again.
-            issue.suggestion_context = get_suggestion_context(issue.suggestion)
+            issue.suggestion_context = get_suggestion_context(
+                issue.suggestion, can_edit=False
+            )
 
             issue.suggestion_context.show_status = False
             github_issue_opened = issue.events.first()


### PR DESCRIPTION
This reduces the number of queries in a list view from >250 to ~30.
Total query time goes down from ~60ms to ~20ms (tested locally).

Reason for the slowdown was that the template filter would query the database on every conditionally displayed button.

The remaining overhead is from inefficient querying of the activity log.
But this need to be thought through properly.
We may not need the edit types and could possibly rely on `pghistory` exclusively.

It's really ugly how this fix is implemented, sorry.
I just wanted to get it out of the way.
We need to redesign how data is mashed up for the templates.