### PR TITLE
docs: add architecture diagram implementation map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,21 @@ The Nixpkgs vulnerability tracker consists of
 
 ![Service architecture diagram](./architecture.mermaid)
 
+## Diagram to implementation map
+
+Maps each labeled diagram component to its implementation.
+
+- [fetch_all_channels](../src/shared/management/commands/fetch_all_channels.py)
+- [ingest_delta_cve](../src/shared/management/commands/ingest_delta_cve.py)
+- [Evaluate Nixpkgs](../src/shared/listeners/nix_evaluation.py)
+- [CVE matching](../src/shared/listeners/automatic_linkage.py)
+- [WSGI Django](../src/project/asgi.py) (Daphne ASGI in production)
+
+Related infrastructure:
+
+- [systemd services and timers](../nix/configuration.nix)
+- [pgpubsub trigger channels](../src/shared/channels.py)
+
 ## External services
 
 The tracker needs to communicate with third party services, namely:

--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -67,3 +67,9 @@ graph TB
     class SystemdTimerChannels,SystemdTimerCVEs,NixEval,MatchingListener backgroundClass
     class PostgreSQL,LocalGitCheckout,NixStore storageClass
     class Storage,Background,ManageCommands,Web subgraphClass
+
+    click FetchAllChannels "https://github.com/NixOS/nix-security-tracker/blob/main/src/shared/management/commands/fetch_all_channels.py" "fetch_all_channels"
+    click IngestCVEs "https://github.com/NixOS/nix-security-tracker/blob/main/src/shared/management/commands/ingest_delta_cve.py" "ingest_delta_cve"
+    click NixEval "https://github.com/NixOS/nix-security-tracker/blob/main/src/shared/listeners/nix_evaluation.py" "Evaluate Nixpkgs"
+    click MatchingListener "https://github.com/NixOS/nix-security-tracker/blob/main/src/shared/listeners/automatic_linkage.py" "CVE matching"
+    click WSGI "https://github.com/NixOS/nix-security-tracker/blob/main/src/project/asgi.py" "Daphne ASGI"


### PR DESCRIPTION
- Added a **Diagram to implementation map** section in `docs/README.md` linking labeled diagram components to their source files.
- Added Mermaid `click` handlers on key diagram nodes in `docs/architecture.mermaid` pointing at GitHub blob URLs on `main`.

### Why
The architecture issue asked for links from diagram boxes to the code that implements them, in a form that works for readers and for link checking. The README list uses normal Markdown links (lychee checks `*.md`). Diagram `click` URLs are an optional convenience when viewing on GitHub.

Related to #931 