### PR TITLE
fix: guard against missing baseScore in CVSS metric parsing

### DIFF
--- a/src/shared/fetchers.py
+++ b/src/shared/fetchers.py
@@ -105,7 +105,8 @@ def make_metric(data: dict[str, Any]) -> models.Metric:
     if raw_cvss:
         ctx["scope"] = raw_cvss.get("scope")
         ctx["vector_string"] = raw_cvss.get("vectorString")
-        ctx["base_score"] = float(raw_cvss.get("baseScore"))
+        raw_base_score = raw_cvss.get("baseScore")
+        ctx["base_score"] = float(raw_base_score) if raw_base_score is not None else None
 
         vector_fields = (
             "attack_complexity",


### PR DESCRIPTION
## Description

This PR fixes a critical ingestion bug by handling missing `baseScore` values in CVSS data to prevent transaction failures during bulk CVE ingestion.

### Changes:

- Updated `fetchers.py` to safely handle `None` values for `baseScore`:
  - Replaced direct `float()` casting with a null-safe conversion
- Ensures `base_score` is set to `None` when missing instead of raising `TypeError`

Ensuring safe handling of incomplete CVSS data prevents a single malformed CVE from rolling back the entire `transaction.atomic()` bulk ingestion process, improving system reliability at scale.