### PR TITLE
fix: automatically create nixpkgs directory 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,10 +167,10 @@ To replicate this on a traditional Unix-like system:
 ### Start the service
 
 > [!NOTE]
-> For a quick start, create dummy credentials:
+> For a quick start, create dummy credentials and a Nixpkgs clone directory:
 >
 > ```console
-> dummy-credentials
+> shell-config-placeholder
 > ```
 >
 > Logging in and publishing issues requires [setting up credentials](#setting-up-credentials).

--- a/default.nix
+++ b/default.nix
@@ -62,13 +62,15 @@ rec {
       '';
       # Run this for a quick start.
       # Login and publishing issues requires setting up credentials properly.
-      dummy-credentials = pkgs.writeShellApplication {
-        name = "dummy-credentials";
+      shell-config-placeholder = pkgs.writeShellApplication {
+        name = "shell-config-placeholder";
         runtimeInputs = [ pkgs.python3 ];
         text = ''
-          dir="${toString ./.credentials}"
-          mkdir -p "$dir"
-          cd "$dir"
+          credentialsDir="${toString ./.credentials}"
+          nixpkgsDir="${toString ./nixpkgs}"
+          mkdir -p "$credentialsDir"
+          mkdir -p "$nixpkgsDir"
+          cd "$credentialsDir"
           set -o noclobber
           python3 -c 'import secrets; print(secrets.token_hex(100))' > SECRET_KEY
           echo bar > GH_CLIENT_ID
@@ -111,7 +113,7 @@ rec {
       };
 
       packages = [
-        dummy-credentials
+        shell-config-placeholder
         manage
         package
         # Explicitly pin git from nixpkgs to ensure the `fetch_all_channels` management command
@@ -138,6 +140,8 @@ rec {
           };
         }).shellHook
         }
+
+        shell-config-placeholder
 
         ln -sf ${sources.htmx}/dist/htmx.js src/webview/static/htmx.min.js
 


### PR DESCRIPTION
resolves #1026 

- renames `dummy-credentials` to `shell-config-placeholder` (both nix shell and docs) 
- this command would now also create `nixpkgs` dir.
- move `USER_SETTINGS_FILE` to `env` from `shellhook export` 

Some thoughts i'd like to share ... 
- Atm we create `settings.py` file inside shellhook, so I was thinking it would be better to move that too inside the `shell-config-placeholder` 
- maybe rename `shell-config-placeholder` to something like `quickstart` or `bootstrap` or `setup-local-env` ... something like it ? 
