### PR TITLE
docs: add quick start helper command and instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,16 +163,51 @@ To replicate this on a traditional Unix-like system:
 
 ### Start the service
 
-The service is comprised of the Django server and workers for ingesting CVEs and derivations.
-What needs to be run is defined in the [`Procfile`](./Procfile) managed by [hivemind](https://github.com/DarthSim/hivemind).
+> ![NOTE]
+> For a quick start, create dummy credentials:
+>
+> ```console
+> dummy-credentials
+> ```
+>
+> Logging in and publishing issues requires [setting up credentials](#setting-up-credentials).
 
-Run everything with:
+Run the server:
 
-```bash
-hivemind
+```console
+manage runserver
 ```
 
-<!-- FIXME(@fricklerhandwerk): Add instructions for manually obtaining CVEs and derivations. -->
+### Ingest Nixpkgs metadata
+
+Fetch the tips of all [channel branches](https://nix.dev/concepts/faq#channel-branches):
+
+```console
+manage fetch_all_channels
+```
+
+Select a ``head_sha1_commit` from the output and run evaluation on that:
+
+```console
+manage run_evaluation <commit>
+```
+
+### Start matching listeners and ingest CVEs for matching
+
+Matching CVEs against Nixpkgs metadata is triggered by `pgpubsub` notifications internally as CVEs are ingested.
+To test this dataflow locally, start the listeners:
+
+```console
+manage listen -v3 --recover
+```
+
+Ingest some CVEs:
+
+```console
+manage ingest_bulk_cve --subset 500
+```
+
+This should produce untriaged matches.
 
 ### Resetting the database
 
@@ -337,20 +372,7 @@ We use the following pattern:
 > [!WARNING]
 > If you create a new listener module but forget to add its import to [`src/shared/listeners/__init__.py`](src/shared/listeners/__init__.py), your listener will fail to run silently!
 
-## Manual ingestion
-
-### CVEs
-
-Add 100 CVE entries to the database:
-
-```console
-manage ingest_bulk_cve --subset 100
-```
-
-This will take a few minutes on an average machine.
-Not passing `--subset N` will take about an hour and produce ~500 MB of data.
-
-### Caching suggestions
+## Re-caching suggestions
 
 Suggestion contents are displayed from a cache to avoid latency from complex database queries.
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: ./src/manage.py runserver
-workers: ./src/manage.py listen -v3 --recover --processes 3

--- a/contrib/mkcredentials.sh
+++ b/contrib/mkcredentials.sh
@@ -1,7 +1,0 @@
-# This script creates `.credentials/` and populates it with some fake secrets
-
-mkdir .credentials
-python3 -c 'import secrets; print(secrets.token_hex(100))' > .credentials/SECRET_KEY
-echo bar > .credentials/GH_CLIENT_ID
-echo baz > .credentials/GH_SECRET
-echo quux > .credentials/GH_WEBHOOK_SECRET

--- a/default.nix
+++ b/default.nix
@@ -59,6 +59,24 @@ rec {
       manage = pkgs.writeScriptBin "manage" ''
         exec ${pkgs.python3}/bin/python ${toString ./src/manage.py} $@
       '';
+      # Run this for a quick start.
+      # Login and publishing issues requires setting up credentials properly.
+      dummy-credentials = pkgs.writeShellApplication {
+        name = "dummy-credentials";
+        runtimeInputs = [ pkgs.python3 ];
+        text = ''
+          dir=${toString ./.credentials}
+          mkdir "$dir"
+          cd "$dir"
+          set -o noclobber
+          python3 -c 'import secrets; print(secrets.token_hex(100))' > SECRET_KEY
+          echo bar > GH_CLIENT_ID
+          echo baz > GH_SECRET
+          echo qux > GH_WEBHOOK_SECRET
+          echo 123 > GH_APP_INSTALLATION_ID
+          echo foo > GH_APP_PRIVATE_KEY
+        '';
+      };
     in
     pkgs.mkShellNoCC {
       env = {
@@ -91,6 +109,7 @@ rec {
       };
 
       packages = [
+        dummy-credentials
         manage
         package
         # Explicitly pin git from nixpkgs to ensure the `fetch_all_channels` management command
@@ -101,7 +120,6 @@ rec {
         pkgs.git
         pkgs.nix-eval-jobs
         pkgs.npins
-        pkgs.hivemind
         pkgs.pv
         (import sources.agenix { inherit pkgs; }).agenix
         format

--- a/src/shared/management/commands/fetch_all_channels.py
+++ b/src/shared/management/commands/fetch_all_channels.py
@@ -119,7 +119,6 @@ class Command(BaseCommand):
 
         repo = GitRepo(
             settings.LOCAL_NIXPKGS_CHECKOUT,
-            stdout=sys.stdout.fileno(),
             stderr=sys.stderr.fileno(),
         )
         parallel_fetches = []
@@ -127,4 +126,5 @@ class Command(BaseCommand):
             parallel_fetches.append(repo.update_from_ref(channel.head_sha1_commit))
 
         results = asyncio.run(wait_for_parallel_fetches(parallel_fetches))
+        # FIXME(@fricklerhandwerk): Fold that into `branch_info`, so there's only one output.
         print("Parallel fetches results", results)


### PR DESCRIPTION
This allows spinning up the service quickly.
Details on GitHub intergration are deferred to later.