### PR TITLE
feat: get issue by code in API

### DIFF
--- a/src/api/issues/views.py
+++ b/src/api/issues/views.py
@@ -1,6 +1,10 @@
+from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
 from rest_framework import serializers, viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from shared.models import NixpkgsIssue
 
@@ -39,3 +43,12 @@ class NixpkgsIssueViewSet(viewsets.ReadOnlyModelViewSet):
         "suggestion__cve",
     ).all()
     serializer_class = Serializer
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path=r"by-code/(?P<code>NIXPKGS-[0-9]{4}-[0-9]{4,19})",
+    )
+    def by_code(self, request: Request, code: str) -> Response:
+        issue = get_object_or_404(self.get_queryset(), code=code)
+        return Response(self.get_serializer(issue).data)

--- a/src/api/tests/test_issues.py
+++ b/src/api/tests/test_issues.py
@@ -4,31 +4,18 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
 from shared.models.cve import Container
-from shared.models.issue import (
-    NixpkgsIssue,
-)
-from shared.models.linkage import (
-    CVEDerivationClusterProposal,
-)
+from shared.models.issue import NixpkgsIssue
 
 
-def test_published_issue(
+def test_list_issues_by_cve(
     make_container: Callable[..., Container],
-    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+    make_issue: Callable[..., NixpkgsIssue],
 ) -> None:
     container1 = make_container(cve_id="CVE-2025-1111")
     container2 = make_container(cve_id="CVE-2025-2222")
-    suggestion1 = make_cached_suggestion(
-        container=container1,
-        status=CVEDerivationClusterProposal.Status.PUBLISHED,
-    )
-    suggestion2 = make_cached_suggestion(
-        container=container2,
-        status=CVEDerivationClusterProposal.Status.PUBLISHED,
-    )
+    issue1 = make_issue(container=container1)
+    make_issue(container=container2)
 
-    issue1 = NixpkgsIssue.create_nixpkgs_issue(suggestion1)
-    _ = NixpkgsIssue.create_nixpkgs_issue(suggestion2)
     client = APIClient()
     url = reverse("nixpkgsissue-list")
 

--- a/src/api/tests/test_issues.py
+++ b/src/api/tests/test_issues.py
@@ -42,3 +42,21 @@ def test_list_issues_by_cve(
     response = client.get(url, {"cve": "CVE-9999-0000"})
     assert response.status_code == 200
     assert len(response.data) == 0
+
+
+def test_issue_detail_by_code(
+    make_container: Callable[..., Container],
+    make_issue: Callable[..., NixpkgsIssue],
+) -> None:
+    container = make_container(cve_id="CVE-2025-1111")
+    issue = make_issue(container=container)
+    client = APIClient()
+
+    detail_url = reverse("nixpkgsissue-by-code", kwargs={"code": issue.code})
+    response = client.get(detail_url)
+    assert response.status_code == 200
+    assert response.data["code"] == issue.code
+    assert response.data["cve"] == container.cve.cve_id
+
+    missing_url = reverse("nixpkgsissue-by-code", kwargs={"code": "NIXPKGS-2099-99999"})
+    assert client.get(missing_url).status_code == 404

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -24,6 +24,7 @@ from shared.models.cve import (
     Tag,
     Version,
 )
+from shared.models.issue import NixpkgsIssue
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
     DerivationClusterProposalLink,
@@ -348,6 +349,26 @@ def cached_suggestion(
     cache_new_suggestions(suggestion)
 
     return suggestion
+
+
+@pytest.fixture
+def make_issue(
+    cve: Container,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> Callable[..., NixpkgsIssue]:
+    def wrapped(container: Container = cve) -> NixpkgsIssue:
+        suggestion = make_cached_suggestion(
+            container=container,
+            status=CVEDerivationClusterProposal.Status.PUBLISHED,
+        )
+        return NixpkgsIssue.create_nixpkgs_issue(suggestion)
+
+    return wrapped
+
+
+@pytest.fixture
+def issue(make_issue: Callable[..., NixpkgsIssue]) -> NixpkgsIssue:
+    return make_issue()
 
 
 @pytest.fixture


### PR DESCRIPTION
Issue detail is now GET `/api/v1/issues/<code>/` where `<code>` matches the web (NIXPKGS-YYYY-NNNN, same regex as the UI). List behaviour and filters are unchanged.

**Breaking Change** : detail no longer accepts the numeric primary key in the URL. Update callers to use `code`.

Related to #1024 

