### PR TITLE
fix: deduplicate CVE references in suggestions context

### DIFF
--- a/src/webview/suggestions/context/types.py
+++ b/src/webview/suggestions/context/types.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
-
+from shared.models import Tag
 from shared.logs.batches import batch_events
 from shared.logs.events import (
     Maintainer,  # FIXME(@florent): This is to import it from that module
@@ -18,7 +17,7 @@ from shared.models.linkage import CVEDerivationClusterProposal
 class Reference:
     url: str
     name: str
-    tags: list[Any]
+    tags: set[Tag]
 
 
 # Packages
@@ -197,15 +196,11 @@ class SuggestionContext:
                     refs_by_url[url] = Reference(
                         url=url,
                         name=ref.name,
-                        tags=list(ref.tags.all()),
+                        tags=set(ref.tags.all()),
                     )
                 else:
                     existing_ref = refs_by_url[url]
-                    existing_tag_values = {tag.value for tag in existing_ref.tags}
-                    for tag in ref.tags.all():
-                        if tag.value not in existing_tag_values:
-                            existing_ref.tags.append(tag)
-                            existing_tag_values.add(tag.value)
+                    existing_ref.tags.update(ref.tags.all())
                     
                     if not existing_ref.name and ref.name:
                         existing_ref.name = ref.name

--- a/src/webview/suggestions/context/types.py
+++ b/src/webview/suggestions/context/types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 from shared.logs.batches import batch_events
 from shared.logs.events import (
@@ -17,7 +18,7 @@ from shared.models.linkage import CVEDerivationClusterProposal
 class Reference:
     url: str
     name: str
-    tags: list[str]
+    tags: list[Any]
 
 
 # Packages
@@ -188,17 +189,27 @@ class SuggestionContext:
         )
 
     def update_references(self) -> None:
-        refs: list[Reference] = []
+        refs_by_url = {}
         for container in self.suggestion.cve.container.all():
             for ref in container.references.all():
-                refs.append(
-                    Reference(
-                        url=ref.url,
+                url = ref.url
+                if url not in refs_by_url:
+                    refs_by_url[url] = Reference(
+                        url=url,
                         name=ref.name,
-                        tags=[tag for tag in ref.tags.all()],
+                        tags=list(ref.tags.all()),
                     )
-                )
-        self.references = refs
+                else:
+                    existing_ref = refs_by_url[url]
+                    existing_tag_values = {tag.value for tag in existing_ref.tags}
+                    for tag in ref.tags.all():
+                        if tag.value not in existing_tag_values:
+                            existing_ref.tags.append(tag)
+                            existing_tag_values.add(tag.value)
+                    
+                    if not existing_ref.name and ref.name:
+                        existing_ref.name = ref.name
+        self.references = list(refs_by_url.values())
 
     def fetch_activity_log(self) -> None:
         events = fetch_suggestion_events([self.suggestion.pk])

--- a/src/webview/tests/test_references.py
+++ b/src/webview/tests/test_references.py
@@ -1,0 +1,40 @@
+from collections.abc import Callable
+import pytest
+
+from shared.listeners.cache_suggestions import cache_new_suggestions
+from shared.models.linkage import CVEDerivationClusterProposal
+from shared.models.cve import Container, Tag, Reference
+from webview.suggestions.context.types import SuggestionContext
+
+@pytest.mark.django_db
+def test_suggestion_context_reference_deduplication(
+    make_container: Callable[..., Container],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    container1 = make_container()
+    suggestion = make_suggestion(container=container1, status=CVEDerivationClusterProposal.Status.ACCEPTED)
+    container2 = make_container(cve=suggestion.cve)
+
+    tag1 = Tag.objects.create(value="CNA-tag")
+    tag2 = Tag.objects.create(value="ADP-tag")
+    
+    ref1 = Reference.objects.create(url="https://duplicate-url.com", name="Duplicate Link")
+    ref1.tags.add(tag1)
+    container1.references.add(ref1)
+
+    ref2 = Reference.objects.create(url="https://duplicate-url.com", name="Duplicate Link")
+    ref2.tags.add(tag2)
+    container2.references.add(ref2)
+    
+    cache_new_suggestions(suggestion)
+
+    context = SuggestionContext(suggestion, user_can_edit=False, pre_fetched_events=[])
+
+    assert len(context.references) == 1, "References were not successfully deduplicated"
+    assert context.references[0].url == "https://duplicate-url.com"
+    
+    assert len(context.references[0].tags) == 2, "Tags belonging to duplicate references were not properly merged"
+    
+    tag_values = {t.value for t in context.references[0].tags}
+    assert "CNA-tag" in tag_values
+    assert "ADP-tag" in tag_values


### PR DESCRIPTION
## Description

This PR resolves issue #876 where CVE references derived from multiple containers (like CNA and ADP) were blindly appended to the UI context, causing identical reference links to be displayed multiple times with identical or split tags.

## Changes
- Modified `SuggestionContext.update_references` inside [src/webview/suggestions/context/types.py](cci:7://file:///media/prashant1901/New%20Volume/GSOC/nix-security-tracker/src/webview/suggestions/context/types.py:0:0-0:0) to efficiently aggregate references using a URL-keyed dictionary.
- Seamlessly merges [Tag](cci:2://file:///media/prashant1901/New%20Volume/GSOC/nix-security-tracker/src/shared/models/cve.py:113:0-116:44) objects from identical references across different containers so that no metadata is lost (e.g. merging `vdb-entry` and `x_refsource_REDHAT` dynamically).
- Adjusted the [Reference](cci:2://file:///media/prashant1901/New%20Volume/GSOC/nix-security-tracker/src/webview/suggestions/context/types.py:16:0-20:19) dataclass `tags` type hint to correctly accept standard Django model instances, appeasing strict static analysis tools.

Fixes #876
