### PR TITLE
fix: less surprising log lines

### DIFF
--- a/src/shared/management/commands/garbage_collect.py
+++ b/src/shared/management/commands/garbage_collect.py
@@ -263,7 +263,7 @@ class Command(BaseCommand):
             ),
             model=DerivationClusterProposalLink,
             pk_field="id",
-            label="proposal links",
+            label="suggestion links to duplicate derivations",
             batch_size=batch_size,
         )
 
@@ -273,7 +273,7 @@ class Command(BaseCommand):
             ),
             model=NixDerivation,
             pk_field="id",
-            label="derivations without metadata",
+            label="duplicate derivations",
             batch_size=batch_size,
         )
 
@@ -281,7 +281,7 @@ class Command(BaseCommand):
             qs=NixDerivationMeta.objects.filter(derivation__isnull=True),
             model=NixDerivationMeta,
             pk_field="id",
-            label="derivation metadata",
+            label="dangling metadata",
             batch_size=batch_size,
         )
 


### PR DESCRIPTION
When trying it out, the wording scared me a bit. I thought for a moment we would delete "derivations that don't have metadata", which was not the point of that particular run.