### PR TITLE
refactor: single source of truth for tracked channel states

### DIFF
--- a/src/shared/listeners/automatic_linkage.py
+++ b/src/shared/listeners/automatic_linkage.py
@@ -25,7 +25,7 @@ from django.db.models import (
 from shared.channels import ContainerChannel
 from shared.models.cve import Container, Cpe
 from shared.models.linkage import CVEDerivationClusterProposal, ProvenanceFlags
-from shared.models.nix_evaluation import MAJOR_CHANNELS, NixDerivation, NixEvaluation
+from shared.models.nix_evaluation import NixChannel, NixDerivation, NixEvaluation
 
 logger = logging.getLogger(__name__)
 
@@ -34,13 +34,8 @@ def produce_linkage_candidates(
     container: Container,
     filtered_affected: models.QuerySet,
 ) -> dict[NixDerivation, ProvenanceFlags]:
-    # FIXME(@fricklerhandwerk): This will fall apart when we obtain the channel structure dynamically [ref:channel-structure]
-    active_channels_q = Q()
-    for ch in MAJOR_CHANNELS:
-        active_channels_q |= Q(channel__channel_branch__contains=ch)
-
     latest_complete_channels = NixEvaluation.objects.filter(
-        active_channels_q
+        channel__state__in=NixChannel.TRACKED_STATES,
     ).latest_completed_per_channel()
 
     package_names = (

--- a/src/shared/listeners/nix_channels.py
+++ b/src/shared/listeners/nix_channels.py
@@ -7,14 +7,6 @@ from shared.models import NixChannel, NixEvaluation
 
 logger = logging.getLogger(__name__)
 
-# Those are channels we care about.
-ADMISSIBLE_CHANNEL_STATES = (
-    NixChannel.ChannelState.DEPRECATED,
-    NixChannel.ChannelState.BETA,
-    NixChannel.ChannelState.STABLE,
-    NixChannel.ChannelState.UNSTABLE,
-)
-
 
 def enqueue_evaluation_job(channel: NixChannel) -> tuple[NixEvaluation, bool]:
     eval_job, created = NixEvaluation.objects.get_or_create(
@@ -35,7 +27,7 @@ def enqueue_evaluation_job(channel: NixChannel) -> tuple[NixEvaluation, bool]:
 @pgpubsub.post_insert_listener(NixChannelInsertChannel)
 def start_evaluation_jobs_upon_insertion(old: NixChannel, new: NixChannel) -> None:
     logger.info("Nix channel created: %s", new.head_sha1_commit)
-    if new.state in ADMISSIBLE_CHANNEL_STATES:
+    if new.state in NixChannel.TRACKED_STATES:
         enqueue_evaluation_job(new)
 
 
@@ -48,6 +40,6 @@ def start_evaluation_jobs_upon_updates(old: NixChannel, new: NixChannel) -> None
     )
     if (
         old.head_sha1_commit != new.head_sha1_commit
-        and new.state in ADMISSIBLE_CHANNEL_STATES
+        and new.state in NixChannel.TRACKED_STATES
     ):
         enqueue_evaluation_job(new)

--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -153,6 +153,15 @@ class NixChannel(TimeStampMixin):
         STABLE = "stable", _("Stable")
         UNSTABLE = "rolling", _("Unstable")
 
+    # States we care about for evaluation and prospective matching, as those are considered to be maintained.
+    # Mutable per channel over time.
+    TRACKED_STATES = (
+        ChannelState.DEPRECATED,
+        ChannelState.BETA,
+        ChannelState.STABLE,
+        ChannelState.UNSTABLE,
+    )
+
     # A staging branch is the `release-$number` branch or `master` for unstable.
     # Not to confuse with the `staging` branch itself.
     release_branch = models.CharField(max_length=255)

--- a/src/shared/tests/test_linkage.py
+++ b/src/shared/tests/test_linkage.py
@@ -12,7 +12,6 @@ from shared.models.linkage import (
     ProvenanceFlags,
 )
 from shared.models.nix_evaluation import (
-    MAJOR_CHANNELS,
     NixChannel,
     NixDerivation,
     NixEvaluation,
@@ -70,21 +69,22 @@ def test_link_only_latest_eval(
     cache_new_suggestions(suggestion)
 
 
-def test_link_only_major_channels(
+def test_eol_channel_produces_no_matches(
     make_container: Callable[..., Container],
     make_channel: Callable[..., NixChannel],
     make_evaluation: Callable[..., NixEvaluation],
     make_drv: Callable[..., NixDerivation],
 ) -> None:
     """
-    Derivations on channels outside MAJOR_CHANNELS must not produce matches.
-    Otherwise we'd be notifying people who aren't maintainers any more.
+    Derivations on unmaintained channels must not produce matches.
     """
-    old_release = "24.05"
-    assert old_release not in MAJOR_CHANNELS
-    old_channel = make_channel(channel_branch=f"nixos-{old_release}")
-    old_eval = make_evaluation(channel=old_channel)
-    make_drv(pname="foo", evaluation=old_eval)
+    assert NixChannel.ChannelState.END_OF_LIFE not in NixChannel.TRACKED_STATES
+    eol_channel = make_channel(
+        channel_branch="nixos-24.05",
+        state=NixChannel.ChannelState.END_OF_LIFE,
+    )
+    eol_eval = make_evaluation(channel=eol_channel)
+    make_drv(pname="foo", evaluation=eol_eval)
 
     container = make_container(package_name="foo")
     assert not build_new_links(container)


### PR DESCRIPTION
Depends on https://github.com/NixOS/nix-security-tracker/pull/1122

Related: https://github.com/NixOS/nix-security-tracker/issues/864