### PR TITLE
chore: Include git in list of shell packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -94,6 +94,12 @@ rec {
       packages = [
         manage
         package
+        # Explicitly pin git from nixpkgs to ensure the `fetch_all_channels` management command
+        # and the Nix evaluation pipeline (which clones and fetches Nixpkgs commits via shared/git.py)
+        # always use a known-good version. Without this, the shell falls back to the system git,
+        # which may be too old to support required flags (e.g. `git fetch --porcelain` requires git 2.41+)
+        # and can cause silent failures or broken behaviour in development.
+        pkgs.git
         pkgs.nix-eval-jobs
         pkgs.npins
         pkgs.hivemind


### PR DESCRIPTION
Description
Explicitly add `pkgs.git` to the dev shell packages in `default.nix`.

## Why

The `fetch_all_channels` management command and the Nix evaluation pipeline
(`shared/git.py`) both rely on git to clone and fetch Nixpkgs commits.
Without this change, the dev shell falls back to the system git which may
be too old `git fetch --porcelain` requires git 2.41+ and silently breaks
on older versions (e.g. macOS ships git 2.39.2 which does not support this flag).

Pinning git through nixpkgs ensures every developer uses a known-good version
regardless of what is installed on their machine.