### PR TITLE
fix: prevent overriding of credentials file everytime someone enters …

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -77,12 +77,12 @@ rec {
           mkdir -p "$nixpkgsDir"
           cd "$credentialsDir"
           set -o noclobber
-          python3 -c 'import secrets; print(secrets.token_hex(100))' > SECRET_KEY
-          echo bar > GH_CLIENT_ID
-          echo baz > GH_SECRET
-          echo qux > GH_WEBHOOK_SECRET
-          echo 123 > GH_APP_INSTALLATION_ID
-          echo foo > GH_APP_PRIVATE_KEY
+          [ -f SECRET_KEY ] || python3 -c 'import secrets; print(secrets.token_hex(100))' > SECRET_KEY
+          [ -f GH_CLIENT_ID ] || echo bar > GH_CLIENT_ID
+          [ -f GH_SECRET ] || echo baz > GH_SECRET
+          [ -f GH_WEBHOOK_SECRET ] || echo qux > GH_WEBHOOK_SECRET
+          [ -f GH_APP_INSTALLATION_ID ] || echo 123 > GH_APP_INSTALLATION_ID
+          [ -f GH_APP_PRIVATE_KEY ] || echo foo > GH_APP_PRIVATE_KEY
         '';
       };
     in


### PR DESCRIPTION
```sh
/nix/store/r6vn1bhg3zn9inbph9rv25n5cjxfvwca-shell-config-placeholder/bin/shell-config-placeholder: line 14: SECRET_KEY: cannot overwrite existing file
```
Because of `set -o noclobber`, I was receiving the error `SECRET_KEY: cannot overwrite existing file. shell-config-placeholder` previously created files in .credentials unconditionally every time someone entered the nix shell. This PR fixes it by first checking for their existence and only creating them when they are not present. This also prevents overriding file contents every time someone re-enters the shell, keeping the key stable across sessions.