### PR TITLE
test: version constraint comparison and string representation

### DIFF
--- a/src/shared/models/cve.py
+++ b/src/shared/models/cve.py
@@ -310,7 +310,7 @@ class Version(models.Model):
         else:
             return None
 
-    def affects(self, version: str) -> str:
+    def affects(self, version: str | None) -> str:
         """
         Determines wether a given version string is affected by this version constraint
         FIXME(kerstin): We currently compare versions by comparing strings, which is really wrong.

--- a/src/shared/tests/test_cve_models.py
+++ b/src/shared/tests/test_cve_models.py
@@ -1,43 +1,51 @@
-import pytest
 from shared.models.cve import Version
 
-def test_version_constraint_str_less_equal():
+
+def test_version_constraint_str_less_equal() -> None:
     v = Version(less_equal="0.4.6")
     assert v.version_constraint_str() == "=<0.4.6"
 
-def test_version_constraint_str_less_than():
+
+def test_version_constraint_str_less_than() -> None:
     v = Version(less_than="1.0.0")
     assert v.version_constraint_str() == "<1.0.0"
 
-def test_version_constraint_str_less_than_star():
+
+def test_version_constraint_str_less_than_star() -> None:
     v = Version(less_than="*")
     assert v.version_constraint_str() == "*"
 
-def test_version_constraint_str_exact_version():
+
+def test_version_constraint_str_exact_version() -> None:
     v = Version(version="1.2.3")
     assert v.version_constraint_str() == "==1.2.3"
 
-def test_version_constraint_str_none():
+
+def test_version_constraint_str_none() -> None:
     v = Version()
     assert v.version_constraint_str() is None
 
-def test_version_affects_less_equal():
+
+def test_version_affects_less_equal() -> None:
     v = Version(status=Version.Status.AFFECTED, less_equal="1.5.0")
     assert v.affects("1.4.0") == Version.Status.AFFECTED
     assert v.affects("1.5.0") == Version.Status.AFFECTED
     assert v.affects("1.6.0") == Version.Status.UNKNOWN
 
-def test_version_affects_less_than():
+
+def test_version_affects_less_than() -> None:
     v = Version(status=Version.Status.AFFECTED, less_than="1.5.0")
     assert v.affects("1.4.0") == Version.Status.AFFECTED
     assert v.affects("1.5.0") == Version.Status.UNKNOWN
 
-def test_version_affects_exact_version():
+
+def test_version_affects_exact_version() -> None:
     v = Version(status=Version.Status.AFFECTED, version="1.5.0")
     assert v.affects("1.5.0") == Version.Status.AFFECTED
     assert v.affects("1.4.0") == Version.Status.UNKNOWN
 
-def test_version_affects_wildcard():
+
+def test_version_affects_wildcard() -> None:
     v_le = Version(status=Version.Status.AFFECTED, less_equal="*")
     assert v_le.affects("any-version") == Version.Status.AFFECTED
 
@@ -47,7 +55,8 @@ def test_version_affects_wildcard():
     v_v = Version(status=Version.Status.AFFECTED, version="*")
     assert v_v.affects("any-version") == Version.Status.AFFECTED
 
-def test_version_affects_empty_version():
+
+def test_version_affects_empty_version() -> None:
     v = Version(status=Version.Status.AFFECTED, version="1.0.0")
     assert v.affects("") == Version.Status.UNKNOWN
     assert v.affects(None) == Version.Status.UNKNOWN


### PR DESCRIPTION
- Add `src/shared/tests/test_cve_models.py` with unit tests for:
  - `Version.version_constraint_str()`
  - `Version.affects()`
- Remove now-resolved TODO comments in `src/shared/models/cve.py` for those two methods.

## What’s Covered
- `version_constraint_str()`:
  - `less_equal` formatting (`=<...`)
  - `less_than` formatting (`<...`)
  - wildcard `less_than="*"` behavior
  - exact `version` formatting (`==...`)
  - no constraint set returns `None`
- `affects()`:
  - `less_equal` boundary behavior
  - `less_than` boundary behavior
  - exact `version` matching
  - wildcard matching (`*`) across fields
  - empty/`None` input version returns `UNKNOWN`

## Verification
- Ran:
  - `nix-shell --run "pytest -q src/shared/tests/test_cve_models.py"`
- Result:
  - `10 passed`