### PR TITLE
fix: don't match against unmaintained channels

### DIFF
--- a/src/shared/listeners/automatic_linkage.py
+++ b/src/shared/listeners/automatic_linkage.py
@@ -19,10 +19,7 @@ from django.db.models.functions import RowNumber
 from shared.channels import ContainerChannel
 from shared.models.cve import Container, Cpe
 from shared.models.linkage import CVEDerivationClusterProposal, ProvenanceFlags
-from shared.models.nix_evaluation import (
-    NixDerivation,
-    NixEvaluation,
-)
+from shared.models.nix_evaluation import MAJOR_CHANNELS, NixDerivation, NixEvaluation
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +28,14 @@ def produce_linkage_candidates(
     container: Container,
     filtered_affected: models.QuerySet,
 ) -> dict[NixDerivation, ProvenanceFlags]:
+    # FIXME(@fricklerhandwerk): This will fall apart when we obtain the channel structure dynamically [ref:channel-structure]
+    active_channels_q = Q()
+    for ch in MAJOR_CHANNELS:
+        active_channels_q |= Q(channel__channel_branch__contains=ch)
+
     latest_complete_channels = (
         NixEvaluation.objects.filter(
+            active_channels_q,
             state=NixEvaluation.EvaluationState.COMPLETED,
         )
         .annotate(

--- a/src/shared/tests/test_linkage.py
+++ b/src/shared/tests/test_linkage.py
@@ -80,6 +80,26 @@ def test_link_only_latest_eval(
     cache_new_suggestions(suggestion)
 
 
+def test_link_only_major_channels(
+    make_container: Callable[..., Container],
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    """
+    Derivations on channels outside MAJOR_CHANNELS must not produce matches.
+    Otherwise we'd be notifying people who aren't maintainers any more.
+    """
+    old_release = "24.05"
+    assert old_release not in MAJOR_CHANNELS
+    old_channel = make_channel(release=old_release)
+    old_eval = make_evaluation(channel=old_channel)
+    make_drv(pname="foo", evaluation=old_eval)
+
+    container = make_container(package_name="foo")
+    assert not build_new_links(container)
+
+
 @pytest.mark.parametrize(
     "package_name,product,drv_pname,expected_flags",
     [


### PR DESCRIPTION
Otherwise we'd be notifying people who aren't maintainers in active channels.

Closes #954