### PR TITLE
feat: rejection reason field

### DIFF
--- a/src/shared/migrations/0070_cvederivationclusterproposal_rejection_reason.py
+++ b/src/shared/migrations/0070_cvederivationclusterproposal_rejection_reason.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("shared", "0069_remove_nixderivation_dependencies_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="cvederivationclusterproposal",
+            name="rejection_reason",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("exclusively_hosted_service", "exclusively hosted service"),
+                ],
+                help_text="Machine-generated reason for automatic rejection",
+                max_length=126,
+                null=True,
+            ),
+        ),
+    ]

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -28,6 +28,12 @@ class CVEDerivationClusterProposal(TimeStampMixin):
         ACCEPTED = "accepted", _("accepted")
         PUBLISHED = "published", _("published")
 
+    class RejectionReason(models.TextChoices):
+        EXCLUSIVELY_HOSTED_SERVICE = (
+            "exclusively_hosted_service",
+            _("exclusively hosted service"),
+        )
+
     cached: "shared.models.cached.CachedSuggestions"
 
     cve = models.ForeignKey(
@@ -50,6 +56,14 @@ class CVEDerivationClusterProposal(TimeStampMixin):
         help_text=_(
             "Optional free text comment for additional notes, context, dismissal reason"
         ),
+    )
+
+    rejection_reason = models.CharField(
+        max_length=126,
+        choices=RejectionReason.choices,
+        null=True,
+        blank=True,
+        help_text=_("Machine-generated reason for automatic rejection"),
     )
 
     @property


### PR DESCRIPTION
Closes #824

Adds a `RejectionReason` TextChoices field to `CVEDerivationClusterProposal`
so that machine-generated rejections carry a structured reason, equivalent
to how `ProvenanceFlags` records provenance on the derivation side.

- Adds `RejectionReason` inner class with `EXCLUSIVELY_HOSTED_SERVICE` choice
- Adds nullable `rejection_reason` field to the model
- Populates it in `build_new_links()` when rejecting hosted-service CVEs
- Updates test to assert the reason is set correctly
- Includes migration

Depends on #819.
