### PR TITLE
fix: ensure maintainers only from tip of branch get maintainer status

### DIFF
--- a/src/shared/auth/utils.py
+++ b/src/shared/auth/utils.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.conf import settings
+from django.db.models import F
 
 from shared.models import NixMaintainer
 
@@ -16,7 +17,10 @@ def iscommitter(user: Any) -> bool:
 
 def ismaintainer(user: Any) -> bool:
     return NixMaintainer.objects.filter(
-        github_id=user.socialaccount_set.get(provider="github").uid
+        github_id=user.socialaccount_set.get(provider="github").uid,
+        nixderivationmeta__derivation__parent_evaluation__commit_sha1=F(
+            "nixderivationmeta__derivation__parent_evaluation__channel__head_sha1_commit"
+        ),
     ).exists()
 
 

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -168,10 +168,13 @@ def make_evaluation(
         channel: NixChannel = channel,
         state: NixEvaluation.EvaluationState = NixEvaluation.EvaluationState.COMPLETED,
         age: timedelta = timedelta(0),
+        commit_sha1: str | None = None,
     ) -> NixEvaluation:
         evaluation = NixEvaluation.objects.create(
             channel=channel,
-            commit_sha1=secrets.token_hex(16),
+            commit_sha1=commit_sha1
+            if commit_sha1 is not None
+            else secrets.token_hex(16),
             state=state,
         )
 

--- a/src/shared/tests/test_auth.py
+++ b/src/shared/tests/test_auth.py
@@ -1,0 +1,33 @@
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from django.contrib.auth.models import User
+
+from shared.auth.utils import ismaintainer
+from shared.models.nix_evaluation import NixChannel
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(("at_tip", "expected"), [(True, True), (False, False)])
+def test_ismaintainer_respects_channel_tip(
+    at_tip: bool,
+    expected: bool,
+    user: User,
+    channel: NixChannel,
+    make_evaluation: Callable[..., Any],
+    make_drv: Callable[..., Any],
+    make_maintainer_from_user: Callable[..., Any],
+) -> None:
+    evaluation = make_evaluation(
+        channel=channel,
+        commit_sha1=channel.head_sha1_commit if at_tip else None,  # otherwise random
+    )
+    make_drv(evaluation=evaluation, maintainer=make_maintainer_from_user(user))
+    assert ismaintainer(user) is expected
+
+
+@pytest.mark.django_db
+def test_ismaintainer_false_for_non_maintainer(user: User) -> None:
+    # user has no maintainer row at all
+    assert ismaintainer(user) is False


### PR DESCRIPTION
Closes #627 

Previously, `ismaintainer()` checked if a user's GitHub ID existed anywhere in global `NixMaintainer` table resulting in giving perms to anyone who was ever a maintainer. 

This pr modifies `ismaintainer` to ensure that only maintainer who are actively linked to pkg at tip of tracked channel .