### PR TITLE
feat: Events for creation (incl. auto dismiss reason) in activity log

### DIFF
--- a/src/shared/logs/batches.py
+++ b/src/shared/logs/batches.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from shared.logs.events import (
     Maintainer,
+    RawCreationEvent,
     RawEventType,
     RawMaintainerEvent,
     RawPackageEvent,
@@ -21,7 +22,14 @@ class FoldedEvent(BaseModel, ABC):
 
     suggestion_id: int
     timestamp: datetime  # Timestamp of the most recent event of the collection
-    username: str
+    username: str | None
+
+
+class FoldedCreationEvent(FoldedEvent):
+    """A folded creation event (always singular)."""
+
+    action: Literal["create"]
+    rejection_reason: str | None
 
 
 class FoldedStatusEvent(FoldedEvent):
@@ -58,7 +66,8 @@ class FoldedReferenceEvent(FoldedEvent):
 
 
 FoldedEventType = (
-    FoldedStatusEvent
+    FoldedCreationEvent
+    | FoldedStatusEvent
     | FoldedPackageEvent
     | FoldedMaintainerEvent
     | FoldedReferenceEvent
@@ -150,6 +159,17 @@ def batch_events(
                 folded_events.append(accumulator)
                 accumulator = None
 
+            # Add creation or status event (always singular)
+            if isinstance(event, RawCreationEvent):
+                folded_events.append(
+                    FoldedCreationEvent(
+                        suggestion_id=event.suggestion_id,
+                        timestamp=event.timestamp,
+                        username=event.username,
+                        action=event.action,
+                        rejection_reason=event.rejection_reason,
+                    )
+                )
             # Add status event (always singular)
             if isinstance(event, RawStatusEvent):
                 folded_events.append(

--- a/src/shared/logs/events.py
+++ b/src/shared/logs/events.py
@@ -11,7 +11,9 @@ class RawEvent(BaseModel, ABC):
 
     suggestion_id: int
     timestamp: datetime
-    username: str
+    # TODO(@florentc): there is no username for non-user initiated events.
+    # Maybe we'll want to have different types for user generated events and other events in the future.
+    username: str | None
 
     @abstractmethod
     def is_canceled_by(
@@ -35,6 +37,18 @@ class RawEvent(BaseModel, ABC):
             and (other.timestamp - self.timestamp).total_seconds()
             <= settings.DEBOUNCE_ACTIVITY_LOG_SECONDS
         )
+
+
+class RawCreationEvent(RawEvent):
+    """Raw suggestion creation event, with optional dismissal reason in case of auto-dismissal."""
+
+    username: str | None = None
+    action: Literal["create"] = "create"
+    rejection_reason: str | None
+
+    def is_canceled_by(self, other: "RawEvent") -> bool:
+        """Creation events are not cancellable"""
+        return False
 
 
 class RawStatusEvent(RawEvent):
@@ -147,7 +161,13 @@ class RawReferenceEvent(RawEvent):
         return False
 
 
-RawEventType = RawStatusEvent | RawPackageEvent | RawMaintainerEvent | RawReferenceEvent
+RawEventType = (
+    RawCreationEvent
+    | RawStatusEvent
+    | RawPackageEvent
+    | RawMaintainerEvent
+    | RawReferenceEvent
+)
 
 
 def sort_events_chronologically(events: list[RawEventType]) -> list[RawEventType]:

--- a/src/shared/logs/fetchers.py
+++ b/src/shared/logs/fetchers.py
@@ -16,6 +16,7 @@ from pghistory.models import EventQuerySet
 
 from shared.logs.events import (
     Maintainer,
+    RawCreationEvent,
     RawEventType,
     RawMaintainerEvent,
     RawPackageEvent,
@@ -64,6 +65,24 @@ def fetch_suggestion_events(
 
     if not suggestion_ids:
         return result
+
+    creation_qs = _annotate_username(
+        CVEDerivationClusterProposalStatusEvent.objects.select_related(
+            "pgh_context"
+        ).filter(pgh_label="insert", pgh_obj_id__in=suggestion_ids)
+    )
+    for creation_event in creation_qs.iterator():
+        result[creation_event.pgh_obj_id].append(
+            RawCreationEvent(
+                suggestion_id=creation_event.pgh_obj_id,
+                timestamp=creation_event.pgh_created_at,
+                rejection_reason=CVEDerivationClusterProposal.RejectionReason(
+                    creation_event.rejection_reason
+                ).label.__str__()
+                if creation_event.rejection_reason is not None
+                else None,
+            )
+        )
 
     status_qs = _annotate_username(
         CVEDerivationClusterProposalStatusEvent.objects.select_related("pgh_context")

--- a/src/webview/templates/components/suggestion_activity_log.html
+++ b/src/webview/templates/components/suggestion_activity_log.html
@@ -9,24 +9,30 @@
     <summary>
       <span class="details-closed">
         {% with last_entry=activity_log|last %}
-          <span class="activity-log-timestamp">updated {{ last_entry.timestamp|naturaltime }}</span>
-          by&nbsp;<strong>@{{ last_entry.username }}</strong>
+          <span class="activity-log-timestamp">
+            {% if last_entry.action == "create" %}
+              created
+            {% else %}
+              updated
+            {% endif %}
+          {{ last_entry.timestamp|naturaltime }}</span>
+          {% if last_entry.username %}by&nbsp;<strong>@{{ last_entry.username }}</strong>{% endif %}
         {% endwith %}
       </span>
       <strong class="details-open">Activity log</strong>
     </summary>
     <ul class="column align-end">
-      <li>
-        Created <span class="automatic-suggestion-text">automatic suggestion</span>
-        <span class="activity-log-entry-timestamp"
-              data-timestamp-relative="{{ suggestion.created_at|naturaltime }}"
-              data-timestamp-iso="{{ suggestion.created_at|iso }}">{{ suggestion.created_at|naturaltime }}</span>
-      </li>
       {% for log_entry in activity_log %}
         <li class="row gap-small baseline">
-          <strong>@{{ log_entry.username }}</strong>
+          {% if log_entry.username %}<strong>@{{ log_entry.username }}</strong>{% endif %}
           {# TODO(@adekoder) Refactor: the text value should come from the activity log context to aviod hardcoding #}
-          {% if "package." in log_entry.action %}
+          {% if log_entry.action == "create" %}
+            {% if log_entry.rejection_reason %}
+              Created & dismissed ({{ log_entry.rejection_reason }}) suggestion
+            {% else %}
+              Created suggestion
+            {% endif %}
+          {% elif "package." in log_entry.action %}
             {# Package update entries #}
             {% if ".restore" in log_entry.action %}
               restored
@@ -124,6 +130,13 @@
               <i class="icon-user-plus"></i>
             {% else %}
               <i class="icon-user-minus"></i>
+            {% endif %}
+          {% elif log_entry.action == "create" %}
+            {# For create, we display the "untriaged" icon by default, and the "dismissed" one in case of automatically rejected at creation #}
+            {% if log_entry.rejection_reason %}
+              <i class="icon-bin"></i>
+            {% else %}
+              <i class="icon-inbox"></i>
             {% endif %}
           {% else %}
             {% if "accepted" in log_entry.status_value %}

--- a/src/webview/tests/test_activity_log.py
+++ b/src/webview/tests/test_activity_log.py
@@ -168,7 +168,7 @@ def test_restore_maintainer_cancels_event_in_activity_log(
         expect(removed_maintainer).to_be_visible()
         expect(added_maintainer).to_be_visible()
     else:
-        expect(activity_log).to_have_count(0)
+        expect(activity_log).to_have_count(1)  # 1 being the creation event
 
 
 def test_multiple_maintainer_edits_are_batched_in_activity_log(
@@ -274,3 +274,25 @@ def test_maintainer_edits_by_different_users_not_batched(
             .filter(has_text=maintainer2.github)
         )
         expect(added_maintainer2).to_be_visible()
+
+
+def test_automatic_rejection_reason_displayed(
+    live_server: LiveServer,
+    as_staff: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Test that automatically dismissed suggestion at creation show the event and reason in their activity log"""
+    db_cached_suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+        rejection_reason=CVEDerivationClusterProposal.RejectionReason.EXCLUSIVELY_HOSTED_SERVICE,
+    )
+    as_staff.goto(live_server.url + reverse("webview:suggestion:dismissed_suggestions"))
+    suggestion = as_staff.locator(f"#suggestion-{db_cached_suggestion.pk}")
+    activity_log = suggestion.locator(
+        f"#suggestion-activity-log-{db_cached_suggestion.pk}"
+    )
+    activity_log.click()
+    entry = activity_log.filter(has_text="Created & dismissed").filter(
+        has_text=CVEDerivationClusterProposal.RejectionReason.EXCLUSIVELY_HOSTED_SERVICE.label.__str__()
+    )
+    expect(entry).to_be_visible()


### PR DESCRIPTION
This addresses #875 

In activity log, creation events used to be fake. We were hardwriting "Created automatic suggestion" and using the creation date of the suggestion.

This PR introduces real events for suggestion creation in the activity log data structure.

These events have an optional `rejection_reason` in case the events are created as already dismissed.

In that case, the reason is displayed in the activity log.

The text for creation event is shortened as it makes it more obvious when an automatic rejection happened, and it avoids display glitches when the line gets too long with the date & rejection reason.

Creation events are the first events without an attached user. It is now possible to have other events without a user. Type wise, this may have to be reworked if this becomes more than an anecdotal need.

### An automatically dismissed suggestion

<img width="1118" height="139" alt="2026-04-21 15-59-54" src="https://github.com/user-attachments/assets/9500686d-85de-4c1a-9745-956f6eb79f16" />

### A manually dismissed suggestion

<img width="1108" height="129" alt="2026-04-21 16-00-03" src="https://github.com/user-attachments/assets/7edded6c-d84f-4988-8edc-64580e67badf" />
