### PR TITLE
feat: View and edit deduplicated references

### DIFF
--- a/src/shared/github.py
+++ b/src/shared/github.py
@@ -116,7 +116,7 @@ def create_gh_issue(
         """
         Format active references from the cached suggestion for inclusion in GitHub issue.
         """
-        references = cached_suggestion.payload.get("categorized_references", {})
+        references = cached_suggestion.payload.get("categorized_url_references", {})
         active_refs = references.get("active", [])
 
         if not active_refs:

--- a/src/shared/listeners/cache_suggestions.py
+++ b/src/shared/listeners/cache_suggestions.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import re
 import urllib.parse
+from collections import defaultdict
 from datetime import datetime
 from itertools import chain
 from typing import Any, overload
@@ -18,7 +19,7 @@ from shared.models.linkage import (
     CVEDerivationClusterProposal,
     MaintainerOverlay,
     PackageOverlay,
-    ReferenceOverlay,
+    ReferenceUrlOverlay,
 )
 from shared.models.nix_evaluation import get_major_channel
 
@@ -102,22 +103,25 @@ class CachedSuggestion(BaseModel):
             "CachedSuggestion.Maintainer"
         ]  # Additional maintainers (not part of original maintainers)
 
-    class CategorizedReferences(BaseModel):
-        # FIXME(@florentc): Having to redefine a pydantic model instead of
-        # using the Django model is annoying. We should find a better solution
-        # for this and the rest in CachedSuggestion (e.g. packages, maintainers).
-        class Reference(BaseModel):
-            id: int
+    class CategorizedUrlReferences(BaseModel):
+        class UrlReference(BaseModel):
+            """
+            These references are in practice the equivalence classes for references wich share the same URL.
+            One object of this model may represent several references which share one URL, and whose tags are combined.
+            """
+
             url: str
             name: str
-            tags: list[str]
+            tags: set[str]
 
-        original: list[Reference]  # References initially present at suggestion creation
-        active: list[Reference]  # Non ignored references
-        ignored: list[Reference]  # Ignored references
+        original: list[
+            UrlReference
+        ]  # References initially present at suggestion creation
+        active: list[UrlReference]  # Non ignored references
+        ignored: list[UrlReference]  # Ignored references
 
     categorized_maintainers: CategorizedMaintainers
-    categorized_references: CategorizedReferences
+    categorized_url_references: CategorizedUrlReferences
 
 
 def apply_package_overlays(
@@ -238,8 +242,8 @@ def cache_new_suggestions(suggestion: CVEDerivationClusterProposal) -> None:
         packages=packages,
         metrics=[to_dict(m) for m in prefetched_metrics],
         categorized_maintainers=categorize_maintainers(packages, maintainer_overlays),
-        categorized_references=categorize_references(
-            suggestion.references, list(suggestion.reference_overlays.all())
+        categorized_url_references=categorize_url_references(
+            suggestion.references, list(suggestion.reference_url_overlays.all())
         ),
     )
 
@@ -439,44 +443,55 @@ def maintainers_list(
     return maintainers
 
 
-def categorize_references(
+def categorize_url_references(
     references: list[Reference],
-    reference_overlay: list[ReferenceOverlay],
-) -> CachedSuggestion.CategorizedReferences:
+    reference_url_overlays: list[ReferenceUrlOverlay],
+) -> CachedSuggestion.CategorizedUrlReferences:
     """
     Categorize references associated to a suggestion.
-    Assumes the references list has no duplicates.
+    Groups references by URL and combines their tags.
     """
 
-    original_references = [
-        CachedSuggestion.CategorizedReferences.Reference(
-            id=ref.id,
-            url=ref.url,
-            name=ref.name,
-            tags=[
-                tag.value for tag in ref.tags.all()
-            ],  # Assuming tags is a many-to-many field
-        )
-        for ref in references
-    ]
+    # Group by URL and combine names and tags
+    url_dict: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"name": None, "tags": set()}
+    )
+    for ref in references:
+        # We use the common name that references share (ignoring empty names).
+        # In case of mismatch, we fallback to an empty name.
+        if url_dict[ref.url]["name"] is None:
+            url_dict[ref.url]["name"] = ref.name
+        elif ref.name and url_dict[ref.url]["name"] != ref.name:
+            url_dict[ref.url]["name"] = ""
 
-    ignored_reference_ids = {
-        edit.reference.id
-        for edit in reference_overlay
-        if edit.type == ReferenceOverlay.Type.IGNORED
+        # Tags are merged
+        url_dict[ref.url]["tags"].update(tag.value for tag in ref.tags.all())
+
+    ignored_urls = {
+        o.reference_url
+        for o in reference_url_overlays
+        if o.type == ReferenceUrlOverlay.Type.IGNORED
     }
 
-    active_references = [
-        ref for ref in original_references if ref.id not in ignored_reference_ids
-    ]
-    ignored_references = [
-        ref for ref in original_references if ref.id in ignored_reference_ids
-    ]
+    original_url_references = []
+    active_url_references = []
+    ignored_url_references = []
 
-    return CachedSuggestion.CategorizedReferences(
-        original=original_references,
-        active=active_references,
-        ignored=ignored_references,
+    for url, data in url_dict.items():
+        ref = CachedSuggestion.CategorizedUrlReferences.UrlReference(
+            url=url, name=data["name"] or "", tags=data["tags"]
+        )
+        original_url_references.append(ref)
+
+        if url in ignored_urls:
+            ignored_url_references.append(ref)
+        else:
+            active_url_references.append(ref)
+
+    return CachedSuggestion.CategorizedUrlReferences(
+        original=original_url_references,
+        active=active_url_references,
+        ignored=ignored_url_references,
     )
 
 

--- a/src/shared/logs/events.py
+++ b/src/shared/logs/events.py
@@ -116,9 +116,8 @@ class RawMaintainerEvent(RawEvent):
         return False
 
 
-# NOTE(@florentc): A true reference has tags but this is just to keep track in the user displayed activity log
+# NOTE(@florentc): A true deduplicated reference has tags but this is just to keep track in the user displayed activity log
 class Reference(TypedDict):
-    id: int
     url: str
     name: str
 
@@ -137,7 +136,7 @@ class RawReferenceEvent(RawEvent):
             return False
 
         if isinstance(other, RawReferenceEvent):
-            return self.reference["id"] == other.reference["id"] and {
+            return self.reference["url"] == other.reference["url"] and {
                 self.action,
                 other.action,
             } == {

--- a/src/shared/logs/fetchers.py
+++ b/src/shared/logs/fetchers.py
@@ -27,7 +27,7 @@ from shared.models import (
     CVEDerivationClusterProposalStatusEvent,  # type: ignore
     MaintainerOverlayEvent,  # type: ignore
     PackageOverlayEvent,  # type: ignore
-    ReferenceOverlayEvent,  # type: ignore
+    ReferenceUrlOverlayEvent,  # type: ignore
 )
 from shared.models.linkage import CVEDerivationClusterProposal
 
@@ -119,7 +119,7 @@ def fetch_suggestion_events(
         )
 
     reference_qs = _annotate_username(
-        ReferenceOverlayEvent.objects.select_related("pgh_context", "reference").filter(
+        ReferenceUrlOverlayEvent.objects.select_related("pgh_context").filter(
             suggestion_id__in=suggestion_ids
         )
     )
@@ -131,9 +131,8 @@ def fetch_suggestion_events(
                 username=m_event.username,
                 action=m_event.pgh_label,
                 reference=Reference(
-                    id=m_event.reference.id,
-                    url=m_event.reference.url,
-                    name=m_event.reference.name,
+                    url=m_event.reference_url,
+                    name=m_event.deduplicated_name,
                 ),
             )
         )

--- a/src/shared/migrations/0081_remove_referenceoverlayevent_pgh_obj_and_more.py
+++ b/src/shared/migrations/0081_remove_referenceoverlayevent_pgh_obj_and_more.py
@@ -1,0 +1,129 @@
+import django.db.models.deletion
+import pgtrigger.compiler
+import pgtrigger.migrations
+from django.db import migrations, models
+from collections import defaultdict
+
+def migrate_reference_overlays(apps, schema_editor):
+    """
+    Migrate ReferenceOverlay data to ReferenceUrlOverlay.
+    This deduplicates ReferenceOverlays.
+    For a given suggestion, we introduce a ReferenceUrlOverlay only if there existed corresponding ReferenceOverlays for ALL the references sharing a given url.
+    """
+    ReferenceOverlay = apps.get_model('shared', 'ReferenceOverlay')
+    ReferenceUrlOverlay = apps.get_model('shared', 'ReferenceUrlOverlay')
+    Reference = apps.get_model('shared', 'Reference')
+    
+    # Group by (suggestion_id, url) to deduplicate while keeping track of original overlays
+    url_overlays = defaultdict(lambda: {"type": None, "deduplicated_name": "", "suggestion": None, "overlay_refs": set()})
+    
+    for overlay in ReferenceOverlay.objects.select_related('reference', 'suggestion'):
+        key = (overlay.suggestion.id, overlay.reference.url)
+        data = url_overlays[key]
+
+        data["overlay_refs"].add(overlay.reference.id) # type: ignore[attr-defined]
+        
+        if data["type"] is None:
+            # Set data from first overlay
+            data["type"] = overlay.type
+            data["deduplicated_name"] = overlay.reference.name
+            data["suggestion"] = overlay.suggestion
+        elif overlay.reference.name and data["deduplicated_name"] != overlay.reference.name:
+            # Empty name in case of name mismatches
+            data["deduplicated_name"] = ""
+    
+    # Creation of the reference url overlays
+    for (_, url), data in url_overlays.items():
+        # Get all references for this suggestion that have this URL
+        all_refs_with_url = set(Reference.objects.filter(
+            container__cve=data["suggestion"].cve, # type: ignore[attr-defined]
+            url=url
+        ).values_list('id', flat=True))
+        
+        # Only create the ignore ReferenceUrlOverlay if ALL references with this URL have overlays
+        if data["overlay_refs"] == all_refs_with_url:
+            ReferenceUrlOverlay.objects.create(
+                type=data["type"],
+                reference_url=url,
+                deduplicated_name=data["deduplicated_name"],
+                suggestion=data["suggestion"],
+            )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pghistory', '0007_auto_20250421_0444'),
+        ('shared', '0080_rename_edit_type_maintaineroverlay_overlay_type_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ReferenceUrlOverlay',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('type', models.CharField(choices=[('ignored', 'ignored')], max_length=126)),
+                ('reference_url', models.URLField(blank=True, max_length=2048)),
+                ('deduplicated_name', models.CharField(blank=True, max_length=512)),
+                ('suggestion', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='reference_url_overlays', to='shared.cvederivationclusterproposal')),
+            ],
+        ),
+
+        migrations.AddConstraint(
+            model_name='referenceurloverlay',
+            constraint=models.UniqueConstraint(fields=('suggestion', 'reference_url'), name='unique_reference_url_overlay_per_suggestion'),
+        ),
+
+        # Migrate data from old to new structure
+        migrations.RunPython(
+            migrate_reference_overlays,
+            # This migration is about deduplicating. Information will be lost and there is no way to reverse.
+        ),
+
+        migrations.CreateModel(
+            name='ReferenceUrlOverlayEvent',
+            fields=[
+                ('pgh_id', models.AutoField(primary_key=True, serialize=False)),
+                ('pgh_created_at', models.DateTimeField(auto_now_add=True)),
+                ('pgh_label', models.TextField(help_text='The event label.')),
+                ('id', models.BigIntegerField()),
+                ('type', models.CharField(choices=[('ignored', 'ignored')], max_length=126)),
+                ('reference_url', models.URLField(blank=True, max_length=2048)),
+                ('deduplicated_name', models.CharField(blank=True, max_length=512)),
+                ('pgh_context', models.ForeignKey(db_constraint=False, null=True, on_delete=django.db.models.deletion.DO_NOTHING, related_name='+', to='pghistory.context')),
+                ('pgh_obj', models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.DO_NOTHING, related_name='events', to='shared.referenceurloverlay')),
+                ('suggestion', models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.DO_NOTHING, related_name='+', related_query_name='+', to='shared.cvederivationclusterproposal')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+
+        migrations.RemoveField(
+            model_name='referenceoverlayevent',
+            name='pgh_obj',
+        ),
+        migrations.RemoveField(
+            model_name='referenceoverlayevent',
+            name='pgh_context',
+        ),
+        migrations.RemoveField(
+            model_name='referenceoverlayevent',
+            name='reference',
+        ),
+        migrations.RemoveField(
+            model_name='referenceoverlayevent',
+            name='suggestion',
+        ),
+
+        migrations.DeleteModel(
+            name='ReferenceOverlay',
+        ),
+        migrations.DeleteModel(
+            name='ReferenceOverlayEvent',
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name='referenceurloverlayevent',
+            trigger=pgtrigger.compiler.Trigger(name='append_only', sql=pgtrigger.compiler.UpsertTriggerSql(func="RAISE EXCEPTION 'pgtrigger: Cannot update or delete rows from % table', TG_TABLE_NAME;", hash='42ebeb9c48651b6e4e88c58a2a376aab61d19ceb', operation='UPDATE OR DELETE', pgid='pgtrigger_append_only_b33b2', table='shared_referenceurloverlayevent', when='BEFORE')),
+        ),
+    ]

--- a/src/shared/models/cached.py
+++ b/src/shared/models/cached.py
@@ -20,7 +20,7 @@ class CachedSuggestions(TimeStampMixin):
 
     @classproperty
     def CURRENT_SCHEMA_VERSION(cls) -> int:  # noqa: N802, N805
-        return 1
+        return 2
 
     proposal = models.OneToOneField(
         CVEDerivationClusterProposal,

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -183,9 +183,10 @@ class PackageOverlay(models.Model):
     pghistory.ManualEvent("reference.restore"),
     pghistory.ManualEvent("reference.ignore"),
 )
-class ReferenceOverlay(models.Model):
+class ReferenceUrlOverlay(models.Model):
     """
     A single manual overlay of the list of references of a suggestion.
+    These overlays are per url, so one overlay may apply to several references which share the same URL.
     """
 
     class Type(models.TextChoices):
@@ -193,10 +194,13 @@ class ReferenceOverlay(models.Model):
         # ADDITIONAL reserved for future use if needed
 
     type = models.CharField(max_length=126, choices=Type.choices)
-    reference = models.ForeignKey(Reference, on_delete=models.CASCADE)
+    reference_url = models.URLField(max_length=2048, blank=True)
+    deduplicated_name = models.CharField(
+        max_length=512, blank=True
+    )  # Used as a base for the activity log events
     suggestion = models.ForeignKey(
         CVEDerivationClusterProposal,
-        related_name="reference_overlays",
+        related_name="reference_url_overlays",
         on_delete=models.CASCADE,
     )
 
@@ -205,8 +209,8 @@ class ReferenceOverlay(models.Model):
             # Ensures that a reference can only be added or removed once per
             # suggestion.
             models.UniqueConstraint(
-                fields=["suggestion", "reference"],
-                name="unique_reference_overlay_per_suggestion",
+                fields=["suggestion", "reference_url"],
+                name="unique_reference_url_overlay_per_suggestion",
             )
         ]
 
@@ -269,42 +273,30 @@ def track_maintainer_overlay_delete(
     )
 
 
-@receiver(post_save, sender=ReferenceOverlay)
+@receiver(post_save, sender=ReferenceUrlOverlay)
 def track_reference_overlay_save(
-    sender: type[ReferenceOverlay],
-    instance: ReferenceOverlay,
+    sender: type[ReferenceUrlOverlay],
+    instance: ReferenceUrlOverlay,
     created: bool,
     **kwargs: Any,
 ) -> None:
     if created:
-        if instance.type == ReferenceOverlay.Type.IGNORED:
+        if instance.type == ReferenceUrlOverlay.Type.IGNORED:
             pghistory.create_event(
                 obj=instance,
                 label="reference.ignore",
             )
-        # TODO(@florentc): Adapt when ReferenceOverlay supports more than IGNORED
-        # if instance.type == ReferenceOverlay.Type.ADDITIONAL:
-        #     pghistory.create_event(
-        #         obj=instance,
-        #         label="reference.additional",
-        #     )
 
 
-@receiver(post_delete, sender=ReferenceOverlay)
+@receiver(post_delete, sender=ReferenceUrlOverlay)
 def track_reference_overlay_delete(
-    sender: type[ReferenceOverlay], instance: ReferenceOverlay, **kwargs: Any
+    sender: type[ReferenceUrlOverlay], instance: ReferenceUrlOverlay, **kwargs: Any
 ) -> None:
-    if instance.type == ReferenceOverlay.Type.IGNORED:
+    if instance.type == ReferenceUrlOverlay.Type.IGNORED:
         pghistory.create_event(
             obj=instance,
             label="reference.restore",
         )
-    # TODO(@florentc): Adapt when ReferenceOverlay supports more than IGNORED
-    # if instance.type == ReferenceOverlay.Type.ADDITIONAL:
-    #     pghistory.create_event(
-    #         obj=instance,
-    #         label="reference.delete",
-    #     )
 
 
 class ProvenanceFlags(IntFlag, boundary=STRICT):

--- a/src/webview/suggestions/context/types.py
+++ b/src/webview/suggestions/context/types.py
@@ -84,7 +84,7 @@ class ReferenceContext:
     # FIXME(@florentc): It'd be better to use the real `Reference` model but we
     # can't use it directly in cached suggestions (pydantic model). Cached
     # suggestions are the source of info to build these contexts.
-    reference: CachedSuggestion.CategorizedReferences.Reference
+    reference: CachedSuggestion.CategorizedUrlReferences.UrlReference
     status: ReferenceStatus
     frozen: bool
     is_compact: bool
@@ -227,8 +227,8 @@ class SuggestionContext:
         user_can_edit: bool,
         is_compact: bool,
     ) -> None:
-        categorized_references = self.suggestion.cached.payload[
-            "categorized_references"
+        categorized_url_references = self.suggestion.cached.payload[
+            "categorized_url_references"
         ]
         frozen = self.suggestion.is_frozen
 
@@ -241,7 +241,7 @@ class SuggestionContext:
                 suggestion_id=self.suggestion.pk,
                 is_compact=is_compact,
             )
-            for reference in categorized_references["active"]
+            for reference in categorized_url_references["active"]
         ]
 
         ignored_contexts = [
@@ -253,7 +253,7 @@ class SuggestionContext:
                 suggestion_id=self.suggestion.pk,
                 is_compact=is_compact,
             )
-            for reference in categorized_references["ignored"]
+            for reference in categorized_url_references["ignored"]
         ]
 
         self.reference_list_context = ReferenceListContext(

--- a/src/webview/suggestions/urls.py
+++ b/src/webview/suggestions/urls.py
@@ -77,12 +77,12 @@ urlpatterns = [
     ),
     # Reference operations
     path(
-        "by-id/<int:suggestion_id>/reference/ignore/<int:reference_id>/",
+        "by-id/<int:suggestion_id>/reference/ignore/",
         IgnoreReferenceView.as_view(),
         name="ignore_reference",
     ),
     path(
-        "by-id/<int:suggestion_id>/reference/restore/<int:reference_id>/",
+        "by-id/<int:suggestion_id>/reference/restore/",
         RestoreReferenceView.as_view(),
         name="restore_reference",
     ),

--- a/src/webview/suggestions/views/references.py
+++ b/src/webview/suggestions/views/references.py
@@ -3,19 +3,16 @@ from abc import ABC, abstractmethod
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 
-from shared.models.cve import Reference
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
-    ReferenceOverlay,
+    ReferenceUrlOverlay,
 )
 
 from .base import SuggestionContentEditBaseView
 
 
 class ReferenceOperationBaseView(SuggestionContentEditBaseView, ABC):
-    def post(
-        self, request: HttpRequest, suggestion_id: int, reference_id: int
-    ) -> HttpResponse:
+    def post(self, request: HttpRequest, suggestion_id: int) -> HttpResponse:
         """Handle reference operation requests."""
         # Check edition is allowed and get suggestion
         try:
@@ -28,14 +25,21 @@ class ReferenceOperationBaseView(SuggestionContentEditBaseView, ABC):
         except self.ForbiddenOperationError as e:
             return e.response
 
+        # Fetch the reference url to act upon
+        reference_url = request.POST.get("reference_url")
+        if not reference_url:
+            return self._handle_error(
+                request, suggestion_context, "Missing reference URL"
+            )
+
         # Validate the requested operation
-        validation_error = self._validate_operation(suggestion, reference_id)
+        validation_error = self._validate_operation(suggestion, reference_url)
         if validation_error:
             return self._handle_error(request, suggestion_context, validation_error)
 
         # Perform the specific operation
         try:
-            self._perform_operation(suggestion, reference_id)
+            self._perform_operation(suggestion, reference_url)
         except Exception:
             return self._handle_error(
                 request,
@@ -60,14 +64,14 @@ class ReferenceOperationBaseView(SuggestionContentEditBaseView, ABC):
 
     @abstractmethod
     def _perform_operation(
-        self, suggestion: CVEDerivationClusterProposal, reference_id: int
+        self, suggestion: CVEDerivationClusterProposal, reference_url: str
     ) -> None:
         """Perform the specific reference operation. To be implemented by subclasses."""
         pass
 
     @abstractmethod
     def _validate_operation(
-        self, suggestion: CVEDerivationClusterProposal, reference_id: int
+        self, suggestion: CVEDerivationClusterProposal, reference_url: str
     ) -> str | None:
         """Validate if the operation can be performed. Return error message or None."""
         pass
@@ -82,24 +86,26 @@ class IgnoreReferenceView(ReferenceOperationBaseView):
     """Ignore a reference that was automatically assigned to the suggestion."""
 
     def _validate_operation(
-        self, suggestion: CVEDerivationClusterProposal, reference_id: int
+        self, suggestion: CVEDerivationClusterProposal, reference_url: str
     ) -> str | None:
         """Validate that the reference can be ignored."""
         # Check if the reference exists in the original references
-        categorized_references = suggestion.cached.payload["categorized_references"]
-        original_references = categorized_references["original"]
+        categorized_url_references = suggestion.cached.payload[
+            "categorized_url_references"
+        ]
+        original_references = categorized_url_references["original"]
 
         # Find if this reference_id exists in original references
         reference_exists = any(
-            reference.get("id") == reference_id for reference in original_references
+            reference.get("url") == reference_url for reference in original_references
         )
 
         if not reference_exists:
             return "Reference not found in the suggestion"
 
         # Check if already ignored (has a IGNORED edit)
-        existing_edit = suggestion.reference_overlays.filter(
-            reference__id=reference_id, type=ReferenceOverlay.Type.IGNORED
+        existing_edit = suggestion.reference_url_overlays.filter(
+            reference_url=reference_url, type=ReferenceUrlOverlay.Type.IGNORED
         ).first()
 
         if existing_edit:
@@ -108,28 +114,32 @@ class IgnoreReferenceView(ReferenceOperationBaseView):
         return None
 
     def _perform_operation(
-        self, suggestion: CVEDerivationClusterProposal, reference_id: int
+        self, suggestion: CVEDerivationClusterProposal, reference_url: str
     ) -> None:
         with transaction.atomic():
-            # Get the reference object
-            reference = Reference.objects.get(id=reference_id)
+            # Get the deduplicated name from from the cached suggestion
+            cat_refs = suggestion.cached.payload["categorized_url_references"]
+            deduplicated_name = next(
+                i["name"] for i in cat_refs["original"] if i["url"] == reference_url
+            )
 
             # Create the reference edit
-            edit, created = suggestion.reference_overlays.get_or_create(
-                reference=reference,
-                defaults={"type": ReferenceOverlay.Type.IGNORED},
+            edit, created = suggestion.reference_url_overlays.get_or_create(
+                reference_url=reference_url,
+                deduplicated_name=deduplicated_name,
+                defaults={"type": ReferenceUrlOverlay.Type.IGNORED},
             )
-            if not created and edit.type != ReferenceOverlay.Type.IGNORED:
-                edit.type = ReferenceOverlay.Type.IGNORED
+            if not created and edit.type != ReferenceUrlOverlay.Type.IGNORED:
+                edit.type = ReferenceUrlOverlay.Type.IGNORED
                 edit.save()
 
             # Update the cached categorized references
-            cat_refs = suggestion.cached.payload["categorized_references"]
+            cat_refs = suggestion.cached.payload["categorized_url_references"]
             cat_refs["active"] = [
-                r for r in cat_refs["active"] if r["id"] != reference_id
+                r for r in cat_refs["active"] if r["url"] != reference_url
             ]
             if ref := next(
-                (r for r in cat_refs["original"] if r["id"] == reference_id), None
+                (r for r in cat_refs["original"] if r["url"] == reference_url), None
             ):
                 cat_refs["ignored"].append(ref)
 
@@ -144,24 +154,26 @@ class RestoreReferenceView(ReferenceOperationBaseView):
     """Restore a reference that was previously ignored."""
 
     def _validate_operation(
-        self, suggestion: CVEDerivationClusterProposal, reference_id: int
+        self, suggestion: CVEDerivationClusterProposal, reference_url: str
     ) -> str | None:
         """Validate that the reference can be restored."""
         # Check if the reference exists in the ignored references
-        categorized_references = suggestion.cached.payload["categorized_references"]
-        ignored_references = categorized_references["ignored"]
+        categorized_url_references = suggestion.cached.payload[
+            "categorized_url_references"
+        ]
+        ignored_references = categorized_url_references["ignored"]
 
         # Find if this reference_id exists in ignored references
         reference_exists = any(
-            reference.get("id") == reference_id for reference in ignored_references
+            reference.get("url") == reference_url for reference in ignored_references
         )
 
         if not reference_exists:
             return "Reference not found in ignored references"
 
         # Check if there's a IGNORED edit to restore (there should be one)
-        existing_edit = suggestion.reference_overlays.filter(
-            reference__id=reference_id, type=ReferenceOverlay.Type.IGNORED
+        existing_edit = suggestion.reference_url_overlays.filter(
+            reference_url=reference_url, type=ReferenceUrlOverlay.Type.IGNORED
         ).first()
 
         if not existing_edit:
@@ -170,22 +182,22 @@ class RestoreReferenceView(ReferenceOperationBaseView):
         return None
 
     def _perform_operation(
-        self, suggestion: CVEDerivationClusterProposal, reference_id: int
+        self, suggestion: CVEDerivationClusterProposal, reference_url: str
     ) -> None:
         with transaction.atomic():
             # Remove the IGNORED edit to restore the reference
-            suggestion.reference_overlays.get(
-                reference__id=reference_id,
-                type=ReferenceOverlay.Type.IGNORED,
+            suggestion.reference_url_overlays.get(
+                reference_url=reference_url,
+                type=ReferenceUrlOverlay.Type.IGNORED,
             ).delete()
 
             # Update the cached categorized references
-            cat_refs = suggestion.cached.payload["categorized_references"]
+            cat_refs = suggestion.cached.payload["categorized_url_references"]
             cat_refs["ignored"] = [
-                r for r in cat_refs["ignored"] if r["id"] != reference_id
+                r for r in cat_refs["ignored"] if r["url"] != reference_url
             ]
             if ref := next(
-                (r for r in cat_refs["original"] if r["id"] == reference_id), None
+                (r for r in cat_refs["original"] if r["url"] == reference_url), None
             ):
                 cat_refs["active"].append(ref)
 

--- a/src/webview/templates/suggestions/components/reference.html
+++ b/src/webview/templates/suggestions/components/reference.html
@@ -4,7 +4,7 @@
   {% if not data.frozen and data.user_can_edit %}
     <form class="contents"
           method="post"
-          action="{% if data.status.value == 'active' %}{% url 'webview:suggestion:ignore_reference' data.suggestion_id data.reference.id %}{% elif data.status.value == 'ignored' %}{% url 'webview:suggestion:restore_reference' data.suggestion_id data.reference.id %}{% endif %}"
+          action="{% if data.status.value == 'active' %}{% url 'webview:suggestion:ignore_reference' data.suggestion_id %}{% elif data.status.value == 'ignored' %}{% url 'webview:suggestion:restore_reference' data.suggestion_id %}{% endif %}"
           hx-boost="true"
           hx-target="#suggestion-{{ data.suggestion_id }}"
           hx-swap="outerHTML show:none"
@@ -15,6 +15,7 @@
       <input type="hidden"
              name="is_compact"
              value="{% if data.is_compact %}true{% else %}false{% endif %}">
+      <input type="hidden" name="reference_url" value="{{ data.reference.url }}">
       <button type="submit"
               class="btn {% if data.status.value == 'active' %}btn-gray{% else %}btn-green{% endif %} row gap-small centered">
         {% if data.status.value == 'active' %}

--- a/src/webview/templates/suggestions/components/reference_list.html
+++ b/src/webview/templates/suggestions/components/reference_list.html
@@ -22,7 +22,7 @@
         <ul id="suggestion-{{ data.suggestion_id }}-ignored-references"
             class="column gap-small">
           {% for reference_context in data.ignored %}
-            <li class="maintainer-container">{% reference reference_context %}</li>
+            <li>{% reference reference_context %}</li>
           {% endfor %}
         </ul>
       </details>

--- a/src/webview/tests/test_references.py
+++ b/src/webview/tests/test_references.py
@@ -104,6 +104,33 @@ def test_ignore_restore_references(
     expect(ignored_references).not_to_be_visible()
 
 
+def test_references_are_deduplicated(
+    live_server: LiveServer,
+    as_staff: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+    make_container: Callable[..., Container],
+) -> None:
+    """Test references are displayed deduplicated per url"""
+    container = make_container(
+        references=[
+            ("Foo", "https://foo.fake", ["tag1", "tag2"]),
+            ("Foo", "https://foo.fake", ["tag2", "tag3"]),
+            ("", "https://bar.fake", ["tag2", "tag3"]),
+        ]
+    )
+    suggestion = make_cached_suggestion(container=container)
+    as_staff.goto(live_server.url + reverse("webview:suggestion:untriaged_suggestions"))
+
+    references = as_staff.locator(f"#suggestion-{suggestion.pk}-references")
+    foo_references = references.get_by_text("Foo")
+    expect(foo_references).to_have_count(1)
+
+    foo_reference = references.get_by_role("listitem").filter(has_text="Foo")
+    expect(foo_reference.get_by_text("tag1")).to_be_visible()
+    expect(foo_reference.get_by_text("tag2")).to_be_visible()
+    expect(foo_reference.get_by_text("tag3")).to_be_visible()
+
+
 def test_ignore_reference_displayed_in_activity_log(
     live_server: LiveServer,
     as_staff: Page,


### PR DESCRIPTION
This PR addresses #876: now users view and edit references through the lens of deduplication.

On the model level, almost nothing changes in suggestions and references. A suggestion may have several references sharing the same url, like before.

On the UI side, users will only see one entry per duplicated group of reference. In other words, given the equivalence relation "having the same url", the users no longer see/edit references but the equivalence classes. When applicable, the common name is used, and the tags are merged.

To make it possible, `ReferenceOverlay` have been modified into `ReferenceUrlOverlay`. Overlays are characterized by the url in question, not by a single reference object. Computing the deduplicated references and applying the overlays is done in the cached suggestions (whose model version is bumped).

The db migration applies the deduplication as such:
- in a suggestion, if all references sharing the same url have a `ReferenceOverlay` (IGNORE), then a corresponding `ReferenceUrlOverlay` is introduced
- if some references of a given equivalence class have an overlay (aka are ignored) but not others, then we don't introduce a corresponding `ReferenceUrlOverlay` as it means the user may have just ignored a few of them to reduce visual clutter of duplication until now, with no intent to actually ignore the reference in question

This migration implies information loss so **it is irreversible**.
Migrating the events related to `ReferenceOverlay` isn't really possible (unclear semantics and hazardous implementation), therefore, reference edition events **are discarded**. This means reference ignore/restore from before this change will no longer appear in activity logs. This has been agreed as an acceptable loss with @fricklerhandwerk 
After merge, cached suggestions **will have to be regenerated**.