### PR TITLE
fix: preserve details open state across htmx swaps

### DIFF
--- a/src/shared/templates/base.html
+++ b/src/shared/templates/base.html
@@ -128,5 +128,26 @@
       </p>
     </footer>
     <script src="/static/htmx.min.js"></script>
+    <script>
+      // Preserve the open/closed state of <details> elements across htmx swaps.
+      // Without this, sections with ignored items collapse every time an item is ignored or restored.
+      // Workaround as proposed in:
+      // https://github.com/bigskysoftware/htmx/issues/2195#issuecomment-2311061249
+      // https://gist.github.com/Odas0R/7a49d2c3b8c4d8aceadf800a8a60937d
+      (function () {
+        var openDetails = [];
+        document.addEventListener("htmx:beforeSwap", function (event) {
+          var target = event.detail.target;
+          openDetails = Array.from(target.querySelectorAll("details[open][id]"))
+            .map(function (el) { return el.id; });
+        });
+        document.addEventListener("htmx:afterSwap", function () {
+          openDetails.forEach(function (id) {
+            var el = document.getElementById(id);
+            if (el) el.setAttribute("open", "");
+          });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/src/webview/tests/test_activity_log.py
+++ b/src/webview/tests/test_activity_log.py
@@ -22,6 +22,7 @@ def test_maintainer_addition_creates_activity_log_entry(
     committer: User,
     make_maintainer_from_user: Callable[..., NixMaintainer],
     cached_suggestion: CVEDerivationClusterProposal,
+    no_js: bool,
     frozen_time: FakeDatetime,
 ) -> None:
     """Test that adding a maintainer creates an activity log entry"""
@@ -59,7 +60,8 @@ def test_maintainer_addition_creates_activity_log_entry(
     activity_log = suggestion.locator(
         f"#suggestion-activity-log-{cached_suggestion.pk}"
     )
-    activity_log.click()
+    if no_js:
+        activity_log.click()
     # activity_log.get_by_text(staff.username)
 
     entry = (

--- a/src/webview/tests/test_maintainers.py
+++ b/src/webview/tests/test_maintainers.py
@@ -147,6 +147,7 @@ def test_ignore_restore_package(
     make_maintainer_from_user: Callable[..., NixMaintainer],
     staff: User,
     committer: User,
+    no_js: bool,
     ignore_maintainer: bool,
 ) -> None:
     """Test ignoring and restoring a package"""
@@ -182,10 +183,10 @@ def test_ignore_restore_package(
     )
     ignore_package1_button.click()
     ignored_packages_section = as_staff.locator(f"#suggestion-{suggestion.pk}")
-    ignore_package = ignored_packages_section.get_by_text(
+    ignored_packages = ignored_packages_section.get_by_text(
         re.compile("Ignored packages"),
     )
-    ignore_package.click()
+    ignored_packages.click()
 
     expect(maintainers_list).to_have_count(1)
 

--- a/src/webview/tests/test_packages.py
+++ b/src/webview/tests/test_packages.py
@@ -100,6 +100,7 @@ def test_ignore_multiple_packages(
     as_staff: Page,
     make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
     make_drv: Callable[..., NixDerivation],
+    no_js: bool,
 ) -> None:
     """Ignoring packages one by one keeps all of them in the ignored section."""
     drv1 = make_drv(pname="alpha")
@@ -132,7 +133,8 @@ def test_ignore_multiple_packages(
     # Ignore bravo
     active.locator(".package-bravo").get_by_role("button", name="Ignore").click()
     expect(active.get_by_text("bravo")).not_to_be_visible()
-    container.get_by_text("Ignored packages").click()
+    if no_js:
+        container.get_by_text("Ignored packages").click()
     expect(ignored.get_by_text("alpha")).to_be_visible()
     expect(ignored.get_by_text("bravo")).to_be_visible()
     expect(active.get_by_text("charlie")).to_be_visible()
@@ -147,6 +149,7 @@ def test_restore_one_of_multiple_ignored_packages(
     as_staff: Page,
     make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
     make_drv: Callable[..., NixDerivation],
+    no_js: bool,
 ) -> None:
     """Restoring one ignored package does not affect other ignored packages."""
     drv1 = make_drv(pname="alpha")
@@ -176,14 +179,15 @@ def test_restore_one_of_multiple_ignored_packages(
     expect(active.get_by_text("bravo")).not_to_be_visible()
 
     # Restore only alpha
-    ignored.click()
+    if no_js:
+        ignored.click()
     ignored.locator(".package-alpha").get_by_role("button", name="Restore").click()
     expect(ignored.get_by_text("alpha")).not_to_be_visible()
 
     expect(active.get_by_text("alpha")).to_be_visible()
     expect(active.get_by_text("charlie")).to_be_visible()
-    # Expand the ignored packages section before asserting since it will close due to re-render
-    container.get_by_text("Ignored packages").click()
+    if no_js:
+        container.get_by_text("Ignored packages").click()
     expect(ignored.get_by_text("bravo")).to_be_visible()
     expect(active.get_by_text("bravo")).not_to_be_visible()
 


### PR DESCRIPTION
## Summary

- Fixes #913: `<details>` sections (e.g. "Ignored packages", "Ignored maintainers") no longer collapse when ignoring or restoring items
- Adds a small inline script after `htmx.min.js` in `base.html` that saves the `open` state of `<details>` elements (by ID) before an htmx swap and restores it after the swap completes
- Uses `htmx:beforeSwap` and `htmx:afterSwap` events as suggested in [htmx#2195](https://github.com/bigskysoftware/htmx/issues/2195)

## How it works

1. On `htmx:beforeSwap`, the script collects the IDs of all `<details open>` elements inside the swap target
2. On `htmx:afterSwap`, it finds those elements by ID in the new content and sets the `open` attribute back

Only `<details>` elements with an `id` attribute are tracked, which currently covers the ignored packages and ignored maintainers sections — exactly the ones affected by this issue.

## Test plan

- [ ] Open a suggestion with multiple ignored packages
- [ ] Expand the "Ignored packages" section
- [ ] Click "Restore" on one package — verify the section stays open
- [ ] Repeat for "Ignored maintainers" section
- [ ] Verify the "Ignore" action on active items also preserves open state of other `<details>` sections
- [ ] Verify non-JS fallback still works (form submits normally, page reloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)