### PR TITLE
fix: prune package-attribute mappings orphaned by garbage collection

### DIFF
--- a/src/shared/management/commands/garbage_collect.py
+++ b/src/shared/management/commands/garbage_collect.py
@@ -21,6 +21,9 @@ from shared.models.nix_evaluation import (
     NixDerivationMeta,
     NixEvaluation,
 )
+from shared.models.package import PackageAttrpath
+
+DEFAULT_CUTOFF_DAYS = 365
 
 
 class Command(BaseCommand):
@@ -59,7 +62,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--cutoff-days",
             type=int,
-            default=365,
+            default=DEFAULT_CUTOFF_DAYS,
             help="Number of days for data cutoff",
         )
 
@@ -79,16 +82,18 @@ class Command(BaseCommand):
         # Each step satisfies the cascading constraints that gate the next step.
         # `pghistory` events are never auto-deleted — each step explicitly clears relevant events first.
 
-        self.stdout.write("\n[1/5] Deleting stale matches")
+        self.stdout.write("\n[1/6] Deleting stale matches")
         self._delete_stale_matches(cutoff, batch_size, dry_run)
-        self.stdout.write("\n[2/5] Deleting unmatched derivations")
+        self.stdout.write("\n[2/6] Deleting unmatched derivations")
         self._delete_unmatched_derivations(cutoff, batch_size, dry_run)
-        self.stdout.write("\n[3/5] Deleting empty evaluations")
+        self.stdout.write("\n[3/6] Deleting empty evaluations")
         self._delete_empty_evaluations(cutoff, batch_size, dry_run)
-        self.stdout.write("\n[4/5] Deleting inactive channels")
+        self.stdout.write("\n[4/6] Deleting inactive channels")
         self._delete_inactive_channels(batch_size, dry_run)
-        self.stdout.write("\n[5/5] Deduplicating evaluations")
+        self.stdout.write("\n[5/6] Deduplicating evaluations")
         self._deduplicate_evaluations(batch_size, dry_run)
+        self.stdout.write("\n[6/6] Pruning stale package attrpaths")
+        self._prune_stale_package_attrpaths(batch_size, dry_run)
 
         self.stdout.write(self.style.SUCCESS("\nGarbage collection complete."))
 
@@ -230,6 +235,16 @@ class Command(BaseCommand):
             pk_field="channel_branch",
             label="channels",
             batch_size=batch_size,
+        )
+
+    def _prune_stale_package_attrpaths(self, batch_size: int, dry_run: bool) -> None:
+        self._delete_in_batches(
+            qs=PackageAttrpath.objects.stale(),
+            model=PackageAttrpath,
+            pk_field="attrpath",
+            label="stale package attrpaths",
+            batch_size=batch_size,
+            dry_run=dry_run,
         )
 
     def _deduplicate_evaluations(self, batch_size: int, dry_run: bool) -> None:

--- a/src/shared/models/package.py
+++ b/src/shared/models/package.py
@@ -1,9 +1,18 @@
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
 from django.db import models
+from django.db.models import Exists, OuterRef
 from pgtrigger import UpdateSearchVector
 
 from shared.models.nix_evaluation import NixDerivation, NixMaintainer
+
+
+class PackageAttrpathQuerySet(models.QuerySet):
+    def stale(self) -> models.QuerySet:
+        live = PackageDerivation.objects.filter(
+            derivation__attribute=OuterRef("attrpath"),
+        )
+        return self.filter(~Exists(live))
 
 
 class Package(models.Model):
@@ -48,6 +57,8 @@ class PackageAttrpath(models.Model):
         Package, on_delete=models.CASCADE, related_name="attrpaths"
     )
     attrpath = models.CharField(max_length=255, unique=True)
+
+    objects = PackageAttrpathQuerySet.as_manager()
 
 
 class PackageDerivation(models.Model):

--- a/src/shared/tests/test_garbage_collect.py
+++ b/src/shared/tests/test_garbage_collect.py
@@ -6,6 +6,7 @@ from io import StringIO
 import pytest
 from django.core.management import call_command
 
+from shared.management.commands.garbage_collect import DEFAULT_CUTOFF_DAYS
 from shared.models.cve import Container, CveRecord
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
@@ -22,6 +23,8 @@ from shared.models.nix_evaluation import (
     NixEvaluation,
     NixMaintainer,
 )
+from shared.models.package import Package, PackageAttrpath, PackageDerivation
+from shared.package_clustering import cluster_packages
 
 
 def test_cve_record_not_deleted_with_stale_proposal(
@@ -348,3 +351,94 @@ def test_when_there_is_duplicate_evaluation(
     assert not DerivationClusterProposalLink.objects.filter(
         proposal=duplicate_suggestion
     ).exists()
+
+
+def test_garbage_collect_prunes_stale_package_attrpaths(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    channel = make_channel(state=NixChannel.ChannelState.END_OF_LIFE)
+    evaluation = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        age=timedelta(days=DEFAULT_CUTOFF_DAYS + 1),
+    )
+    drv = make_drv(evaluation=evaluation)
+    cluster_packages(NixDerivation.objects.filter(pk=drv.pk))
+    assert PackageAttrpath.objects.filter(attrpath=drv.attribute).exists()
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert not NixDerivation.objects.filter(pk=drv.pk).exists()
+    assert not PackageAttrpath.objects.filter(attrpath=drv.attribute).exists()
+
+
+def test_garbage_collect_preserves_linked_attrpaths(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    channel = make_channel(state=NixChannel.ChannelState.END_OF_LIFE)
+    evaluation = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        age=timedelta(days=DEFAULT_CUTOFF_DAYS + 1),
+    )
+    drv = make_drv(evaluation=evaluation)
+    cluster_packages(NixDerivation.objects.filter(pk=drv.pk))
+    make_suggestion(
+        drvs={drv: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+    )
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert NixDerivation.objects.filter(pk=drv.pk).exists()
+    assert PackageDerivation.objects.filter(derivation=drv).exists()
+    assert PackageAttrpath.objects.filter(attrpath=drv.attribute).exists()
+
+
+def test_garbage_collect_preserves_attrpath_with_live_link(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    channel = make_channel(state=NixChannel.ChannelState.END_OF_LIFE)
+    evaluation = make_evaluation(
+        channel=channel,
+        state=NixEvaluation.EvaluationState.COMPLETED,
+        age=timedelta(days=DEFAULT_CUTOFF_DAYS + 1),
+    )
+    drv_orphan = make_drv(evaluation=evaluation, attribute="shared-attr")
+    drv_linked = make_drv(evaluation=evaluation, attribute="shared-attr")
+    cluster_packages(
+        NixDerivation.objects.filter(pk__in=[drv_orphan.pk, drv_linked.pk])
+    )
+    make_suggestion(
+        drvs={drv_linked: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+    )
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert not NixDerivation.objects.filter(pk=drv_orphan.pk).exists()
+    assert NixDerivation.objects.filter(pk=drv_linked.pk).exists()
+    assert PackageDerivation.objects.filter(derivation=drv_linked).exists()
+    assert PackageAttrpath.objects.filter(attrpath="shared-attr").exists()
+
+
+def test_garbage_collect_dry_run_preserves_stale_package_attrpaths(
+    drv: NixDerivation,
+    make_package: Callable[..., Package],
+) -> None:
+    make_package(drv)
+    assert PackageAttrpath.objects.filter(attrpath=drv.attribute).exists()
+
+    out = StringIO()
+    call_command("garbage_collect", "--dry-run", stdout=out)
+
+    assert PackageAttrpath.objects.filter(attrpath=drv.attribute).exists()
+    assert "stale package attrpath" in out.getvalue().lower()


### PR DESCRIPTION
Package clustering registers `PackageAttrpath` rows as derivations are linked, but when derivations are garbage-collected their `PackageDerivation` rows are removed while the attrpath mappings can remain. This adds a batched prune helper and runs it as the final step of `garbage_collect`.

Closes #1111 