### PR TITLE
fix: parse derivation name according to spec

### DIFF
--- a/src/shared/cache_suggestions.py
+++ b/src/shared/cache_suggestions.py
@@ -391,7 +391,7 @@ def parse_drv_name(name: str) -> tuple[str, str]:
     The package name is everything up to but not including the first dash
     not followed by a letter, and the version is everything after that dash.
     """
-    match = re.match(r"^(.+?)-([^-]*\d.*)$", name)
+    match = re.match(r"^(.+?)-([^a-zA-Z].*)$", name)
     if match:
         return match.group(1), match.group(2)
     else:

--- a/src/shared/tests/test_utils.py
+++ b/src/shared/tests/test_utils.py
@@ -12,6 +12,11 @@ from shared.cache_suggestions import parse_drv_name
         ("foo-unstable", ("foo-unstable", "")),
         ("python3-3.11.0", ("python3", "3.11.0")),
         ("no-version", ("no-version", "")),
+        ("mypy-boto3-1.0.0", ("mypy-boto3", "1.0.0")),
+        (
+            "python3.12-mypy-boto3-appmesh-1.43.0",
+            ("python3.12-mypy-boto3-appmesh", "1.43.0"),
+        ),
     ],
 )
 def test_parse_drv_name(drv_name: str, expected: tuple[str, str]) -> None:


### PR DESCRIPTION
Big facepalm. How could this have been so obviously wrong all this time? I even know who [reviewed](https://github.com/NixOS/nix-security-tracker/pull/385) the code before it was merged!