### PR TITLE
test: send notification explicitly

### DIFF
--- a/src/shared/tests/test_notifications.py
+++ b/src/shared/tests/test_notifications.py
@@ -2,18 +2,19 @@ from collections.abc import Callable
 
 from django.contrib.auth.models import User
 
+from shared.models.linkage import CVEDerivationClusterProposal, ProvenanceFlags
 from shared.models.nix_evaluation import (
     NixDerivation,
     NixMaintainer,
 )
-from webview.models import Notification
+from shared.notify_users import create_package_subscription_notifications
 
 
 def test_github_username_changed(
     user: User,
     make_maintainer_from_user: Callable[..., NixMaintainer],
     make_drv: Callable[..., NixDerivation],
-    make_package_notification: Callable[..., list[Notification]],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
 ) -> None:
     """
     Check that notifications get sent even if the user's GitHub handle changed after first login.
@@ -23,5 +24,7 @@ def test_github_username_changed(
     # GitHub username could have changed between evaluations.
     maintainer.github = maintainer.github + "-new"
     maintainer.save()
-    notifications = make_package_notification(drv)
+
+    suggestion = make_cached_suggestion(drvs={drv: ProvenanceFlags.PACKAGE_NAME_MATCH})
+    notifications = create_package_subscription_notifications(suggestion)
     assert notifications


### PR DESCRIPTION
This allows more clearly expressing that we're modeling the fixtures after how ingestion works.

Note how `make_drv` now gets "parsed data" including the metadata.
It adds the separate homepage and description rows, and then completes the derivation.