### PR TITLE
Support CVSS 4.0 metric ingestion in make_metric 

### DIFF
--- a/src/shared/fetchers.py
+++ b/src/shared/fetchers.py
@@ -98,8 +98,19 @@ def to_camel_case(name: str) -> str:
 
 def make_metric(data: dict[str, Any]) -> models.Metric:
     ctx: dict[str, Any] = dict()
-    ctx["format"] = "cvssV3_1"
-    raw_cvss = data.get("cvssV3_1", {})
+    supported_versions = ["cvssV4_0", "cvssV3_1", "cvssV3_0"]
+    fmt = data.get("format")
+    if fmt in supported_versions:
+        raw_cvss = data.get(fmt) or {}
+    else:
+        raw_cvss = {}
+        fmt = None
+        for version in supported_versions:
+            if version in data:
+                raw_cvss = data.get(version) or {}
+                fmt = version
+                break
+    ctx["format"] = fmt
     ctx["raw_cvss_json"] = raw_cvss
 
     if raw_cvss:


### PR DESCRIPTION
This PR fixes CVSS metric ingestion for newer CVEs that no longer provide `cvssV3_1`.

Previously, `make_metric` always attempted to read CVSS data from `cvssV3_1`, which caused CVEs that only include `cvssV4_0` to store an empty `raw_cvss_json`. As a result, severity metrics were not shown in the overview.

The logic has been updated to select the available CVSS version in priority order (`cvssV4_0` -> `cvssV3_1` -> `cvssV3_0`) while respecting `data["format"]` if provided. The selected format is stored in `ctx["format"]`.

This keeps the change minimal and ensures modern CVEs with CVSS 4.0 metrics are ingested correctly.

Fixes #839