### PR TITLE
feat: API tokens control panel and API support

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -18,6 +18,24 @@ in
     packageOverrides = pyfinal: _pyprev: {
       django = pyfinal.django_5;
       psycopg2 = pyfinal.psycopg;
+      django-rest-knox = pyfinal.buildPythonPackage rec {
+        pname = "django-rest-knox";
+        version = "5.0.4";
+        format = "setuptools";
+
+        src = pyfinal.fetchPypi {
+          pname = "django_rest_knox";
+          inherit version;
+          hash = "sha256-AVXA3z1fZoENmOFtImYD/MoiTBzEwSg/r1abcrcmyTw=";
+        };
+
+        propagatedBuildInputs = with pyfinal; [
+          django
+          djangorestframework
+        ];
+
+        doCheck = false;
+      };
     };
   };
   # go through the motions to make a flake-incompat project use the build
@@ -76,6 +94,7 @@ in
       freezegun
       django-model-utils
       drf-spectacular
+      django-rest-knox
     ];
 
     passthru.PLAYWRIGHT_BROWSERS_PATH = final.playwright-driver.browsers;

--- a/src/api/tests/test_subscriptions.py
+++ b/src/api/tests/test_subscriptions.py
@@ -56,5 +56,5 @@ def test_put_invalid_body(client: APIClient, user: User) -> None:
 
 def test_unauthenticated() -> None:
     anon = APIClient()
-    assert anon.get(URL).status_code == status.HTTP_403_FORBIDDEN
-    assert anon.put(URL).status_code == status.HTTP_403_FORBIDDEN
+    assert anon.get(URL).status_code == status.HTTP_401_UNAUTHORIZED
+    assert anon.put(URL).status_code == status.HTTP_401_UNAUTHORIZED

--- a/src/api/tests/test_token_auth.py
+++ b/src/api/tests/test_token_auth.py
@@ -1,0 +1,107 @@
+from collections.abc import Callable
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth.models import User
+from freezegun import freeze_time
+from knox.models import AuthToken
+from rest_framework.test import APIClient
+
+from shared.models.linkage import CVEDerivationClusterProposal
+
+# A public (AllowAny) endpoint that returns 404 for non-existent objects,
+# used to probe authentication without needing real fixture data.
+PROBE_URL = "/api/v1/suggestions/999999/status"
+
+
+@pytest.mark.django_db
+def test_bearer_auth_valid_token(
+    user: User, make_token: Callable[..., tuple[AuthToken, str]]
+) -> None:
+    _, raw = make_token(user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {raw}")
+    response = client.get(PROBE_URL)
+    # 404 means the auth worked (no 401/403)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_bearer_auth_invalid_token() -> None:
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Bearer invalidtoken")
+    response = client.get(PROBE_URL)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_bearer_auth_expired_token(
+    user: User, make_token: Callable[..., tuple[AuthToken, str]]
+) -> None:
+    token_obj, raw = make_token(user)
+    assert token_obj.expiry is not None
+    with freeze_time(token_obj.expiry + timedelta(seconds=1)):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {raw}")
+        response = client.get(PROBE_URL)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_bearer_auth_revoked_token(
+    user: User, make_token: Callable[..., tuple[AuthToken, str]]
+) -> None:
+    _, raw = make_token(user)
+    AuthToken.objects.filter(user=user).delete()
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {raw}")
+    response = client.get(PROBE_URL)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_bearer_auth_missing_header() -> None:
+    """No Authorization header → anonymous; AllowAny endpoints still respond."""
+    client = APIClient()
+    response = client.get(PROBE_URL)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_bearer_auth_malformed_header() -> None:
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Token sometoken")
+    response = client.get(PROBE_URL)
+    # Not a Bearer header → treated as anonymous → AllowAny endpoint → 404
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("actor_fixture", "expected_status"),
+    [
+        ("user", 403),
+        ("staff", 200),
+    ],
+)
+@pytest.mark.django_db
+def test_bearer_auth_change_status_permissions(
+    request: pytest.FixtureRequest,
+    actor_fixture: str,
+    expected_status: int,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+    make_token: Callable[..., tuple[AuthToken, str]],
+) -> None:
+    """Bearer token: regular users get 403, staff can change status (200)."""
+    actor: User = request.getfixturevalue(actor_fixture)
+    suggestion = make_cached_suggestion()
+    _, raw = make_token(actor)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {raw}")
+    response = client.post(
+        f"/api/v1/suggestions/{suggestion.pk}/change_status",
+        {"status": CVEDerivationClusterProposal.Status.ACCEPTED},
+        format="json",
+    )
+    assert response.status_code == expected_status
+    if expected_status == 200:
+        assert response.data["status"] == CVEDerivationClusterProposal.Status.ACCEPTED

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import importlib.util
 import sys
+from datetime import timedelta
 from os import environ as env
 from pathlib import Path
 from typing import Annotated, Self
@@ -370,6 +371,7 @@ INSTALLED_APPS = [
     "pglock",
     "pgactivity",
     "rest_framework",
+    "knox",
     "shared",
     "api",
     "webview",
@@ -443,6 +445,10 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "EXCEPTION_HANDLER": "api.exceptions.custom_exception_handler",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "knox.auth.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ],
 }
 
 # drf-spectacular (openapi generation) settings
@@ -450,6 +456,13 @@ SPECTACULAR_SETTINGS = {
     "TITLE": "Nixpkgs security tracker API",
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
+}
+
+REST_KNOX = {
+    "TOKEN_TTL": timedelta(days=30),
+    "AUTH_HEADER_PREFIX": "Bearer",
+    "TOKEN_LIMIT_PER_USER": 1,
+    "AUTO_REFRESH": False,
 }
 
 SITE_ID = 1

--- a/src/shared/templates/base.html
+++ b/src/shared/templates/base.html
@@ -51,6 +51,7 @@
             <a href="{% url 'webview:subscriptions:center' %}"
                id="subscriptions-navbar-icon"></a>
             {% notifications_badge user.profile.unread_notifications_count %}
+            <a href="{% url 'webview:tokens:manage' %}">API</a>
             <a href="{% url 'account_logout' %}">Logout</a>
 
           {% else %}

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -9,6 +9,7 @@ from allauth.socialaccount.providers.github.provider import GitHubProvider
 from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.utils import timezone
+from knox.models import AuthToken
 
 from shared.cache_suggestions import cache_new_suggestions, parse_drv_name
 from shared.fetchers import make_metrics
@@ -479,5 +480,15 @@ def make_package_notification(
             drvs={drv: ProvenanceFlags.PACKAGE_NAME_MATCH}
         )
         return create_package_subscription_notifications(suggestion)
+
+    return wrapped
+
+
+@pytest.fixture
+def make_token(db: None) -> Callable[..., tuple[AuthToken, str]]:
+    def wrapped(user: User) -> tuple[AuthToken, str]:
+        return AuthToken.objects.create(  # type: ignore[return-value]
+            user=user, expiry=settings.REST_KNOX["TOKEN_TTL"]
+        )
 
     return wrapped

--- a/src/webview/templates/tokens/token_management.html
+++ b/src/webview/templates/tokens/token_management.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+  <h1 class="page-title">API token</h1>
+
+  <div class="column gap">
+
+    <p>
+      Use an API token to authenticate requests with
+      <code>Authorization: Bearer &lt;token&gt;</code>.
+      Tokens are valid for {{ TOKEN_LIFETIME_DAYS }} days.
+    </p>
+
+    {% if new_token_value %}
+      <div class="rounded-box column gap">
+        <h2 class="heading">Your new token</h2>
+        <p>
+          <strong>Copy this value now — it will not be shown again.</strong>
+        </p>
+        <pre>{{ new_token_value }}</pre>
+        <p>
+          Created: {{ token.created }}
+          <br />
+          Expires: {{ token.expiry }}
+        </p>
+      </div>
+    {% elif token %}
+      <div class="rounded-box column gap">
+        <h2 class="heading">Active token</h2>
+        <p>
+          Created: {{ token.created }}
+          <br />
+          Expires: {{ token.expiry }}
+        </p>
+        <div class="row gap">
+          <form method="post">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="extend" />
+            <button type="submit" class="btn btn-green">Extend by {{ TOKEN_LIFETIME_DAYS }} days</button>
+          </form>
+          <form method="post">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="revoke" />
+            <button type="submit" class="btn btn-red">Revoke</button>
+          </form>
+        </div>
+      </div>
+    {% else %}
+      <div class="rounded-box column gap">
+        <h2 class="heading">No active token</h2>
+        <form method="post">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="generate" />
+          <button type="submit" class="btn btn-green">Generate API token</button>
+        </form>
+      </div>
+    {% endif %}
+
+  </div>
+
+{% endblock content %}

--- a/src/webview/tests/test_token_views.py
+++ b/src/webview/tests/test_token_views.py
@@ -1,0 +1,84 @@
+from collections.abc import Callable
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+from knox.models import AuthToken
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+def test_token_page_redirects_anonymous(client: APIClient) -> None:
+    response = client.get(reverse("webview:tokens:manage"))
+    assert response.status_code == 302
+    # LoginRequiredMixin redirects to the allauth login URL
+    login_url = reverse("account_login")
+    assert response.headers["Location"].startswith(login_url)
+
+
+@pytest.mark.django_db
+def test_token_page_no_token(user: User, client: APIClient) -> None:
+    client.force_login(user)
+    response = client.get(reverse("webview:tokens:manage"))
+    assert response.status_code == 200
+    assert b"Generate API token" in response.content
+
+
+@pytest.mark.django_db
+def test_generate_shows_token_value_once(user: User, client: APIClient) -> None:
+    client.force_login(user)
+    response = client.post(reverse("webview:tokens:manage"), {"action": "generate"})
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Copy this value now" in content
+    assert AuthToken.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_second_get_hides_token_value(user: User, client: APIClient) -> None:
+    client.force_login(user)
+    client.post(reverse("webview:tokens:manage"), {"action": "generate"})
+    # Follow-up GET must not expose the raw value
+    response = client.get(reverse("webview:tokens:manage"))
+    assert response.status_code == 200
+    assert b"Active token" in response.content
+
+
+@pytest.mark.django_db
+def test_revoke_deletes_token(
+    user: User, client: APIClient, make_token: Callable[..., tuple[AuthToken, str]]
+) -> None:
+    make_token(user)
+    client.force_login(user)
+    response = client.post(
+        reverse("webview:tokens:manage"), {"action": "revoke"}, follow=True
+    )
+    assert response.status_code == 200
+    assert not AuthToken.objects.filter(user=user).exists()
+    assert b"Generate API token" in response.content
+
+
+@pytest.mark.django_db
+def test_extend_pushes_expiry(
+    user: User, client: APIClient, make_token: Callable[..., tuple[AuthToken, str]]
+) -> None:
+    token_obj, _ = make_token(user)
+    old_expiry = token_obj.expiry
+    client.force_login(user)
+    client.post(reverse("webview:tokens:manage"), {"action": "extend"}, follow=True)
+    token_obj.refresh_from_db()
+    assert old_expiry is not None
+    assert token_obj.expiry is not None
+    assert token_obj.expiry > old_expiry
+
+
+@pytest.mark.django_db
+def test_generate_replaces_existing_token(
+    user: User, client: APIClient, make_token: Callable[..., tuple[AuthToken, str]]
+) -> None:
+    old_obj, _ = make_token(user)
+    client.force_login(user)
+    client.post(reverse("webview:tokens:manage"), {"action": "generate"})
+    assert AuthToken.objects.filter(user=user).count() == 1
+    new_obj = AuthToken.objects.get(user=user)
+    assert new_obj.pk != old_obj.pk

--- a/src/webview/tokens/urls.py
+++ b/src/webview/tokens/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import TokenManagementView
+
+app_name = "tokens"
+
+urlpatterns = [
+    path("", TokenManagementView.as_view(), name="manage"),
+]

--- a/src/webview/tokens/views.py
+++ b/src/webview/tokens/views.py
@@ -1,0 +1,53 @@
+from datetime import timedelta
+from typing import Any
+
+from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.models import User
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils import timezone
+from django.views.generic import TemplateView
+from knox.models import AuthToken
+
+expiry: timedelta = settings.REST_KNOX["TOKEN_TTL"]
+
+
+class TokenManagementView(LoginRequiredMixin, TemplateView):
+    template_name = "tokens/token_management.html"
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["token"] = AuthToken.objects.filter(user=self.request.user).first()
+        context["TOKEN_LIFETIME_DAYS"] = expiry.days
+        return context
+
+    def post(self, request: HttpRequest) -> HttpResponse:
+        assert isinstance(request.user, User)
+        action = request.POST.get("action", "")
+
+        if action == "generate":
+            AuthToken.objects.filter(user=request.user).delete()
+            token_obj, raw = AuthToken.objects.create(  # type: ignore[misc]
+                user=request.user, expiry=expiry
+            )
+            return self.render_to_response(
+                self.get_context_data(
+                    token=token_obj,
+                    new_token_value=raw,
+                )
+            )
+
+        if action == "revoke":
+            AuthToken.objects.filter(user=request.user).delete()
+            return redirect(reverse("webview:tokens:manage"))
+
+        if action == "extend":
+            token_obj = AuthToken.objects.filter(user=request.user).first()
+            if token_obj is not None:
+                token_obj.expiry = timezone.now() + expiry
+                token_obj.save(update_fields=["expiry"])
+            return redirect(reverse("webview:tokens:manage"))
+
+        return redirect(reverse("webview:tokens:manage"))

--- a/src/webview/urls.py
+++ b/src/webview/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
         name="issue_detail",
     ),
     path("github-webhook/", handle_github_hook, name="github_webhook"),
+    path("tokens/", include("webview.tokens.urls"), name="tokens"),
 ]


### PR DESCRIPTION
This implements #1039 

## Link in menu

<img width="676" height="90" alt="2026-06-03 16-52-19" src="https://github.com/user-attachments/assets/4488a6db-6e93-405d-b3ec-e8200fc15c9b" />

## Generate

<img width="1214" height="500" alt="2026-06-03 16-51-32" src="https://github.com/user-attachments/assets/7ee841f1-c876-4037-b15f-68bda047c59c" />

## Consult token ONCE after creation

<img width="1210" height="672" alt="2026-06-03 16-51-44" src="https://github.com/user-attachments/assets/b1400a81-c778-4a0d-aa43-90c6eb9484ef" />

## Consult status, extend, revoke

<img width="1210" height="672" alt="2026-06-03 16-51-56" src="https://github.com/user-attachments/assets/ab95f4fd-1061-4769-9f56-1d92c8923fa6" />
