### PR TITLE
docs: emphasize that `direnv` is optional

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,0 @@
-use nix
-
-# Source a user-specific config in .envrc-local at the project
-# top-level.
-# This file can contain your customizations of `env.rb`.
-source_env_if_exists .envrc-local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ nix-shell
 This will provide most of tools necessary to run the service locally.
 
 > [!NOTE]
-> Set up [`nix-direnv`](https://github.com/nix-community/nix-direnv) on your system and run `direnv allow` to enter the development environment automatically when entering the project directory.
+> If you want to start the development environment automatically when entering the project directory, set up [`nix-direnv`](https://github.com/nix-community/nix-direnv) on your system.
+> Add your `.envrc` to `.git/info/exclude`.
 
 List all available [management commands](https://docs.djangoproject.com/en/6.0/ref/django-admin/):
 


### PR DESCRIPTION
Whether or not to use `direnv`, and how to configure it, is very much a local concern.
Corresponding to the new instructions, this also stops tracking `.envrc`.