### PR TITLE
refactor: replace nixfmt-rfc-style with nixfmt

### DIFF
--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -19,7 +19,7 @@ rec {
     in
     lib.mapAttrs (_: v: v // { inherit stages; }) {
       # Nix setup
-      nixfmt-rfc-style.enable = true;
+      nixfmt.enable = true;
       statix = {
         enable = true;
         # XXX(@fricklerhandwerk): statix for some reason needs its own ignores repeated...


### PR DESCRIPTION
resolves #1042 

- replaces `nixfmt-rfc-style` in pre-commit hook with `nixfmt`