### PR TITLE
fix: Don't count created packages as updated

### DIFF
--- a/src/shared/package_clustering.py
+++ b/src/shared/package_clustering.py
@@ -193,7 +193,7 @@ def _cluster_batch(
 
     return ClusterResult(
         derivations_processed=len(drvs),
-        packages_updated=len(updated),
+        packages_updated=len(updated - created),
         packages_created=len(created),
         attrpaths_updated=len(attrpath_to_pkg),
         attrpaths_created=len(new_attrpaths),


### PR DESCRIPTION
I believe we're counting newly added packages twice, once [when they're created](https://github.com/NixOS/nix-security-tracker/blob/0b05716347124856116de9a822434dc6267a88d1/src/shared/package_clustering.py#L159) and once [again further down the function](https://github.com/NixOS/nix-security-tracker/blob/0b05716347124856116de9a822434dc6267a88d1/src/shared/package_clustering.py#L169) regardless of their state. As such, the count for updated packages should not include the number of added packages.