### PR TITLE
docs: align architecture docs with production monitoring and ASGI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ The tracker needs to communicate with third party services, namely:
 - GitHub repositories:
   - https://github.com/nixos/nixpkgs to pull the latest changes from Nixpkgs
   - https://github.com/CVEProject/cvelistV5 to pull CVE data
-- https://prometheus.nixos.org/ to get information about the latest channels
+- https://monitoring.nixos.org/prometheus/api/v1/query?query=channel_revision to get information about the latest channels
 
 ## Storage space considerations
 

--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -5,13 +5,13 @@ graph TB
         GitHub["GitHub API"]
         GitHubNixos["GitHub Repository<br/>nixos/nixpkgs"]
         GitHubCVEs["GitHub Repository<br/>CVEProject/cvelistV5"]
-        NixMonitoring["NixOS Monitoring<br/>Channel Status"]
+        NixMonitoring["monitoring.nixos.org<br/>channel revision"]
     end
 
     subgraph SecurityTracker ["Security Tracker Host"]
 	  subgraph Web["Web"]
 		  Nginx["Nginx HTTP"]
-		  WSGI["WSGI Django<br/>Django Views"]
+		  DaphneAsgi["Daphne ASGI<br/>Django"]
 	  end
 
 	  subgraph ManageCommands["Management Commands"]
@@ -35,8 +35,8 @@ graph TB
     end
 
 	%% User interactions
-	Users -->|HTTP Request| Nginx -->|Forward| WSGI -->|Queries| PostgreSQL
-    WSGI --> GitHub
+	Users -->|HTTP Request| Nginx -->|Forward| DaphneAsgi -->|Queries| PostgreSQL
+    DaphneAsgi --> GitHub
 
     %% Timers
     SystemdTimerChannels -.->|Triggers Daily| FetchAllChannels
@@ -62,7 +62,7 @@ graph TB
 
     class Users userClass
     class GitHub,GitHubNixos,GitHubCVEs,NixMonitoring externalClass
-    class Nginx,WSGI webClass
+    class Nginx,DaphneAsgi webClass
     class FetchAllChannels,IngestCVEs commandClass
     class SystemdTimerChannels,SystemdTimerCVEs,NixEval,MatchingListener backgroundClass
     class PostgreSQL,LocalGitCheckout,NixStore storageClass
@@ -72,4 +72,4 @@ graph TB
     click IngestCVEs "https://github.com/NixOS/nix-security-tracker/blob/main/src/shared/management/commands/ingest_delta_cve.py" "ingest_delta_cve"
     click NixEval "https://github.com/NixOS/nix-security-tracker/blob/main/src/shared/listeners/nix_evaluation.py" "Evaluate Nixpkgs"
     click MatchingListener "https://github.com/NixOS/nix-security-tracker/blob/main/src/shared/listeners/automatic_linkage.py" "CVE matching"
-    click WSGI "https://github.com/NixOS/nix-security-tracker/blob/main/src/project/asgi.py" "Daphne ASGI"
+    click DaphneAsgi "https://github.com/NixOS/nix-security-tracker/blob/main/src/project/asgi.py" "Daphne ASGI"


### PR DESCRIPTION
- Updated the channel monitoring URL in `docs/README.md` to match runtime configuration (`monitoring.nixos.org` Prometheus API).
- Renamed the web server box in `docs/architecture.mermaid` from WSGI Django to Daphne ASGI (production uses Daphne + `project.asgi`).
- Renamed the external monitoring box to `monitoring.nixos.org` (channel revision).

## Why
Architecture documentation still referenced `prometheus.nixos.org` and WSGI, which no longer match how the tracker is deployed and how channel heads are fetched (`CHANNEL_MONITORING_URL` in `src/project/settings.py`, Daphne in `nix/configuration.nix`).

Related to #931 

I guess this is the overall change required for the issue #931 , so this could be closed.