### PR TITLE
style: reduce tag font size for more consistent-looking padding

### DIFF
--- a/src/webview/static/utility.css
+++ b/src/webview/static/utility.css
@@ -197,9 +197,10 @@
  */
 
 .tag {
-  border-radius: 1000px;
-  padding: 0em 0.4em;
+  border-radius: 1rem;
+  padding: 0.15rem 0.5rem;
   word-break: normal;
+  font-size: 0.8rem;
 }
 
 .tag-gray {


### PR DESCRIPTION
The wide-radius, narrow-padding borders were visually cutting off the text, which was always irritating to me. It's kind of hard to adjust this correctly, because there's always a trade-off against bulkiness...

Before:

<img width="767" height="207" alt="image" src="https://github.com/user-attachments/assets/6f528644-86f9-43fa-94c2-23751d60b3f7" />


After:

<img width="735" height="207" alt="image" src="https://github.com/user-attachments/assets/b0f30e5a-0f99-4e63-b88f-e8946c7d4c11" />
