### PR TITLE
perf: don't write `.drv` files on evaluation

### DIFF
--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -59,6 +59,7 @@ async def perform_evaluation(
         "--meta",
         "--repair",
         "--quiet",
+        "--no-instantiate",
         "--expr",
         evaluation_wrapper,
         "--include",


### PR DESCRIPTION
Apparently they're written unconditionally by some code path in `nix-eval-jobs` even if not needed for anything specific.

Closes #1047