### PR TITLE
fix: deduplicate Description and Reference records on CVE ingestion

### DIFF
--- a/src/shared/fetchers.py
+++ b/src/shared/fetchers.py
@@ -44,12 +44,12 @@ def make_media(data: dict[str, str]) -> models.SupportingMedia:
 
 
 def make_description(data: dict[str, Any]) -> models.Description:
-    ctx: dict[str, Any] = dict()
-    ctx["lang"] = data["lang"]
-    ctx["value"] = data["value"]
-
-    obj = models.Description.objects.create(**ctx)
-    obj.media.set(map(make_media, data.get("supportingMedia", [])))
+    obj, created = models.Description.objects.get_or_create(
+        lang=data["lang"],
+        value=data["value"],
+    )
+    if created:
+        obj.media.set(map(make_media, data.get("supportingMedia", [])))
 
     return obj
 
@@ -61,12 +61,12 @@ def make_tag(name: str) -> models.Tag:
 
 
 def make_reference(data: dict[str, Any]) -> models.Reference:
-    ctx: dict[str, Any] = dict()
-    ctx["url"] = data["url"]
-    ctx["name"] = data.get("name", "")
-
-    obj = models.Reference.objects.create(**ctx)
-    obj.tags.set(map(make_tag, data.get("tags", [])))
+    obj, created = models.Reference.objects.get_or_create(
+        url=data["url"],
+        name=data.get("name", ""),
+    )
+    if created:
+        obj.tags.set(map(make_tag, data.get("tags", [])))
 
     return obj
 

--- a/src/shared/tests/test_fetchers.py
+++ b/src/shared/tests/test_fetchers.py
@@ -1,0 +1,26 @@
+import pytest
+
+from shared.fetchers import make_description, make_reference
+from shared.models.cve import Description, Reference
+
+
+@pytest.mark.django_db
+def test_make_description_deduplicates() -> None:
+    """Calling make_description twice with identical lang+value returns the same row."""
+    data = {"lang": "en", "value": "A test vulnerability description."}
+    first = make_description(data)
+    second = make_description(data)
+
+    assert first.pk == second.pk
+    assert Description.objects.filter(lang="en", value=data["value"]).count() == 1
+
+
+@pytest.mark.django_db
+def test_make_reference_deduplicates() -> None:
+    """Calling make_reference twice with identical url+name returns the same row."""
+    data = {"url": "https://example.com/advisory", "name": "Advisory"}
+    first = make_reference(data)
+    second = make_reference(data)
+
+    assert first.pk == second.pk
+    assert Reference.objects.filter(url=data["url"], name=data["name"]).count() == 1


### PR DESCRIPTION
Fixes #710

`make_description` and `make_reference` were calling `objects.create()` unconditionally, generating millions of duplicate rows on every ingestion run.

Switched both to `get_or_create()` keyed on the natural identity fields (`lang`+`value` and `url`+`name` respectively). M2M relations are only populated for newly created objects.

Also adds tests covering the deduplication behaviour.