### PR TITLE
fix: show up-to-date maintainers deterministically

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -200,15 +200,16 @@ pkgs.testers.runNixOSTest {
               ]:
                 assert model.objects.count() == count, f"{model._meta.object_name}: expected {count}, got {model.objects.count()}"
 
-              # Maintainers should only be attached to derivations from rolling-release channels.
-              stable_meta = NixDerivationMeta.objects.get(
-                derivation__parent_evaluation__channel__state=NixChannel.ChannelState.STABLE,
+              # Maintainers should only be attached to derivations from the tracking branch.
+              from django.conf import settings
+              tracking_meta = NixDerivationMeta.objects.get(
+                derivation__parent_evaluation__channel__channel_branch=settings.TRACKING_BRANCH,
               )
-              assert not stable_meta.maintainers.exists()
-              for m in NixDerivationMeta.objects.filter(
-                derivation__parent_evaluation__channel__state=NixChannel.ChannelState.UNSTABLE,
+              assert tracking_meta.maintainers.exists(), f"{settings.TRACKING_BRANCH} meta has no maintainers"
+              for m in NixDerivationMeta.objects.exclude(
+                derivation__parent_evaluation__channel__channel_branch=settings.TRACKING_BRANCH,
               ):
-                assert m.maintainers.exists()
+                assert not m.maintainers.exists(), f"{m.derivation.parent_evaluation.channel.channel_branch}) has unexpected maintainers"
             ''
           }
     '';

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -163,6 +163,13 @@ class Settings(BaseSettings):
             The base URL of the tracker instance, used to construct backlinks for GitHub issues.
             """,
         )
+        TRACKING_BRANCH: str = Field(
+            description="""
+            The branch that tracks upstream development.
+            Serves as the source of truth for package metadata such as maintainers and descriptions.
+            """,
+            default="nixpkgs-unstable",
+        )
         MAX_MATCHES: int = Field(
             description="""
             CVEs matching more than this number of derivations are ignored.

--- a/src/shared/cache_suggestions.py
+++ b/src/shared/cache_suggestions.py
@@ -310,16 +310,17 @@ def channel_structure(
         _, package_version = parse_drv_name(derivation.name)
         if attribute_path not in packages:
             packages[attribute_path] = CachedSuggestion.Package()
-            if derivation.metadata:
-                if derivation.metadata.description:
-                    packages[
-                        attribute_path
-                    ].description = derivation.metadata.description
-                packages[attribute_path].maintainers = [
-                    CachedSuggestion.Maintainer.model_validate(to_dict(m))
-                    for m in derivation.metadata.prefetched_maintainers
-                ]
         packages[attribute_path].derivation_ids.append(derivation.pk)
+        if (
+            derivation.metadata
+            and derivation.parent_evaluation.channel.is_rolling_release
+        ):
+            if derivation.metadata.description:
+                packages[attribute_path].description = derivation.metadata.description
+            packages[attribute_path].maintainers = [
+                CachedSuggestion.Maintainer.model_validate(to_dict(m))
+                for m in derivation.metadata.prefetched_maintainers
+            ]
         # Get the branch from which that derivation originates
         branch_name = derivation.parent_evaluation.channel.channel_branch
         # Get primary ("major") channel to which that branch belongs

--- a/src/shared/models/cached.py
+++ b/src/shared/models/cached.py
@@ -20,7 +20,7 @@ class CachedSuggestions(TimeStampMixin):
 
     @classproperty
     def CURRENT_SCHEMA_VERSION(cls) -> int:  # noqa: N802, N805
-        return 3
+        return 4
 
     proposal = models.OneToOneField(
         CVEDerivationClusterProposal,

--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.postgres import fields
 from django.contrib.postgres.indexes import BTreeIndex, GinIndex
 from django.contrib.postgres.search import SearchVectorField
@@ -117,8 +118,7 @@ class NixDerivationMeta(models.Model):
 
 class NixChannelQuerySet(models.QuerySet):
     def rolling(self) -> "NixChannelQuerySet":
-        # FIXME(@fricklerhandwerk): This will fall apart when we obtain the channel structure dynamically [ref:channel-structure]
-        return self.filter(channel_branch__contains=MAJOR_CHANNELS[0])
+        return self.filter(channel_branch=settings.TRACKING_BRANCH)
 
 
 class NixChannel(TimeStampMixin):
@@ -167,13 +167,11 @@ class NixChannel(TimeStampMixin):
     @property
     def is_rolling_release(self) -> bool:
         """
-        Whether the channel corresponds to a rolling release
+        Whether the channel corresponds to a the tracking branch.
 
-        A rolling release tracks the Nixpkgs `master` branch.
         It's the source of truth for metadata such as package descriptions and maintainer information.
         """
-        # FIXME(@fricklerhandwerk): This will fall apart when we obtain the channel structure dynamically [ref:channel-structure]
-        return MAJOR_CHANNELS[0] in self.channel_branch
+        return self.channel_branch == settings.TRACKING_BRANCH
 
 
 class NixEvaluation(TimeStampMixin):

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -31,7 +31,6 @@ from shared.models.linkage import (
     ProvenanceFlags,
 )
 from shared.models.nix_evaluation import (
-    MAJOR_CHANNELS,
     NixChannel,
     NixDerivation,
     NixDerivationMeta,
@@ -135,21 +134,24 @@ def cve(make_container: Callable[..., Container]) -> Container:
 def make_channel(db: None) -> Callable[..., NixChannel]:
     # FIXME(@fricklerhandwerk): This will fall apart when we obtain the channel structure dynamically [ref:channel-structure]
     def wrapped(
-        release: str = MAJOR_CHANNELS[1],
-        state: NixChannel.ChannelState = NixChannel.ChannelState.STABLE,
+        release: str = "unstable",
+        state: NixChannel.ChannelState = NixChannel.ChannelState.UNSTABLE,
         branch: str | None = None,
     ) -> NixChannel:
         if branch is None:
-            branch = f"nixos-{release}"
+            branch = f"nixpkgs-{release}"
 
-        return NixChannel.objects.create(
-            staging_branch=branch,
+        channel, _ = NixChannel.objects.get_or_create(
             channel_branch=branch,
-            head_sha1_commit=secrets.token_hex(16),
-            state=state,
-            release_version=release,
-            repository="https://github.com/NixOS/nixpkgs",
+            defaults=dict(
+                staging_branch=branch,
+                head_sha1_commit=secrets.token_hex(16),
+                state=state,
+                release_version=release,
+                repository="https://github.com/NixOS/nixpkgs",
+            ),
         )
+        return channel
 
     return wrapped
 

--- a/src/shared/tests/test_suggestion_caching.py
+++ b/src/shared/tests/test_suggestion_caching.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 from datetime import timedelta
 
+import pytest
+
 from shared.cache_suggestions import cache_new_suggestions
 from shared.models.cached import CachedSuggestions
 from shared.models.cve import Container
@@ -13,6 +15,7 @@ from shared.models.nix_evaluation import (
     NixChannel,
     NixDerivation,
     NixEvaluation,
+    NixMaintainer,
 )
 
 
@@ -25,13 +28,16 @@ def test_caching_newest_package(
     suggestion: CVEDerivationClusterProposal,
 ) -> None:
     """
-    Check that when aggregating derivations from a suggestion, only the newest one for a given package name (== attribute path) is used.
+    Check that when aggregating derivations from a suggestion, only the newest one for a given package name (== attribute path) and a given channel is used.
     """
 
+    # Use a primary channel, since otherwise the overall version won't be captured.
+    # FIXME(@fricklerhandwerk): This shouldn't be something to keep track of. [ref:channel-structure]
+    primary_channel = make_channel(branch="nixos-26.05")
     # Order of creation matters for triggering the bug.
     # This is brittle because it assumes things about the database, but it seems that derivations are scanned in insertion order of their evaluations.
-    eval_new = make_evaluation()
-    eval_old = make_evaluation()
+    eval_new = make_evaluation(channel=primary_channel)
+    eval_old = make_evaluation(channel=primary_channel)
     # Overwrite the timestamp without triggering the `save()` hook that would write the current time again
     target_time = eval_old.created_at - timedelta(hours=1)
     NixEvaluation.objects.filter(pk=eval_old.pk).update(
@@ -70,6 +76,60 @@ def test_caching_newest_package(
     )
 
     assert package["major_version"] == "2.0"
+
+
+@pytest.mark.parametrize("stable_is_older", [True, False])
+@pytest.mark.parametrize("stable_has_maintainers", [True, False])
+@pytest.mark.parametrize("rolling_has_maintainers", [True, False])
+def test_maintainers_come_from_rolling_release_channel(
+    cve: Container,
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_maintainer: Callable[..., NixMaintainer],
+    stable_is_older: bool,
+    stable_has_maintainers: bool,
+    rolling_has_maintainers: bool,
+) -> None:
+    """
+    The rolling-release channel is the source of truth for maintainers.
+    Its maintainers must appear regardless of evaluation order,
+    and stable-only maintainers must never appear.
+    """
+    stable_channel = make_channel(release="26.05")
+    rolling_channel = make_channel()
+    stable_age = timedelta(hours=1) if stable_is_older else timedelta(0)
+    rolling_age = timedelta(0) if stable_is_older else timedelta(hours=1)
+    eval_stable = make_evaluation(channel=stable_channel, age=stable_age)
+    eval_rolling = make_evaluation(channel=rolling_channel, age=rolling_age)
+
+    rolling_maintainer = make_maintainer(github_id=1001, github="rolling-maintainer")
+    stable_maintainer = make_maintainer(github_id=1002, github="stable-maintainer")
+
+    drv_stable = make_drv(evaluation=eval_stable, maintainer=stable_maintainer)
+    drv_rolling = make_drv(evaluation=eval_rolling, maintainer=rolling_maintainer)
+    assert drv_stable.metadata is not None and drv_rolling.metadata is not None
+    if not stable_has_maintainers:
+        drv_stable.metadata.maintainers.clear()
+    if not rolling_has_maintainers:
+        drv_rolling.metadata.maintainers.clear()
+
+    suggestion = CVEDerivationClusterProposal.objects.create(
+        status="pending",
+        cve=cve.cve,
+    )
+    for drv in (drv_stable, drv_rolling):
+        DerivationClusterProposalLink.objects.create(
+            proposal=suggestion,
+            derivation=drv,
+            provenance_flags=ProvenanceFlags.PACKAGE_NAME_MATCH,
+        )
+
+    cache_new_suggestions(suggestion)
+    cached = CachedSuggestions.objects.get(proposal=suggestion)
+    maintainers = cached.payload["packages"][drv_rolling.attribute]["maintainers"]
+    expected = ["rolling-maintainer"] if rolling_has_maintainers else []
+    assert [m["github"] for m in maintainers] == expected
 
 
 def test_cache_stale_check(


### PR DESCRIPTION
Closes #1058

Prior to this change, we would sometimes lose maintainers, because they would be picked from an older branch, where they might not exist.
It could also happen that maintainers that are gone on `master` are shown instead.

The problem was that we weren't applying the same rule as we do on ingestion:
Only consider maintainers and other derivation metadata from the latest known revision of Nixpkgs.
Currently, that is `nixpkgs-unstable`, but eventually we want to evaluate `master` instead.