### PR TITLE
fix: limit retries when waiting for Git's shallow lockfile

### DIFF
--- a/src/shared/git.py
+++ b/src/shared/git.py
@@ -3,6 +3,8 @@ import itertools
 import logging
 import os.path
 import pathlib
+import random
+import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -126,7 +128,14 @@ class GitRepo:
             )
         )
 
-    async def update_from_ref(self, object_sha1: str) -> bool:
+    async def update_from_ref(
+        self,
+        object_sha1: str,
+        # Age above which a leftover `shallow.lock` is considered stale and removed.
+        max_lock_age_seconds: int = 300,
+        # Retries between attempts happen with exponential backoff. Increase with care.
+        max_attempts: int = 7,
+    ) -> bool:
         """
         This checks if `object_sha1` is already present in the repo or not.
         If not, perform a fetch to our remote to obtain it.
@@ -146,25 +155,46 @@ class GitRepo:
         if exists:
             return False
         else:
-            locking_problem = True
-            while locking_problem:
-                # We need to acquire a shallow lock here.
-                # TODO: replace me by an async variant.
-                while os.path.exists(os.path.join(self.repo_path, "shallow.lock")):
-                    await asyncio.sleep(1)
+            # Git tries to create `shallow.lock` before attempting a shallow fetch, in order to prevent conflicts on the `shallow` metadata file:
+            # https://git-scm.com/docs/shallow
+            lock_path = os.path.join(self.repo_path, "shallow.lock")
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    if time.time() - os.path.getmtime(lock_path) > max_lock_age_seconds:
+                        logger.warning("Stale `shallow.lock`, removing: %s", lock_path)
+                        os.remove(lock_path)
+                except FileNotFoundError:
+                    # The lock is gone, nothing to do.
+                    pass
                 process = await self.execute_git_command(
                     f"git fetch --porcelain --depth=1 {repo_clone_url} {object_sha1}",
                     stderr=asyncio.subprocess.PIPE,
                 )
                 _, stderr = await process.communicate()
                 rc = await process.wait()
-                locking_problem = "shallow" in stderr.decode("utf8")
-                if rc != 0 and not locking_problem:
-                    logger.error("git fetch stderr: %s", stderr.decode("utf8"))
+                stderr_text = stderr.decode("utf8")
+                if rc == 0:
+                    return True
+                if "shallow.lock" not in stderr_text:
+                    logger.error("git fetch stderr: %s", stderr_text)
                     raise RepositoryError(
                         f"failed to fetch {object_sha1} while running `git fetch --depth=1 {repo_clone_url} {object_sha1}`"
                     )
-            return True
+                if attempt < max_attempts:
+                    # Exponential backoff with full jitter, per
+                    # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+                    backoff = random.uniform(0, 2 ** (attempt - 1))
+                    logger.warning(
+                        "Found `shallow.lock` when trying to fetch %s (attempt %d/%d), retrying in %.1fs",
+                        object_sha1[:8],
+                        attempt,
+                        max_attempts,
+                        backoff,
+                    )
+                    await asyncio.sleep(backoff)
+            raise RepositoryError(
+                f"Failed to fetch {object_sha1}: exceeded {max_attempts} attempts due to repeated `shallow.lock` contention"
+            )
 
     async def remove_working_tree(self, name: str) -> bool:
         """

--- a/src/shared/tests/test_git_update_from_ref.py
+++ b/src/shared/tests/test_git_update_from_ref.py
@@ -1,0 +1,168 @@
+"""
+Tests locking and retry handling when fetching a Git repository.
+"""
+
+import asyncio
+import time
+from collections.abc import Sequence
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shared.git import GitRepo, RepositoryError
+
+
+def _proc(command: str, rc: int, stderr: bytes = b"") -> MagicMock:
+    p = MagicMock()
+    p.command = command
+    p.communicate = AsyncMock(return_value=(b"", stderr))
+    p.wait = AsyncMock(return_value=rc)
+    return p
+
+
+def _run(
+    processes: Sequence[MagicMock],
+    getmtime_side_effect: object = FileNotFoundError,
+    max_attempts: int = 3,
+    object_sha1: str = "a" * 40,
+) -> tuple[object, AsyncMock, AsyncMock, AsyncMock]:
+    repo = GitRepo("/nonexistent/repo")
+    exec_mock = AsyncMock(side_effect=list(processes))
+    sleep_mock = AsyncMock()
+    remove_mock = MagicMock()
+    getmtime_mock = MagicMock(side_effect=getmtime_side_effect)
+
+    async def _go() -> object:
+        try:
+            return await repo.update_from_ref(object_sha1, max_attempts=max_attempts)
+        except Exception as e:
+            return e
+
+    with (
+        patch.object(repo, "execute_git_command", exec_mock),
+        patch("shared.git.asyncio.sleep", sleep_mock),
+        patch("shared.git.os.path.getmtime", getmtime_mock),
+        patch("shared.git.os.remove", remove_mock),
+    ):
+        result = asyncio.run(_go())
+
+    # Validate that mocked processes lined up with real call sites:
+    # The Nth call to `execute_git_command` should contain the Nth expected process's `command` substring.
+    expected = [p.command for p in processes[: exec_mock.await_count]]
+    actual = [call.args[0] for call in exec_mock.await_args_list]
+    for cmd, sig in zip(actual, expected, strict=True):
+        assert sig in cmd, f"expected a {sig!r} command, got: {cmd!r}"
+
+    return result, exec_mock, sleep_mock, remove_mock
+
+
+def test_returns_false_when_commit_already_present() -> None:
+    # `git cat-file` returning 0 means the commit is already in the local repo.
+    result, exec_mock, sleep_mock, _ = _run([_proc("git cat-file", 0)])
+    assert result is False
+    assert exec_mock.await_count == 1
+    sleep_mock.assert_not_awaited()
+
+
+def test_fetches_successfully_first_attempt() -> None:
+    result, exec_mock, sleep_mock, _ = _run(
+        [_proc("git cat-file", 1), _proc("git fetch", 0)]
+    )
+    assert result is True
+    assert exec_mock.await_count == 2
+    sleep_mock.assert_not_awaited()
+
+
+def test_retries_then_succeeds_on_lock_contention() -> None:
+    result, exec_mock, sleep_mock, _ = _run(
+        [
+            _proc("git cat-file", 1),
+            _proc("git fetch", 128, b"fatal: could not lock ref: shallow.lock\n"),
+            _proc("git fetch", 0),
+        ]
+    )
+    assert result is True
+    assert exec_mock.await_count == 3
+    sleep_mock.assert_awaited_once()
+
+
+def _lock_err() -> MagicMock:
+    return _proc("git fetch", 128, b"fatal: could not lock ref: shallow.lock\n")
+
+
+@pytest.mark.parametrize("max_attempts", [1, 2, 5])
+def test_raises_when_every_attempt_locks(max_attempts: int) -> None:
+    # Whatever the retry budget is, if every attempt sees a lock, we raise.
+    result, *_ = _run(
+        [_proc("git cat-file", 1), *(_lock_err() for _ in range(max_attempts))],
+        max_attempts=max_attempts,
+    )
+    assert isinstance(result, RepositoryError)
+    assert "exceeded" in str(result)
+
+
+@pytest.mark.parametrize("max_attempts", [2, 5])
+def test_succeeds_when_the_last_allowed_attempt_wins(max_attempts: int) -> None:
+    # With one fewer lock error than the budget, fetch on the final attempt and succeed.
+    fetches = [_lock_err() for _ in range(max_attempts - 1)] + [_proc("git fetch", 0)]
+    result, *_ = _run(
+        [_proc("git cat-file", 1), *fetches],
+        max_attempts=max_attempts,
+    )
+    assert result is True
+
+
+def test_raises_immediately_on_non_lock_error() -> None:
+    result, exec_mock, sleep_mock, _ = _run(
+        [
+            _proc("git cat-file", 1),
+            _proc("git fetch", 128, b"fatal: remote hung up unexpectedly\n"),
+        ]
+    )
+    assert isinstance(result, RepositoryError)
+    assert "failed to fetch" in str(result)
+    assert exec_mock.await_count == 2
+    sleep_mock.assert_not_awaited()
+
+
+def test_removes_stale_lock() -> None:
+    # A `getmtime` far in the past triggers the stale-lock cleanup.
+    _, _, _, remove_mock = _run(
+        [_proc("git cat-file", 1), _proc("git fetch", 0)],
+        getmtime_side_effect=lambda _: 0.0,  # epoch == ancient
+    )
+    remove_mock.assert_called_once()
+    assert remove_mock.call_args.args[0].endswith("shallow.lock")
+
+
+def test_does_not_remove_fresh_lock() -> None:
+    _, _, _, remove_mock = _run(
+        [_proc("git cat-file", 1), _proc("git fetch", 0)],
+        getmtime_side_effect=lambda _: time.time(),
+    )
+    remove_mock.assert_not_called()
+
+
+def test_missing_lock_file_does_not_error() -> None:
+    # No `shallow.lock` present: `getmtime` raises FileNotFoundError,
+    # which the function swallows and proceeds to fetch normally.
+    result, exec_mock, _, remove_mock = _run(
+        [_proc("git cat-file", 1), _proc("git fetch", 0)]
+    )
+    assert result is True
+    assert exec_mock.await_count == 2
+    remove_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("rc", [128, 1])
+def test_unrelated_shallow_error_does_not_retry(rc: int) -> None:
+    # The stderr matcher looks for "shallow.lock" verbatim.
+    # An unrelated error containing only "shallow" must not trigger a retry.
+    result, _, sleep_mock, _ = _run(
+        [
+            _proc("git cat-file", 1),
+            _proc("git fetch", rc, b"fatal: shallow clone has no parent\n"),
+        ]
+    )
+    assert isinstance(result, RepositoryError)
+    sleep_mock.assert_not_awaited()


### PR DESCRIPTION
### Fix infinite retry loop in `update_from_ref`

This PR fixes an issue where `update_from_ref` could get stuck in an endless loop when a stale `shallow.lock` file exists or when git repeatedly returns shallow-related errors.

#### What’s changed
- Added a timeout while waiting for `shallow.lock` and clean it up if it looks stale
- Limited the number of retries for fetch attempts
- Added exponential backoff between retries
- Fixed logic so successful fetches with "shallow" warnings don’t trigger retries

#### Why this matters
Previously, this could cause evaluation workers to hang forever, blocking evaluation slots and stopping further processing. With these changes, the system will either recover or fail gracefully instead of getting stuck.