### PR TITLE
style: align header and footer with NixOS brand styleguide

### DIFF
--- a/src/webview/static/colors.css
+++ b/src/webview/static/colors.css
@@ -12,4 +12,6 @@
   --light-green: #dbfcdb;
   --light-yellow: #fcfaba;
   --light-gray: #eee;
+  /* Source: https://github.com/NixOS/branding/blob/main/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml#L92 */
+  --nixos-blue: #15213a;
 }

--- a/src/webview/static/page-layout.css
+++ b/src/webview/static/page-layout.css
@@ -6,7 +6,7 @@
  */
 
 #header-bar {
-  background-color: black;
+  background-color: var(--nixos-blue);
   padding: 0.5em;
   color: white;
 }
@@ -60,7 +60,7 @@ footer {
   flex-direction: column;
   align-items: center;
   gap: 1em;
-  background-color: black;
+  background-color: var(--nixos-blue);
   color: white;
   padding: 2em;
 }


### PR DESCRIPTION
Closes #947

## What and why
The header and footer used hardcoded `black` backgrounds, which does 
not align with the official NixOS brand styleguide.

## Changes
- Introduce `--nixos-blue` (#5277c3) as a CSS variable in `colors.css`
- Apply it to `#header-bar` and `footer` in `page-layout.css`

`#5277c3` corresponds to "NixOS Dark Blue", defined in the official NixOS branding color palette.

Source:
- https://github.com/NixOS/branding/blob/main/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml#L4-L7 (entry: "NixOS Dark Blue", value: [0.55, 0.12, 264])

## Screenshots
-Before
<img width="1899" height="915" alt="image" src="https://github.com/user-attachments/assets/dd974490-1efc-4800-98d1-6e0589b4d565" />
-After
<img width="1898" height="918" alt="image" src="https://github.com/user-attachments/assets/ce5e8ef6-7c7c-4e28-a454-b3e441f3b1ee" />

