### PR TITLE
fix: show issue code inline with CVE metadata in published issues

### DIFF
--- a/src/webview/suggestions/context/types.py
+++ b/src/webview/suggestions/context/types.py
@@ -82,6 +82,7 @@ class SuggestionContext:
         self.can_edit: bool = can_edit
         self.suggestion: CVEDerivationClusterProposal = suggestion
         self.suggestion_stub_context: SuggestionStubContext | None = None
+        self.issue_code: str | None = None
         self.update_package_list_context(can_edit=can_edit)
         self.update_maintainer_list_context(can_edit=can_edit)
         # FIXME(@fricklerhandwerk): Constructor should take pre-fetched events in argument

--- a/src/webview/templates/components/issue.html
+++ b/src/webview/templates/components/issue.html
@@ -3,9 +3,6 @@
 <article class="rounded-box column gap" id="issue-{{ issue.code }}">
 
   <div class="row gap spread">
-    <div class="uppercase bold">
-      {{ issue.code }}
-    </div>
     <div>
       {% if github_issue %}
         <a href="{{ github_issue }}" target="_blank" class="permalink">GitHub issue</a>

--- a/src/webview/templates/suggestions/components/suggestion.html
+++ b/src/webview/templates/suggestions/components/suggestion.html
@@ -23,6 +23,9 @@
 
     <div class="row spread gap wrap">
       <div class="row gap wrap">
+        {% if data.issue_code %}
+          <span class="uppercase bold">{{ data.issue_code }}</span>
+        {% endif %}
         <a href="{% url 'webview:suggestion:detail' suggestion_id=data.suggestion.pk %}">Permalink</a>
         <a href="https://nvd.nist.gov/vuln/detail/{{ data.suggestion.cached.payload.cve_id | urlencode }}">
           {{ data.suggestion.cached.payload.cve_id }}

--- a/src/webview/templatetags/viewutils.py
+++ b/src/webview/templatetags/viewutils.py
@@ -176,6 +176,7 @@ def issue(
     github_issue: str | None,
     show_permalink: bool = False,
 ) -> dict:
+    suggestion_context.issue_code = issue.code
     return {
         "issue": issue,
         "show_permalink": show_permalink,


### PR DESCRIPTION
Closes #616

Published issues showed the internal issue code (NST-XXXX) as a prominent standalone header above the CVE description, making the layout inconsistent with draft issues (accepted suggestions) where the description appears immediately.

- Moves the issue code into the CVE metadata row in `suggestion.html` so both published and draft views look the same
- Removes the separate issue code header from `issue.html`, keeping the GitHub link and published date
- Adds optional `issue_code` field to `SuggestionContext`, populated by the `issue()` template tag