### PR TITLE
refactor: simplify a test case

### DIFF
--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -147,7 +147,7 @@ def make_channel(db: None) -> Callable[..., NixChannel]:
                 staging_branch=branch,
                 head_sha1_commit=secrets.token_hex(16),
                 state=state,
-                release_version=release,
+                release_version=None if release == "unstable" else release,
                 repository="https://github.com/NixOS/nixpkgs",
             ),
         )

--- a/src/shared/tests/test_linkage.py
+++ b/src/shared/tests/test_linkage.py
@@ -29,19 +29,9 @@ def test_link_only_latest_eval(
     Check that only derivations from the latest complete evaluation of each channel are matched.
     """
 
-    # FIXME(@fricklerhandwerk): This will fall apart when we obtain the channel structure dynamically [ref:channel-structure]
-    release = MAJOR_CHANNELS[1]
     channels = [
-        make_channel(
-            release=release,
-            branch=branch,
-            state=NixChannel.ChannelState.UNSTABLE,
-        )
-        for branch in [
-            f"nixos-${release}",
-            f"nixos-${release}-small",
-            f"nixpkgs-${release}-darwin",
-        ]
+        make_channel(release="26.05", state=NixChannel.ChannelState.STABLE),
+        make_channel(release="unstable", state=NixChannel.ChannelState.UNSTABLE),
     ]
 
     evaluations = []
@@ -49,26 +39,22 @@ def test_link_only_latest_eval(
     # But for simplicity we simply iterate over all states.
     for state in NixEvaluation.EvaluationState.values:
         for channel in channels:
-            for day in range(3):
-                ev = make_evaluation(channel=channel, state=state)
-                target_time = ev.created_at - timedelta(days=day)
-                # Overwrite the timestamp without triggering the `save()` hook that would write the current time again
-                NixEvaluation.objects.filter(pk=ev.pk).update(
-                    created_at=target_time,
-                    updated_at=target_time,
-                )
-                evaluations.append(ev)
+            evaluations.extend(
+                [
+                    make_evaluation(
+                        channel=channel, state=state, age=timedelta(days=0)
+                    ),
+                    make_evaluation(
+                        channel=channel, state=state, age=timedelta(days=1)
+                    ),
+                ]
+            )
 
     for i, ev in enumerate(evaluations):
-        make_drv(
-            evaluation=ev,
-            pname="foobar",
-            version=f"1.{i}",
-        )
+        make_drv(evaluation=ev, pname="foobar", version=f"1.{i}")
 
     container = make_container(package_name="foo", affected_version="<3.2")
-    match = build_new_links(container)
-    assert match
+    assert build_new_links(container)
     suggestion = CVEDerivationClusterProposal.objects.first()
     assert suggestion
     states = suggestion.derivations.values_list("parent_evaluation__state", flat=True)


### PR DESCRIPTION
We're only testing for evaluation age, not branch names. Also there's now a fixture for setting the age.