### PR TITLE
feat: explain pgpubsub listener registration pattern in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,7 +232,7 @@ This is the default Django workflow.
 
 ## `pgpubsub` listener registration pattern
 
-The application uses `django-pgpubsub` to react to database changes asynchronously.
+The application uses [`django-pgpubsub`](https://github.com/PaulGilmartin/django-pgpubsub) to react to database changes asynchronously.
 Listeners are defined as functions decorated with `@pgpubsub.post_insert_listener`, `@pgpubsub.post_update_listener` etc., and are primarily located in the [`src/shared/listeners/`](src/shared/listeners/) directory.
 
 To ensure your listener is proactively registered when the Django application starts, its containing module must be imported.


### PR DESCRIPTION
Summary:
This PR adds a new section to new section to Contributing guideline that documents the required pattern for registering pgpubsub listeners.

Thought Process:
In this project, pgpubsub listeners must be explicitly imported during the appliication's startup phase to be correctly registered. Currently, this is handled by:
1. `src/shared/apps.py` imports `shared.listeners`.
2. `src/shared/listeners/__init__.py` importing individual listener modules.

New contributors adding listeners in new files might overlook this requirement, leading to listeners that silently fail to trigger. Explicitly documenting this step helps prevent debugging frustration and ensures consistent implementation across th code.