### PR TITLE
chore: remove unused redis configuration

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -62,7 +62,6 @@ rec {
     in
     pkgs.mkShellNoCC {
       env = {
-        REDIS_SOCKET_URL = "unix:///run/redis/redis.sock";
         DATABASE_URL = "postgres://nix-security-tracker@/nix-security-tracker";
         # psql doesn't take DATABASE_URL
         PGDATABASE = "nix-security-tracker";

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -247,16 +247,6 @@ if "GLITCHTIP_DSN" in env:
         traces_sample_rate=0,
     )
 
-## Channel setup
-CHANNEL_LAYERS = {
-    "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {
-            "hosts": list(filter(None, [env.get("REDIS_UNIX_SOCKET")])),
-        },
-    },
-}
-
 ## Logging settings
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
This was a very old artefact from early prototype days.
We never actually used redis anywhere.