### PR TITLE
perf: only evaluate one system

### DIFF
--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -52,8 +52,17 @@ async def perform_evaluation(
     the execution runtime.
     """
     # TODO(raitobezarius): bring a Nix code generator, that'd be cuter.
-    nixpkgs_config = "{ config = { allowUnfree = true; inHydra = false; allowInsecurePredicate = (_: true); scrubJobs = false; }; };"
-    evaluation_wrapper = f"(import <nixpkgs/pkgs/top-level/release.nix> {{ nixpkgsArgs = {nixpkgs_config} }})"
+    nixpkgs_config = """
+    {
+      config = {
+        allowUnfree = true;
+        inHydra = false;
+        allowInsecurePredicate = (_: true);
+        scrubJobs = false;
+      };
+    }
+    """
+    evaluation_wrapper = f"(import <nixpkgs/pkgs/top-level/release.nix> {{ nixpkgsArgs = {nixpkgs_config}; }})"
     arguments = [
         "--force-recurse",
         "--meta",

--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -59,6 +59,7 @@ async def perform_evaluation(
         inHydra = false;
         allowInsecurePredicate = (_: true);
         scrubJobs = false;
+        supportedSystems = [ "x86_64-linux" ];
       };
     }
     """


### PR DESCRIPTION
This may lose some coverage, as it won't catch packages that only exist on the other platforms.
But it reduces evaluation time and storage consuption to 1/4.

@NixOS/security would that constitute a notable negative impact for your purposes?