### PR TITLE
fix: don't create duplicate CVE containers on updates

### DIFF
--- a/src/shared/fetchers.py
+++ b/src/shared/fetchers.py
@@ -285,8 +285,9 @@ def make_cve(
     cve.save()
 
     if record is not None:
-        # TODO: Remove stale data to prevent overgrowth
-        pass
+        # FIXME(@fricklerhandwerk): This loses updates, but acutely we don't care all that much about them.
+        # Also remove stale data from past duplication.
+        return record
 
     make_container(data["containers"]["cna"], _type=models.Container.Type.CNA, cve=cve)
 


### PR DESCRIPTION
This is a hotfix because upstream decided to mass-edit old records to add microsecond precision (!) to publication dates.
While that probably has some good reason, for us it triggers matches with very old CVEs, degrading user experience.
Up to now it would also create duplicate containers, which should be cleaned up in the future.

The general issue still needs to be addressed properly by updating existing records.


Partially addresses #812