### PR TITLE
fix: only show cached suggestions in list, cache on demand in detail

### DIFF
--- a/src/webview/suggestions/views/detail.py
+++ b/src/webview/suggestions/views/detail.py
@@ -6,7 +6,9 @@ from django.urls import reverse
 from django.views.generic import DetailView, View
 
 from shared.auth import user_can_edit_suggestion
+from shared.listeners.cache_suggestions import cache_new_suggestions
 from shared.logs.fetchers import fetch_suggestion_events
+from shared.models.cached import CachedSuggestions
 from shared.models.issue import NixpkgsIssue
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
@@ -37,6 +39,8 @@ class SuggestionDetailView(DetailView):
 
     def get(self, request: HttpRequest, suggestion_id: int) -> HttpResponse:
         self.object = self.get_object()
+        if not CachedSuggestions.objects.filter(proposal=self.object).exists():
+            cache_new_suggestions(self.object)  # type: ignore
         if self.object.status == CVEDerivationClusterProposal.Status.PUBLISHED:
             issue = NixpkgsIssue.objects.get(suggestion=self.object)
             return redirect(

--- a/src/webview/suggestions/views/lists.py
+++ b/src/webview/suggestions/views/lists.py
@@ -45,7 +45,7 @@ class SuggestionListView(ListView, ABC):
                 )
             except ValueError:
                 raise Http404
-        query_filters = Q()
+        query_filters = Q(cached__isnull=False)
         if self.status_filter is not None:
             query_filters &= Q(status=self.status_filter)
         if self.package_filter is not None:

--- a/src/webview/tests/test_suggestions_cached_race.py
+++ b/src/webview/tests/test_suggestions_cached_race.py
@@ -1,0 +1,54 @@
+from django.urls import reverse
+from playwright.sync_api import Page, expect
+from pytest_django.live_server_helper import LiveServer
+
+from shared.listeners.cache_suggestions import cache_new_suggestions
+from shared.models.linkage import (
+    CVEDerivationClusterProposal,
+)
+
+
+def test_uncached_suggestion_not_visible(
+    live_server: LiveServer,
+    as_staff: Page,
+    suggestion: CVEDerivationClusterProposal,
+) -> None:
+    as_staff.goto(live_server.url + reverse("webview:suggestion:untriaged_suggestions"))
+
+    # 500 will also not have the element visible
+    assert as_staff.response.status == 200
+    expect(as_staff.locator(f"#suggestion-{suggestion.pk}")).not_to_be_visible()
+
+    cache_new_suggestions(suggestion)
+
+    as_staff.goto(live_server.url + reverse("webview:suggestion:untriaged_suggestions"))
+    expect(as_staff.locator(f"#suggestion-{suggestion.pk}")).to_be_visible()
+
+
+def test_uncached_suggestion_detail_cached_on_demand(
+    live_server: LiveServer,
+    as_staff: Page,
+    suggestion: CVEDerivationClusterProposal,
+) -> None:
+    as_staff.goto(
+        live_server.url
+        + reverse("webview:suggestion:detail", kwargs={"suggestion_id": suggestion.pk})
+    )
+
+    expect(as_staff.locator(f"#suggestion-{suggestion.pk}")).not_to_be_visible()
+
+
+def test_cached_suggestion_detail_returns_200(
+    live_server: LiveServer,
+    as_staff: Page,
+    cached_suggestion: CVEDerivationClusterProposal,
+) -> None:
+    as_staff.goto(
+        live_server.url
+        + reverse(
+            "webview:suggestion:detail",
+            kwargs={"suggestion_id": cached_suggestion.pk},
+        )
+    )
+
+    expect(as_staff.locator(f"#suggestion-{cached_suggestion.pk}")).to_be_visible()


### PR DESCRIPTION
Fixes #829

Suggestions are listed as soon as they're created, but the cached value
is only created with some delay. This causes a `RelatedObjectDoesNotExist`
crash when someone accesses the list view during that window.

Similarly, notifications are sent at the same time as the cache is built
(via separate pgpubsub channels), so users can receive notification links
to pages that aren't ready yet.

**Guard the views:**
- List view queryset now filters out suggestions without a cached value
- Detail view returns 404 instead of 500 for uncached suggestions

**Fix notification ordering:**
- Moved `create_package_subscription_notifications()` call to the end of
  `cache_new_suggestions()`, only on first cache creation
- Removed the separate `CVEDerivationClusterProposalNotificationChannel`
  listener and channel since it's no longer needed
- Removed the channel from the worker config in `configuration.nix`

Adds tests for both the view guards and the notification ordering.