### PR TITLE
fix: handle Git `shallow.lock` error handling

### DIFF
--- a/src/shared/git.py
+++ b/src/shared/git.py
@@ -175,7 +175,13 @@ class GitRepo:
                 stderr_text = stderr.decode("utf8")
                 if rc == 0:
                     return True
-                if "shallow.lock" not in stderr_text:
+                for err in [
+                    "cannot lock ref",
+                    "shallow file has changed since we read it",
+                ]:
+                    if err in stderr_text:
+                        break
+                else:
                     logger.error("git fetch stderr: %s", stderr_text)
                     raise RepositoryError(
                         f"failed to fetch {object_sha1} while running `git fetch --depth=1 {repo_clone_url} {object_sha1}`"

--- a/src/shared/tests/test_git_update_from_ref.py
+++ b/src/shared/tests/test_git_update_from_ref.py
@@ -77,7 +77,7 @@ def test_retries_then_succeeds_on_lock_contention() -> None:
     result, exec_mock, sleep_mock, _ = _run(
         [
             _proc("git cat-file", 1),
-            _proc("git fetch", 128, b"fatal: could not lock ref: shallow.lock\n"),
+            _proc("git fetch", 128, b"fatal: cannot lock ref\n"),
             _proc("git fetch", 0),
         ]
     )
@@ -87,7 +87,9 @@ def test_retries_then_succeeds_on_lock_contention() -> None:
 
 
 def _lock_err() -> MagicMock:
-    return _proc("git fetch", 128, b"fatal: could not lock ref: shallow.lock\n")
+    return _proc(
+        "git fetch", 128, b"fatal: shallow file has changed since we read it\n"
+    )
 
 
 @pytest.mark.parametrize("max_attempts", [1, 2, 5])


### PR DESCRIPTION
The last change had made a wrong assumption about the exact error string.