### PR TITLE
fix: avoid git branch name warning in smoke test

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -41,7 +41,7 @@ pkgs.testers.runNixOSTest {
             EOF
 
             cd $out
-            git init
+            git init --initial-branch=master
             git add -A
             git -c user.name=test -c user.email=test@test commit -m "test"
             git rev-parse HEAD > REVISION


### PR DESCRIPTION
Git 2.x warns about the default initial branch changing in Git 3.0.
This can be avoided by fixing a branch name explicitly.