### PR TITLE
fix: skip CVEs tagged with exclusively-hosted-service during ingestion

### DIFF
--- a/src/shared/listeners/automatic_linkage.py
+++ b/src/shared/listeners/automatic_linkage.py
@@ -105,6 +105,17 @@ def build_new_links(container: Container) -> bool:
         logger.info("Suggestion already exists for '%s', skipping", container.cve)
         return False
 
+    if container.tags.filter(value="exclusively-hosted-service").exists():
+        logger.info(
+            "Container for '%s' is exclusively-hosted-service, rejecting without match.",
+            container.cve,
+        )
+        CVEDerivationClusterProposal.objects.create(
+            cve=container.cve,
+            status=CVEDerivationClusterProposal.Status.REJECTED,
+        )
+        return True
+
     drvs = produce_linkage_candidates(container)
     if not drvs:
         logger.info("No derivations matching '%s', ignoring", container.cve)


### PR DESCRIPTION
Fixes #804

CVEs tagged `exclusively-hosted-service` on their CNA container arenever applicable to Nixpkgs packages. Added a module level `_EXCLUDED_CNA_TAGS` frozenset and an early return in `make_cve()` to skip ingestion of such records entirely no DB rows created.

Adds tests covering both the skip and the normal ingest paths.