### PR TITLE
chore: update infra repo and migrate ssh keys reference

### DIFF
--- a/infra/common.nix
+++ b/infra/common.nix
@@ -57,7 +57,7 @@ in
       ];
       # We're using both keys and keyFiles here in order to keep some alignment
       # with github:nixos/infra
-      openssh.authorizedKeys.keys = (import "${sources.infra}/ssh-keys.nix").infra;
+      openssh.authorizedKeys.keys = (import "${sources.infra}/keys.nix").ssh.groups.infra;
     };
 
   environment.systemPackages = with pkgs; [

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -50,9 +50,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "3f4291c4dddb67f605778f67ac3d9e4d2b690e7f",
-      "url": "https://github.com/nixos/infra/archive/3f4291c4dddb67f605778f67ac3d9e4d2b690e7f.tar.gz",
-      "hash": "sha256-lDzsr7QneUxbGfrruz02Rf4hu+0RX8AMg9uQPp2aYmc="
+      "revision": "2f6f4f1234455fdb68d05a885ad83693f0d7e6d0",
+      "url": "https://github.com/nixos/infra/archive/2f6f4f1234455fdb68d05a885ad83693f0d7e6d0.tar.gz",
+      "hash": "sha256-yePsSQMVblYQdCgwaTuxpROojdPjXzH+ONmHeFVv2RI="
     },
     "nixpkgs": {
       "type": "Channel",


### PR DESCRIPTION
Follow-up to keys restructuring in infra repo.

https://github.com/NixOS/infra/pull/1032