### PR TITLE
docs: add guideline on contribution culture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ nix-shell --run format
 
 ## Contribution culture
 
-A pull request asks a maintainer to accept responsibility for a decision.
+A pull request asks maintainers to accept responsibility for a decision.
 Help them understand what they're agreeing to.
 
 To minimise turnaround time for getting your contribution merged:


### PR DESCRIPTION
After many years in software maintenance, I realized that most of the time reviewing is spent deciding whether doing the things proposed in a change are a good idea. And that accepting a change means taking responsibility for the consequences. The more decisions, the longer it takes. Hard decisions block easy decisions, especially if they're unrelated.