### PR TITLE
feat: add latest_per_channel queryset method

### DIFF
--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -186,18 +186,19 @@ class NixChannel(TimeStampMixin):
 
 
 class NixEvaluationQuerySet(models.QuerySet):
+    def latest_per_channel(self) -> "NixEvaluationQuerySet":
+        return self.annotate(
+            row_num=Window(
+                expression=RowNumber(),
+                partition_by=[F("channel")],
+                order_by=F("updated_at").desc(),
+            ),
+        ).filter(row_num=1)
+
     def latest_completed_per_channel(self) -> "NixEvaluationQuerySet":
-        return (
-            self.filter(state=NixEvaluation.EvaluationState.COMPLETED)
-            .annotate(
-                row_num=Window(
-                    expression=RowNumber(),
-                    partition_by=[F("channel")],
-                    order_by=F("updated_at").desc(),
-                ),
-            )
-            .filter(row_num=1)
-        )
+        return self.filter(
+            state=NixEvaluation.EvaluationState.COMPLETED
+        ).latest_per_channel()
 
 
 class NixEvaluation(TimeStampMixin):

--- a/src/shared/tests/test_evaluation_status.py
+++ b/src/shared/tests/test_evaluation_status.py
@@ -1,0 +1,28 @@
+from collections.abc import Callable
+from datetime import timedelta
+
+from shared.models.nix_evaluation import NixChannel, NixEvaluation
+
+
+def test_latest_per_channel_selects_by_updated_at(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+) -> None:
+    channel = make_channel(branch="nixpkgs-unstable")
+    older = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        commit_sha1="older-eval",
+        age=timedelta(days=2),
+    )
+    newer = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.CRASHED,
+        commit_sha1="newer-eval",
+        age=timedelta(days=0),
+    )
+
+    latest = NixEvaluation.objects.filter(channel=channel).latest_per_channel().get()
+
+    assert latest == newer
+    assert latest != older


### PR DESCRIPTION
Part of #626

Callers chain filters before calling queryset methods, same pattern as #1093:

```python
NixEvaluation.objects.filter(channel=ch).latest_per_channel()