### PR TITLE
fix: make NixOS logo also show in development instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ result
 *.log
 src/static
 src/webview/static/htmx.min.js
+src/webview/static/nixos-logo.svg
 # A shallow checkout of nixpkgs
 nixpkgs/
 nixpkgs-gc-roots/

--- a/default.nix
+++ b/default.nix
@@ -152,6 +152,7 @@ rec {
         shell-config-placeholder
 
         ln -sf ${sources.htmx}/dist/htmx.js src/webview/static/htmx.min.js
+        ln -sf ${sources.nixos-logo} src/webview/static/nixos-logo.svg
 
         mkdir -p $CREDENTIALS_DIRECTORY
         # TODO(@fricklerhandwerk): move all configuration over to pydantic-settings

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,12 +1,6 @@
 final: prev:
 let
   sources = import ../npins;
-  # FIXME(@fricklerhandwerk): `npins` doesn't support references to separate files.
-  # Build the logo from source, find a tarball reference, or add a `file` type to `npins`.
-  nixos-logo = final.fetchurl {
-    url = "https://brand.nixos.org/internals/nixos-logomark-white-flat-none.svg";
-    hash = "sha256-00efVhs4+7AOH9Y8Evg1snHLSw54sg06iEEF/LaScwk=";
-  };
   meta = with builtins; fromTOML (readFile ../src/pyproject.toml);
 in
 {
@@ -105,7 +99,7 @@ in
       chmod +x $out/bin/manage.py
       wrapProgram $out/bin/manage.py --prefix PYTHONPATH : "$PYTHONPATH"
       cp ${sources.htmx}/dist/htmx.min.js* $out/${final.python3.sitePackages}/webview/static/
-      cp ${nixos-logo} $out/${final.python3.sitePackages}/webview/static/nixos-logomark-white-flat-none.svg
+      cp ${sources.nixos-logo} $out/${final.python3.sitePackages}/webview/static/nixos-logo.svg
     '';
   };
 }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -55,6 +55,12 @@
       "url": "https://github.com/nixos/infra/archive/07d71a891450d248f21e628e9b2bd93c7b42a371.tar.gz",
       "hash": "sha256-rzjAy2h7P8JbHCslPhXDa3YXmNXhWJRi9WmhfPFNzXQ="
     },
+    "nixos-logo": {
+      "type": "Url",
+      "url": "https://brand.nixos.org/internals/nixos-logomark-white-flat-none.svg",
+      "unpack": false,
+      "hash": "sha256-00efVhs4+7AOH9Y8Evg1snHLSw54sg06iEEF/LaScwk="
+    },
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",

--- a/src/shared/templates/base.html
+++ b/src/shared/templates/base.html
@@ -32,7 +32,7 @@
                aria-hidden="true"
                height="40"
                width="40"
-               src="{% static 'nixos-logomark-white-flat-none.svg' %}" />
+               src="{% static 'nixos-logo.svg' %}" />
         Nixpkgs security tracker</a>
       </h1>
       <div class="row gap centered">


### PR DESCRIPTION
Thanks @piegamesde and contributors to https://github.com/andir/npins/pull/223 for making this sort of thing a lot more elegant!