### PR TITLE
docs: show CVE ingestion triggers matching in architecture diagram

### DIFF
--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -23,7 +23,7 @@ graph TB
 		  SystemdTimerChannels["Systemd Timer Fetch Channels"]
 		  SystemdTimerCVEs["Systemd Timer Ingest CVEs"]
           NixEval["Evaluate Nixpkgs"]
-          DjangoWorker["Django worker"]
+          MatchingListener["CVE matching"]
 	  end
 
 	  subgraph Storage["Storage"]
@@ -50,7 +50,7 @@ graph TB
     SystemdTimerCVEs -.->|Triggers Daily| IngestCVEs
     IngestCVEs -->|1 Fetch CVEs| GitHubCVEs
     IngestCVEs -->|2 Update Database| PostgreSQL
-    IngestCVEs -->|3 PgTrigger Suggestions| DjangoWorker
+    IngestCVEs -.->|3 triggers matching| MatchingListener
 
   classDef userClass fill:#e1f5fe,stroke:#01579b,stroke-width:3px,color:#000
     classDef externalClass fill:#f3e5f5,stroke:#4a148c,stroke-width:3px,color:#000
@@ -64,6 +64,6 @@ graph TB
     class GitHub,GitHubNixos,GitHubCVEs,NixMonitoring externalClass
     class Nginx,WSGI webClass
     class FetchAllChannels,IngestCVEs commandClass
-    class SystemdTimerChannels,SystemdTimerCVEs,NixEval,DjangoWorker backgroundClass
+    class SystemdTimerChannels,SystemdTimerCVEs,NixEval,MatchingListener backgroundClass
     class PostgreSQL,LocalGitCheckout,NixStore storageClass
     class Storage,Background,ManageCommands,Web subgraphClass


### PR DESCRIPTION
- Updated the CVE ingestion flow in `docs/architecture.mermaid` to reflect matching behavior.
- Renamed the generic background node from `Django worker` to `CVE matching`.
- Replaced `IngestCVEs -->|3 PgTrigger Suggestions| ...` with a dotted `IngestCVEs -.->|3 triggers matching| ...` edge to match the diagram abstraction used in the evaluation flow.

### Why

The previous edge implied a vague worker step and implementation detail wording. This change makes the architecture diagram more accurate at the same abstraction level as the rest of the diagram: CVE ingestion triggers matching.

Related to #931 