### PR TITLE
feat: GET /api/v1/suggestions/{id}/status

### DIFF
--- a/src/api/suggestions/views.py
+++ b/src/api/suggestions/views.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.permissions import AllowAny, BasePermission, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -31,6 +31,17 @@ class SuggestionViewSet(viewsets.GenericViewSet):
 
     queryset = CVEDerivationClusterProposal.objects.all()
     permission_classes = [IsAuthenticated, CanEditSuggestion]
+
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="status",
+        serializer_class=StatusSerializer,
+        permission_classes=[AllowAny],
+    )
+    def status(self, request: Request, pk: int) -> Response:
+        instance = self.get_object()
+        return Response(self.get_serializer(instance).data)
 
     @action(detail=True, methods=["post"], serializer_class=StatusSerializer)
     def change_status(self, request: Request, pk: int) -> Response:

--- a/src/api/tests/test_suggestion_status.py
+++ b/src/api/tests/test_suggestion_status.py
@@ -87,3 +87,54 @@ def test_suggestion_change_state(
         assert error in response.text
     else:
         assert response.data == {"status": to_status} | post_data
+
+
+def test_suggestion_status_get_anonymous_pending(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    client = APIClient()
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    response = client.get(f"/api/v1/suggestions/{suggestion.pk}/status")
+    assert response.status_code == 200
+    assert response.data == {"status": CVEDerivationClusterProposal.Status.PENDING}
+
+
+def test_suggestion_status_get_anonymous_not_found(db: None) -> None:
+    client = APIClient()
+    response = client.get("/api/v1/suggestions/999999999/status")
+    assert response.status_code == 404
+
+
+def test_suggestion_status_get_rejected_includes_reason(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    client = APIClient()
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+        rejection_reason=CVEDerivationClusterProposal.RejectionReason.NOT_IN_NIXPKGS,
+    )
+    response = client.get(f"/api/v1/suggestions/{suggestion.pk}/status")
+    assert response.status_code == 200
+    assert response.data == {
+        "status": CVEDerivationClusterProposal.Status.REJECTED,
+        "rejection_reason": CVEDerivationClusterProposal.RejectionReason.NOT_IN_NIXPKGS,
+    }
+
+
+def test_suggestion_status_get_includes_comment_when_set(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    client = APIClient()
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.ACCEPTED
+    )
+    suggestion.comment = "triager note"
+    suggestion.save(update_fields=["comment"])
+    response = client.get(f"/api/v1/suggestions/{suggestion.pk}/status")
+    assert response.status_code == 200
+    assert response.data == {
+        "status": CVEDerivationClusterProposal.Status.ACCEPTED,
+        "comment": "triager note",
+    }


### PR DESCRIPTION
Adds a public read-only endpoint that returns the same triage fields as change_status (status, optional rejection_reason, optional comment). POST /change_status is unchanged (still authenticated committers/staff). Includes API tests for success, 404, rejected payload, and comment.

Related to #1024 