### PR TITLE
docs: document different components of the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,6 @@ It contains general contribution information, and lists resources to help you ge
 
 Other directories in this repository have additional `README.md` files with more specific information relevant to their sibling files.
 
-## System Architecture and Project Structure
-
-The security tracker is a distributed system where Nix manages the infrastructure and services, while Django handles the application logic and web interface.
-
 Service definitions are in [`nix/configuration.nix`](nix/configuration.nix).
 
 Application logic lives in the [`src/`](src/) directory.


### PR DESCRIPTION
As discussed with the maintainer, he suggested implementing this section.

Thought Process: New contributors often find it difficult to understand how the various services (Daphne, Workers, Cron) are defined and where the core business logic resides. This documentation provides the necessary "mental map" to navigate the project effectively.