### PR TITLE
fix: preserve comment field across HTMX suggestion refreshes

### DIFF
--- a/src/webview/templates/suggestions/components/suggestion.html
+++ b/src/webview/templates/suggestions/components/suggestion.html
@@ -76,6 +76,8 @@
         {% endif %}
       {% else %}
         <textarea
+          id="comment-{{ data.suggestion.pk }}"
+          hx-preserve
           class="rounded-box monospace highlight-nonempty"
           name="comment"
           maxlength="1000"


### PR DESCRIPTION
Closes #795

Any edit operation (ignore/restore package, maintainer changes) triggers an HTMX swap of the entire suggestion component, which reset the comment textarea to its saved DB value, dropping any unsaved text.

Fix: add `hx-preserve` and a unique `id` to the comment textarea. HTMX will retain the current DOM value of the textarea across swaps instead of replacing it with the server-rendered value.