### PR TITLE
test: add evaluation test

### DIFF
--- a/src/shared/evaluation_status.py
+++ b/src/shared/evaluation_status.py
@@ -4,8 +4,14 @@ from django.db.models.functions import RowNumber
 from shared.models.nix_evaluation import NixEvaluation
 
 
-def latest_completed_evaluations(channel_filter: Q | None = None) -> QuerySet[NixEvaluation]:
-    qs = NixEvaluation.objects.filter(state=NixEvaluation.EvaluationState.COMPLETED)
+def _latest_evaluations_per_channel(
+    *,
+    channel_filter: Q | None = None,
+    completed_only: bool = False,
+) -> QuerySet[NixEvaluation]:
+    qs = NixEvaluation.objects.all()
+    if completed_only:
+        qs = qs.filter(state=NixEvaluation.EvaluationState.COMPLETED)
     if channel_filter is not None:
         qs = qs.filter(channel_filter)
     return qs.annotate(
@@ -15,3 +21,10 @@ def latest_completed_evaluations(channel_filter: Q | None = None) -> QuerySet[Ni
             order_by=F("updated_at").desc(),
         ),
     ).filter(row_num=1)
+
+
+def latest_completed_evaluations(channel_filter: Q | None = None) -> QuerySet[NixEvaluation]:
+    return _latest_evaluations_per_channel(
+        channel_filter=channel_filter,
+        completed_only=True,
+    )

--- a/src/shared/evaluation_status.py
+++ b/src/shared/evaluation_status.py
@@ -1,0 +1,17 @@
+from django.db.models import F, Q, QuerySet, Window
+from django.db.models.functions import RowNumber
+
+from shared.models.nix_evaluation import NixEvaluation
+
+
+def latest_completed_evaluations(channel_filter: Q | None = None) -> QuerySet[NixEvaluation]:
+    qs = NixEvaluation.objects.filter(state=NixEvaluation.EvaluationState.COMPLETED)
+    if channel_filter is not None:
+        qs = qs.filter(channel_filter)
+    return qs.annotate(
+        row_num=Window(
+            expression=RowNumber(),
+            partition_by=[F("channel")],
+            order_by=F("updated_at").desc(),
+        ),
+    ).filter(row_num=1)

--- a/src/shared/evaluation_status.py
+++ b/src/shared/evaluation_status.py
@@ -12,6 +12,25 @@ class ChannelEvaluationStatus:
     latest: NixEvaluation | None
     latest_successful: NixEvaluation | None
 
+    @property
+    def is_healthy(self) -> bool:
+        if self.latest is None:
+            return False
+
+        if self.latest.commit_sha1 != self.channel.head_sha1_commit:
+            return False
+
+        if self.latest.state == NixEvaluation.EvaluationState.COMPLETED:
+            return True
+
+        if self.latest.state in (
+            NixEvaluation.EvaluationState.WAITING,
+            NixEvaluation.EvaluationState.IN_PROGRESS,
+        ):
+            return True
+
+        return False
+
 
 def _latest_evaluations_per_channel(
     *,

--- a/src/shared/evaluation_status.py
+++ b/src/shared/evaluation_status.py
@@ -1,7 +1,16 @@
+from dataclasses import dataclass
+
 from django.db.models import F, Q, QuerySet, Window
 from django.db.models.functions import RowNumber
 
-from shared.models.nix_evaluation import NixEvaluation
+from shared.models.nix_evaluation import NixChannel, NixEvaluation
+
+
+@dataclass(frozen=True)
+class ChannelEvaluationStatus:
+    channel: NixChannel
+    latest: NixEvaluation | None
+    latest_successful: NixEvaluation | None
 
 
 def _latest_evaluations_per_channel(
@@ -23,7 +32,9 @@ def _latest_evaluations_per_channel(
     ).filter(row_num=1)
 
 
-def latest_completed_evaluations(channel_filter: Q | None = None) -> QuerySet[NixEvaluation]:
+def latest_completed_evaluations(
+    channel_filter: Q | None = None,
+) -> QuerySet[NixEvaluation]:
     return _latest_evaluations_per_channel(
         channel_filter=channel_filter,
         completed_only=True,

--- a/src/shared/evaluation_status.py
+++ b/src/shared/evaluation_status.py
@@ -58,3 +58,28 @@ def latest_completed_evaluations(
         channel_filter=channel_filter,
         completed_only=True,
     )
+
+
+def get_channel_evaluation_statuses(
+    channels: QuerySet[NixChannel] | None = None,
+) -> list[ChannelEvaluationStatus]:
+    if channels is None:
+        channels = NixChannel.objects.order_by("channel_branch")
+
+    latest_by_channel = {
+        evaluation.channel_id: evaluation
+        for evaluation in _latest_evaluations_per_channel()
+    }
+    latest_successful_by_channel = {
+        evaluation.channel_id: evaluation
+        for evaluation in _latest_evaluations_per_channel(completed_only=True)
+    }
+
+    return [
+        ChannelEvaluationStatus(
+            channel=channel,
+            latest=latest_by_channel.get(channel.pk),
+            latest_successful=latest_successful_by_channel.get(channel.pk),
+        )
+        for channel in channels
+    ]

--- a/src/shared/listeners/automatic_linkage.py
+++ b/src/shared/listeners/automatic_linkage.py
@@ -21,14 +21,13 @@ from django.db.models import (
     Q,
     Value,
     When,
-    Window,
 )
-from django.db.models.functions import RowNumber
 
 from shared.channels import ContainerChannel
+from shared.evaluation_status import latest_completed_evaluations
 from shared.models.cve import Container, Cpe
 from shared.models.linkage import CVEDerivationClusterProposal, ProvenanceFlags
-from shared.models.nix_evaluation import MAJOR_CHANNELS, NixDerivation, NixEvaluation
+from shared.models.nix_evaluation import MAJOR_CHANNELS, NixDerivation
 
 logger = logging.getLogger(__name__)
 
@@ -42,20 +41,7 @@ def produce_linkage_candidates(
     for ch in MAJOR_CHANNELS:
         active_channels_q |= Q(channel__channel_branch__contains=ch)
 
-    latest_complete_channels = (
-        NixEvaluation.objects.filter(
-            active_channels_q,
-            state=NixEvaluation.EvaluationState.COMPLETED,
-        )
-        .annotate(
-            row_num=Window(
-                expression=RowNumber(),
-                partition_by=[F("channel")],
-                order_by=F("updated_at").desc(),
-            ),
-        )
-        .filter(row_num=1)
-    )
+    latest_complete_channels = latest_completed_evaluations(active_channels_q)
 
     package_names = (
         filtered_affected.exclude(package_name__isnull=True)

--- a/src/shared/listeners/automatic_linkage.py
+++ b/src/shared/listeners/automatic_linkage.py
@@ -15,7 +15,6 @@ from django.db import models
 from django.db.models import (
     Case,
     Exists,
-    F,
     IntegerField,
     OuterRef,
     Q,

--- a/src/shared/tests/test_evaluation_status.py
+++ b/src/shared/tests/test_evaluation_status.py
@@ -1,0 +1,172 @@
+from collections.abc import Callable
+from datetime import timedelta
+
+from shared.evaluation_status import ChannelEvaluationStatus, get_channel_evaluation_statuses
+from shared.models.nix_evaluation import NixChannel, NixEvaluation
+
+
+def _status_for(
+    statuses: list[ChannelEvaluationStatus],
+    channel: NixChannel,
+) -> ChannelEvaluationStatus:
+    return next(s for s in statuses if s.channel.pk == channel.pk)
+
+
+def test_latest_and_latest_successful_selected_by_updated_at(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+) -> None:
+    channel = make_channel(branch="nixpkgs-unstable")
+    older_completed = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        commit_sha1="completed-old",
+        age=timedelta(days=2),
+    )
+    newer_crashed = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.CRASHED,
+        commit_sha1="crashed-new",
+        age=timedelta(days=0),
+    )
+
+    status = _status_for(get_channel_evaluation_statuses(), channel)
+
+    assert status.latest == newer_crashed
+    assert status.latest_successful == older_completed
+
+
+def test_healthy_when_completed_at_head(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+) -> None:
+    channel = make_channel(branch="nixpkgs-unstable")
+    head = "head-commit-abc"
+    channel.head_sha1_commit = head
+    channel.save(update_fields=["head_sha1_commit"])
+
+    make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        commit_sha1="older-commit",
+        age=timedelta(days=1),
+    )
+    latest = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        commit_sha1=head,
+        age=timedelta(days=0),
+    )
+
+    status = _status_for(get_channel_evaluation_statuses(), channel)
+
+    assert status.is_healthy
+    assert status.latest == latest
+    assert status.latest_successful == latest
+
+
+def test_healthy_when_in_progress_at_head(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+) -> None:
+    channel = make_channel(branch="nixpkgs-unstable")
+    head = "head-commit-in-progress"
+    channel.head_sha1_commit = head
+    channel.save(update_fields=["head_sha1_commit"])
+
+    make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        commit_sha1="older-successful",
+        age=timedelta(days=1),
+    )
+    make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.IN_PROGRESS,
+        commit_sha1=head,
+        age=timedelta(days=0),
+    )
+
+    status = _status_for(get_channel_evaluation_statuses(), channel)
+
+    assert status.is_healthy
+    assert status.latest.state == NixEvaluation.EvaluationState.IN_PROGRESS
+    assert status.latest_successful.commit_sha1 == "older-successful"
+
+
+def test_unhealthy_when_crashed_at_head_with_stale_successful(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+) -> None:
+    channel = make_channel(branch="nixpkgs-unstable")
+    head = "head-commit-crashed"
+    channel.head_sha1_commit = head
+    channel.save(update_fields=["head_sha1_commit"])
+
+    make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        commit_sha1="stale-successful",
+        age=timedelta(days=30),
+    )
+    make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.CRASHED,
+        commit_sha1=head,
+        age=timedelta(days=0),
+    )
+
+    status = _status_for(get_channel_evaluation_statuses(), channel)
+
+    assert not status.is_healthy
+    assert status.latest.state == NixEvaluation.EvaluationState.CRASHED
+    assert status.latest_successful.commit_sha1 == "stale-successful"
+
+
+def test_unhealthy_when_channel_has_no_evaluations(
+    make_channel: Callable[..., NixChannel],
+) -> None:
+    channel = make_channel(branch="nixpkgs-empty")
+
+    status = _status_for(get_channel_evaluation_statuses(), channel)
+
+    assert status.latest is None
+    assert status.latest_successful is None
+    assert not status.is_healthy
+
+
+def test_unhealthy_when_never_completed(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+) -> None:
+    channel = make_channel(branch="nixpkgs-never-completed")
+    head = "head-commit-never-completed"
+    channel.head_sha1_commit = head
+    channel.save(update_fields=["head_sha1_commit"])
+
+    make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.FAILED,
+        commit_sha1=head,
+    )
+
+    status = _status_for(get_channel_evaluation_statuses(), channel)
+
+    assert status.latest is not None
+    assert status.latest_successful is None
+    assert not status.is_healthy
+
+
+def test_returns_channels_ordered_by_branch(
+    make_channel: Callable[..., NixChannel],
+) -> None:
+    channel_b = make_channel(branch="nixpkgs-b")
+    channel_a = make_channel(branch="nixpkgs-a")
+
+    statuses = get_channel_evaluation_statuses(
+        NixChannel.objects.filter(
+            channel_branch__in=[channel_a.pk, channel_b.pk],
+        ).order_by("channel_branch"),
+    )
+
+    assert [status.channel.pk for status in statuses] == [channel_a.pk, channel_b.pk]


### PR DESCRIPTION
Depends on #1093,#1093,#1097,#1098,#1099 and #1100, tests the feature implemented in these PRs

Coverage Includes:
* latest vs latest-successful selection by updated_at
* healthy when completed at HEAD
* healthy when in-progress at HEAD (with older successful eval)
* unhealthy when crashed at HEAD with stale successful eval (#625 scenario)
* unhealthy when channel has no evaluations
* unhealthy when never completed
* channels returned ordered by channel_branch

Will rebase after the previous PRs have been reviewed.