### PR TITLE
fix: unbreak API endpoint

### DIFF
--- a/src/shared/tests/test_api.py
+++ b/src/shared/tests/test_api.py
@@ -1,0 +1,57 @@
+from collections.abc import Callable
+
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from shared.models.cve import Container
+from shared.models.issue import (
+    NixpkgsIssue,
+)
+from shared.models.linkage import (
+    CVEDerivationClusterProposal,
+)
+
+
+def test_published_issue(
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    container1 = make_container(cve_id="CVE-2025-1111")
+    container2 = make_container(cve_id="CVE-2025-2222")
+    suggestion1 = make_cached_suggestion(
+        container=container1,
+        status=CVEDerivationClusterProposal.Status.PUBLISHED,
+    )
+    suggestion2 = make_cached_suggestion(
+        container=container2,
+        status=CVEDerivationClusterProposal.Status.PUBLISHED,
+    )
+
+    issue1 = NixpkgsIssue.create_nixpkgs_issue(suggestion1)
+    _ = NixpkgsIssue.create_nixpkgs_issue(suggestion2)
+    client = APIClient()
+    url = reverse("nixpkgsissue-list")
+
+    # All CVEs
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == 2
+
+    # A specific CVE
+    response = client.get(url, {"cve": container1.cve.cve_id})
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]["code"] == issue1.code
+    assert response.data[0]["cve"] == container1.cve.cve_id
+
+    # Multiple CVEs
+    response = client.get(
+        url, {"cve": f"{container1.cve.cve_id},{container2.cve.cve_id}"}
+    )
+    assert response.status_code == 200
+    assert len(response.data) == 2
+
+    # Non-existent CVE
+    response = client.get(url, {"cve": "CVE-9999-0000"})
+    assert response.status_code == 200
+    assert len(response.data) == 0

--- a/src/shared/views.py
+++ b/src/shared/views.py
@@ -13,7 +13,7 @@ class NixpkgsIssueViewSet(viewsets.ReadOnlyModelViewSet):
     class Filter(filters.FilterSet):
         cve = StringInFilter(
             label="Filter by CVEs referenced",
-            field_name="cve__cve_id",
+            field_name="suggestion__cve__cve_id",
             lookup_expr="in",
         )
 
@@ -25,8 +25,8 @@ class NixpkgsIssueViewSet(viewsets.ReadOnlyModelViewSet):
         status = serializers.CharField(source="get_status_display")
         cve = serializers.SerializerMethodField()
 
-        def get_cve(self, obj: NixpkgsIssue) -> list[str]:
-            return [cve.cve_id for cve in obj.cve.iterator()]
+        def get_cve(self, obj: NixpkgsIssue) -> str:
+            return obj.suggestion.cve.cve_id
 
         class Meta:
             model = NixpkgsIssue
@@ -35,5 +35,7 @@ class NixpkgsIssueViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = Filter
 
     permission_classes = [AllowAny]
-    queryset = NixpkgsIssue.objects.all()
+    queryset = NixpkgsIssue.objects.select_related(
+        "suggestion__cve",
+    ).all()
     serializer_class = Serializer


### PR DESCRIPTION
I'm opening this as a reply to #985  (which merging this PR will close #985). If we don't care about DRF and think we should get rid of it for now, this PR completely removes any DRF code, the broken view it's used in and removes it from the dependencies as well.