### PR TITLE
fix: Properly handle GH labels search query

### DIFF
--- a/src/webview/templatetags/viewutils.py
+++ b/src/webview/templatetags/viewutils.py
@@ -289,7 +289,7 @@ def maintainer_add(
 @register.simple_tag
 def gh_issues_url() -> str:
     base = f"https://github.com/{settings.GH_ORGANIZATION}/{settings.GH_ISSUES_REPO}/issues"
-    labels = " ".join(f'label:"{label!r}"' for label in settings.GH_ISSUES_LABELS)
+    labels = " ".join(f'label:"{label}"' for label in settings.GH_ISSUES_LABELS)
     query = f"is:issue state:open {labels}".strip()
     return f"{base}?{urlencode({'q': query})}"
 


### PR DESCRIPTION
The way this change was implemented in #1001 doesn't properly fix the label query, due to the `!r` we end up with an extra pair of single quotes.

```
>>> labels_now = " ".join(f'label:"{label!r}"' for label in [ "1.severity: security" ])
>>> labels_fixed = " ".join(f'label:"{label}"' for label in [ "1.severity: security" ])
>>> labels_now
'label:"\'1.severity: security\'"'
>>> labels_fixed
'label:"1.severity: security"'
```
The query then becomes https://github.com/NixOS/nixpkgs/issues?q=label%3A%22%271.severity%3A+security%27%22 which is incorrect.