### PR TITLE
test: add unit tests for parse_drv_name utility

### DIFF
--- a/src/shared/tests/test_utils.py
+++ b/src/shared/tests/test_utils.py
@@ -1,0 +1,18 @@
+import pytest
+
+from shared.listeners.cache_suggestions import parse_drv_name
+
+
+@pytest.mark.parametrize(
+    "drv_name,expected",
+    [
+        ("openssl-3.0.8", ("openssl", "3.0.8")),
+        ("libfoo-bar-1.2.3", ("libfoo-bar", "1.2.3")),
+        ("foo-1.0-beta", ("foo", "1.0-beta")),
+        ("foo-unstable", ("foo-unstable", "")),
+        ("python3-3.11.0", ("python3", "3.11.0")),
+        ("no-version", ("no-version", "")),
+    ],
+)
+def test_parse_drv_name(drv_name: str, expected: tuple[str, str]) -> None:
+    assert parse_drv_name(drv_name) == expected


### PR DESCRIPTION
### Description
This PR adds comprehensive unit tests for the `parse_drv_name` utility function, ensuring it correctly splits Nix derivation names into their respective package name and version components. 

The tests use `@pytest.mark.parametrize` to cover various naming edge cases, including:
- Standard derivation names (example: `openssl-3.0.8`)
- Packages with hyphens in the name (exampe: `libfoo-bar-1.2.3`)
- Alpha/beta version suffixes (example: `foo-1.0-beta`)
- Packages with digits in the base name (example `python3-3.11.0`)
- Derivations without explicitly defined versions (example `foo-unstable`, `no-version`)

These tests guarantee that our regex parsing behavior remains robust and strictly adheres to the expected Nix parseDrvName semantics (https://nix.dev/manual/nix/latest/language/builtins.html#builtins-parseDrvName).