### PR TITLE
feat: show references (links) from CVE in suggestion

### DIFF
--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -17,6 +17,8 @@ from shared.models.cve import (
     Description,
     Metric,
     Organization,
+    Reference,
+    Tag,
     Version,
 )
 from shared.models.linkage import (
@@ -44,6 +46,7 @@ def make_container(db: None) -> Callable[..., Container]:
         affected_version: str = "1.0",
         package_name: str | None = "foo",
         product: str | None = "bar",
+        references: list[tuple[str, str, list[str]]] = [],
     ) -> Container:
         org, _created = Organization.objects.get_or_create(
             uuid=1, short_name="test-org"
@@ -63,6 +66,19 @@ def make_container(db: None) -> Callable[..., Container]:
         affected.versions.add(version)
 
         container = cve.container.create(provider=org, title=title)
+        refs = []
+        for text, link, tags in references:
+            tag_objs: dict[str, Tag] = {}
+            for tag in tags:
+                tag_objs[tag], _ = Tag.objects.get_or_create(value=tag)
+            refs.append(
+                Reference.objects.create(
+                    url=link,
+                    name=text,
+                    tags=tag_objs.values(),
+                )
+            )
+        container.references.set(refs)
         container.affected.add(affected)
         if description is not None:
             desc = Description.objects.create(value=description)

--- a/src/webview/static/colors.css
+++ b/src/webview/static/colors.css
@@ -12,4 +12,7 @@
   --light-green: #dbfcdb;
   --light-yellow: #fcfaba;
   --light-gray: #eee;
+
+  --foreground: black;
+  --background: white;
 }

--- a/src/webview/static/utility.css
+++ b/src/webview/static/utility.css
@@ -24,6 +24,24 @@
   margin: 1em 0;
 }
 
+.small {
+  font-size: 0.75rem;
+}
+
+.tag {
+  border: solid 2px var(--background);
+  border-radius: 0.4em;
+  padding: 0.2rem 0.4rem;
+  outline-width: 2px;
+  word-break: normal;
+  display: inline-block;
+}
+
+.fill-gray {
+  color: var(--background);
+  background-color: var(--gray);
+}
+
 /* Buttons
  *
  * .btn - Base button style to be used on every standard button

--- a/src/webview/suggestions/context/types.py
+++ b/src/webview/suggestions/context/types.py
@@ -9,6 +9,16 @@ from shared.logs.events import (
 from shared.logs.fetchers import fetch_suggestion_events
 from shared.models.linkage import CVEDerivationClusterProposal
 
+# CVEs
+
+
+@dataclass
+class Reference:
+    url: str
+    name: str
+    tags: list[str]
+
+
 # Packages
 
 
@@ -85,6 +95,7 @@ class SuggestionContext:
         self.suggestion_stub_context: SuggestionStubContext | None = None
         self.update_package_list_context(can_edit=can_edit)
         self.update_maintainer_list_context(can_edit=can_edit)
+        self.update_references()
         # FIXME(@fricklerhandwerk): Constructor should take pre-fetched events in argument
         self.fetch_activity_log()
         self.error_message: str | None = None
@@ -165,6 +176,19 @@ class SuggestionContext:
                 self.suggestion.pk, maintainer_add_error_message
             ),
         )
+
+    def update_references(self) -> None:
+        refs: list[Reference] = []
+        for container in self.suggestion.cve.container.all():
+            for ref in container.references.all():
+                refs.append(
+                    Reference(
+                        url=ref.url,
+                        name=ref.name,
+                        tags=[tag for tag in ref.tags.all()],
+                    )
+                )
+        self.references = refs
 
     def fetch_activity_log(self) -> None:
         raw_events = fetch_suggestion_events(self.suggestion.pk)

--- a/src/webview/suggestions/views/lists.py
+++ b/src/webview/suggestions/views/lists.py
@@ -44,6 +44,7 @@ class SuggestionListView(ListView, ABC):
             CVEDerivationClusterProposal.objects.select_related(
                 "cached",
             )
+            .prefetch_related("cve__container__references__tags")
             .filter(query_filters)
             .order_by("-updated_at", "-created_at")
         )

--- a/src/webview/templates/components/cve_references.html
+++ b/src/webview/templates/components/cve_references.html
@@ -1,0 +1,21 @@
+{% load viewutils %}
+
+<div class="rounded-box">
+  <h2 class="heading dimmed">References</h2>
+  <ul class="column gap">
+  {% for ref in references %}
+    <li class="row baseline gap">
+      <div>
+      {% if ref.name %}
+        <a href="{{ref.url}}" target="_blank">{{ref.name}}</a>
+      {% else %}
+        <a href="{{ref.url}}" target="_blank">{{ref.url}}</a>
+      {% endif %}
+        {% for tag in ref.tags %}
+          <span class="tag fill-gray">{{tag.value}}</span>
+        {% endfor %}
+      </div>
+    </li>
+  {% endfor %}
+  </ul>
+</div>

--- a/src/webview/templates/suggestions/components/suggestion.html
+++ b/src/webview/templates/suggestions/components/suggestion.html
@@ -47,6 +47,10 @@
       <p>{{ data.suggestion.cached.payload.description }}</p>
     </details>
 
+    {% if data.references %}
+      {% include "../../components/cve_references.html" with references=data.references %}
+    {% endif %}
+
     <div class="rounded-box column gap">
       <h2 class="heading dimmed">Affected products</h2>
       {% affected_products data.suggestion.cached.payload.affected_products %}


### PR DESCRIPTION
Towards #775

<img width="1093" height="465" alt="image" src="https://github.com/user-attachments/assets/685d6abf-f505-45ea-9d7a-f2c3436576c6" />

This change flushes work in progress that's being dragged down by other stuff to be moved out of the way first. Showing references will save triagers a few clicks already, but the next steps should be to allow ignoring items and showing the remaining ones in the GitHub issue.