### PR TITLE
fix: disable setting custom email address for now

### DIFF
--- a/src/webview/subscriptions/views.py
+++ b/src/webview/subscriptions/views.py
@@ -230,6 +230,9 @@ class SetNotificationEmailView(LoginRequiredMixin, TemplateView):
     template_name = "subscriptions/components/email_setter.html"
 
     def post(self, request: HttpRequest) -> HttpResponse:
+        # FIXME(@fricklerhandwerk): Verify ownership first.
+        return self._handle_error(request, "Setting email not implemented")
+
         email = request.POST.get("email", "")
 
         profile = request.user.profile

--- a/src/webview/templates/subscriptions/subscriptions_center.html
+++ b/src/webview/templates/subscriptions/subscriptions_center.html
@@ -30,7 +30,7 @@
 
       {% email_notifications_toggler user.profile.receive_email_notifications %}
 
-      {% email_setter notification_email=user.profile.notification_email maintainer_email=user.profile.maintainer_email %}
+      {# email_setter notification_email=user.profile.notification_email maintainer_email=user.profile.maintainer_email #}
     </div>
 
   </div>

--- a/src/webview/tests/test_subscriptions.py
+++ b/src/webview/tests/test_subscriptions.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Callable
 
+import pytest
 from django.contrib.auth.models import User
 from django.urls import reverse
 from playwright.sync_api import Page, expect
@@ -243,6 +244,7 @@ def test_maintainer_notification_many_packages_in_suggestion(
     assert notification.user == user
 
 
+@pytest.mark.xfail(reason="Not implemented")
 def test_email_notifications(
     live_server: LiveServer,
     staff: User,


### PR DESCRIPTION
At the moment the worst that could happen is that NixOS GitHub org members would be able to send notifications on their behalf and with their name to unsuspecting third parties.
That's still undesirable to allow in the first place.
Once any GitHub user can log in with the system, there won't be quick and easy way to stop abuse.
And in any case that would be easiest to avoid by verifying address ownership.