### PR TITLE
chore: Enable merge queues for actions

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/**"
+  merge_group:
   push:
     branches: main
     paths:

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -1,6 +1,7 @@
 name: Builds
 on:
   pull_request:
+  merge_group:
   push:
     branches: main
   # allow "manual" triggering from automatic PRs

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -2,6 +2,7 @@ name: "CodeQL"
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: main
   workflow_dispatch:


### PR DESCRIPTION
I've already enabled the `Require merge queue` setting in branch protection rules in the repo settings.

Closes #940 