### PR TITLE
docs: correct evaluation data flow in architecture diagram

### DIFF
--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -44,7 +44,7 @@ graph TB
     FetchAllChannels -->|2 Git pull| GitHubNixos
     FetchAllChannels -->|3 Update Repo| LocalGitCheckout
     FetchAllChannels -->|4 update channels| PostgreSQL
-    PostgreSQL -.->|NixEvaluationChannel NOTIFY| NixEval
+    FetchAllChannels -.->|triggers evaluation| NixEval
     NixEval -->|ingest derivations| PostgreSQL
 
     SystemdTimerCVEs -.->|Triggers Daily| IngestCVEs

--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -43,7 +43,9 @@ graph TB
     FetchAllChannels -->|1 Fetch Channels| NixMonitoring
     FetchAllChannels -->|2 Git pull| GitHubNixos
     FetchAllChannels -->|3 Update Repo| LocalGitCheckout
-    FetchAllChannels -->|4 Evaluate Nix| NixEval --> NixStore
+    FetchAllChannels -->|4 update channels| PostgreSQL
+    PostgreSQL -.->|NixEvaluationChannel NOTIFY| NixEval
+    NixEval -->|ingest derivations| PostgreSQL
 
     SystemdTimerCVEs -.->|Triggers Daily| IngestCVEs
     IngestCVEs -->|1 Fetch CVEs| GitHubCVEs

--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -22,7 +22,7 @@ graph TB
 	  subgraph Background["Background Tasks"]
 		  SystemdTimerChannels["Systemd Timer Fetch Channels"]
 		  SystemdTimerCVEs["Systemd Timer Ingest CVEs"]
-          NixEval["Evaluate Nix"]
+          NixEval["Evaluate Nixpkgs"]
           DjangoWorker["Django worker"]
 	  end
 


### PR DESCRIPTION
Topologically sorted 2nd change:

**Removed**: 
FetchAllChannels -->|4 Evaluate Nix| NixEval --> NixStore

**Added**:

FetchAllChannels -->|4 update channels| PostgreSQL # **channel updates from the command**
PostgreSQL -.->|NixEvaluationChannel NOTIFY| NixEval # **async trigger via pgpubsub**
NixEval -->|ingest derivations| PostgreSQL # **evaluation writes derivations to the DB**

Related to #931 