### PR TITLE
feat: update pending and draft suggestion for new evaluation

### DIFF
--- a/src/shared/listeners/automatic_linkage.py
+++ b/src/shared/listeners/automatic_linkage.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 
 import pgpubsub
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.db.models import (
     Case,
     Exists,
@@ -269,6 +269,73 @@ def build_new_links(container: Container) -> bool:
         )
 
     return True
+
+
+def refresh_suggestion_derivation_links(
+    suggestion: CVEDerivationClusterProposal,
+) -> None:
+    """
+    Re-match a suggestion against the latest evaluations and reconcile its
+    derivation links, mirroring all rejection/match conditions from build_new_links.
+    """
+    container = (
+        suggestion.cve.container.filter(
+            affected__package_name__isnull=False,
+        ).first()
+        or suggestion.cve.container.first()
+    )
+
+    if container is None:
+        return
+
+    outcome = resolve_linkage_candidates(container)
+
+    with transaction.atomic():
+        try:
+            suggestion = CVEDerivationClusterProposal.objects.select_for_update().get(
+                pk=suggestion.pk,
+                status__in=[
+                    CVEDerivationClusterProposal.Status.PENDING,
+                    CVEDerivationClusterProposal.Status.ACCEPTED,
+                ],
+            )
+        except CVEDerivationClusterProposal.DoesNotExist:
+            return
+
+        update_fields = ["algorithm_version"]
+        suggestion.algorithm_version = (
+            CVEDerivationClusterProposal.CURRENT_ALGORITHM_VERSION
+        )
+
+        if outcome.rejection is not None:
+            suggestion.status = CVEDerivationClusterProposal.Status.REJECTED
+            suggestion.rejection_reason = outcome.rejection.reason
+            suggestion.rejection_match_count = outcome.rejection.match_count or None
+            suggestion.rejection_max_matches_limit = (
+                outcome.rejection.max_matches_limit or None
+            )
+            update_fields += [
+                "status",
+                "rejection_reason",
+                "rejection_match_count",
+                "rejection_max_matches_limit",
+            ]
+
+        suggestion.save(update_fields=update_fields)
+
+        DerivationClusterProposalLink.objects.filter(proposal=suggestion).delete()
+
+        if outcome.derivations:
+            DerivationClusterProposalLink.objects.bulk_create(
+                build_derivation_links(suggestion, outcome.derivations)
+            )
+
+    logger.info(
+        "Refreshed derivation links for suggestion %d (rejection_reason=%s, derivations=%s).",
+        suggestion.pk,
+        outcome.rejection.reason if outcome.rejection else None,
+        outcome.derivations.count() if outcome.derivations is not None else 0,
+    )
 
 
 @pgpubsub.post_insert_listener(ContainerChannel)

--- a/src/shared/listeners/package_clustering.py
+++ b/src/shared/listeners/package_clustering.py
@@ -2,8 +2,11 @@ import logging
 
 import pgpubsub
 
+from shared.cache_suggestions import cache_new_suggestions
 from shared.channels import NixEvaluationUpdateChannel
+from shared.listeners.automatic_linkage import refresh_suggestion_derivation_links
 from shared.models import NixDerivation, NixEvaluation
+from shared.models.linkage import CVEDerivationClusterProposal
 from shared.package_clustering import cluster_packages
 
 logger = logging.getLogger(__name__)
@@ -26,3 +29,24 @@ def cluster_after_evaluation(old: NixEvaluation, new: NixEvaluation) -> None:
         f"updated {result.packages_updated}, created {result.packages_created} packages, "
         f"updated {result.attrpaths_updated}, created {result.attrpaths_created} attrpaths."
     )
+
+    affected_suggestions = CVEDerivationClusterProposal.objects.filter(
+        derivations__parent_evaluation__channel=evaluation.channel,
+        status__in=[
+            CVEDerivationClusterProposal.Status.PENDING,
+            CVEDerivationClusterProposal.Status.ACCEPTED,
+        ],
+    ).distinct()
+
+    count = 0
+    for suggestion in affected_suggestions:
+        refresh_suggestion_derivation_links(suggestion)
+        cache_new_suggestions(suggestion)
+        count += 1
+
+    if count:
+        logger.info(
+            "Updated derivation links and rebuilt caches for %d suggestion(s) after evaluation %s",
+            count,
+            evaluation,
+        )

--- a/src/shared/tests/test_linkage.py
+++ b/src/shared/tests/test_linkage.py
@@ -5,7 +5,10 @@ import pytest
 from django.test import override_settings
 
 from shared.cache_suggestions import cache_new_suggestions
-from shared.listeners.automatic_linkage import build_new_links
+from shared.listeners.automatic_linkage import (
+    build_new_links,
+    refresh_suggestion_derivation_links,
+)
 from shared.models.cve import Container, Tag
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
@@ -284,3 +287,183 @@ def test_skip_known_vulnerability(
     )
     assert not proposal.derivations.filter(attribute=drv1.attribute).exists()
     assert proposal.derivations.filter(attribute=drv2.attribute).exists()
+
+
+def test_refresh_links_replaced_with_latest_evaluation(
+    cve: Container,
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """
+    Links are replaced with derivations from the latest evaluation,
+    using the same name-based matching as the initial linkage algorithm.
+    """
+    old_eval = make_evaluation()
+    new_eval = make_evaluation()
+
+    old_drv = make_drv(pname="foo", evaluation=old_eval)
+    new_drv = make_drv(pname="foo", evaluation=new_eval, attribute=old_drv.attribute)
+
+    suggestion = make_suggestion(
+        container=cve, drvs={old_drv: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+
+    refresh_suggestion_derivation_links(suggestion)
+
+    suggestion.refresh_from_db()
+    assert (
+        suggestion.algorithm_version
+        == CVEDerivationClusterProposal.CURRENT_ALGORITHM_VERSION
+    )
+    links = DerivationClusterProposalLink.objects.filter(proposal=suggestion)
+    assert links.count() == 1
+    link = links.get()
+    assert link.derivation == new_drv
+    assert link.provenance_flags == ProvenanceFlags.PACKAGE_NAME_MATCH
+
+
+def test_refresh_suggestion_rejected_when_package_gone(
+    cve: Container,
+    make_evaluation: Callable[..., NixEvaluation],
+    drv: NixDerivation,
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """
+    When a package no longer appears in the latest evaluation the suggestion is
+    rejected with NO_MATCHES and its links are cleared.
+    """
+    suggestion = make_suggestion(
+        container=cve, drvs={drv: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+
+    make_evaluation()
+
+    refresh_suggestion_derivation_links(suggestion)
+
+    suggestion.refresh_from_db()
+    assert suggestion.status == CVEDerivationClusterProposal.Status.REJECTED
+    assert (
+        suggestion.rejection_reason
+        == CVEDerivationClusterProposal.RejectionReason.NO_MATCHES
+    )
+    assert not DerivationClusterProposalLink.objects.filter(
+        proposal=suggestion
+    ).exists()
+
+
+@override_settings(MAX_MATCHES=1)
+def test_refresh_suggestion_rejected_when_too_many_matches(
+    cve: Container,
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """When matches exceed MAX_MATCHES the suggestion is rejected with MAX_MATCHES_EXCEEDED."""
+    old_eval = make_evaluation()
+    new_eval = make_evaluation()
+
+    old_drv = make_drv(pname="foo", evaluation=old_eval)
+    make_drv(pname="foo", evaluation=new_eval)
+    make_drv(pname="foo", evaluation=new_eval)
+
+    suggestion = make_suggestion(
+        container=cve, drvs={old_drv: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+
+    refresh_suggestion_derivation_links(suggestion)
+
+    suggestion.refresh_from_db()
+    assert suggestion.status == CVEDerivationClusterProposal.Status.REJECTED
+    assert (
+        suggestion.rejection_reason
+        == CVEDerivationClusterProposal.RejectionReason.MAX_MATCHES_EXCEEDED
+    )
+
+
+def test_refresh_suggestion_rejected_when_derivation_has_known_vulnerability(
+    cve: Container,
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Suggestion is rejected when the latest matching derivation lists the CVE as a known vulnerability."""
+    old_eval = make_evaluation()
+    new_eval = make_evaluation()
+
+    old_drv = make_drv(pname="foo", evaluation=old_eval)
+    make_drv(
+        pname="foo",
+        evaluation=new_eval,
+        attribute=old_drv.attribute,
+        known_vulnerabilities=[cve.cve.cve_id],
+    )
+
+    suggestion = make_suggestion(
+        container=cve, drvs={old_drv: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+    assert suggestion.status == CVEDerivationClusterProposal.Status.PENDING
+
+    refresh_suggestion_derivation_links(suggestion)
+
+    suggestion.refresh_from_db()
+    assert suggestion.status == CVEDerivationClusterProposal.Status.REJECTED
+    assert (
+        suggestion.rejection_reason
+        == CVEDerivationClusterProposal.RejectionReason.KNOWN_VULNERABILITY
+    )
+    assert DerivationClusterProposalLink.objects.filter(proposal=suggestion).exists()
+
+
+def test_refresh_skips_published_suggestion_on_rejection(
+    make_evaluation: Callable[..., NixEvaluation],
+    drv: NixDerivation,
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """
+    When a suggestion is published while refresh is running, the status must not
+    be overwritten to REJECTED and its links must not be deleted.
+    """
+    suggestion = make_suggestion(
+        drvs={drv: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=CVEDerivationClusterProposal.Status.PUBLISHED,
+    )
+    # Simulate the stale in-memory object the worker would hold.
+    suggestion.status = CVEDerivationClusterProposal.Status.ACCEPTED
+    # A new evaluation with no matching derivation makes the resolver return NO_MATCHES.
+    make_evaluation()
+
+    refresh_suggestion_derivation_links(suggestion)
+
+    suggestion.refresh_from_db()
+    assert suggestion.status == CVEDerivationClusterProposal.Status.PUBLISHED
+    assert DerivationClusterProposalLink.objects.filter(proposal=suggestion).exists()
+
+
+def test_refresh_skips_published_suggestion_on_match(
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """
+    When a suggestion is published while refresh is running, its derivation links
+    must not be replaced even when newer matching derivations exist.
+    """
+    old_eval = make_evaluation()
+    new_eval = make_evaluation()
+
+    old_drv = make_drv(pname="foo", evaluation=old_eval)
+    make_drv(pname="foo", evaluation=new_eval, attribute=old_drv.attribute)
+
+    suggestion = make_suggestion(
+        drvs={old_drv: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=CVEDerivationClusterProposal.Status.PUBLISHED,
+    )
+    # Simulate the stale in-memory object the worker would hold.
+    suggestion.status = CVEDerivationClusterProposal.Status.ACCEPTED
+
+    refresh_suggestion_derivation_links(suggestion)
+
+    links = DerivationClusterProposalLink.objects.filter(proposal=suggestion)
+    assert links.count() == 1
+    assert links.get().derivation == old_drv

--- a/src/shared/tests/test_package_clustering.py
+++ b/src/shared/tests/test_package_clustering.py
@@ -10,8 +10,15 @@ from django.conf import settings
 from django.core.management import call_command
 from django.db import close_old_connections
 
-from shared.cache_suggestions import parse_drv_name
+from shared.cache_suggestions import cache_new_suggestions, parse_drv_name
 from shared.listeners.package_clustering import cluster_after_evaluation
+from shared.models.cached import CachedSuggestions
+from shared.models.cve import Container
+from shared.models.linkage import (
+    CVEDerivationClusterProposal,
+    DerivationClusterProposalLink,
+    ProvenanceFlags,
+)
 from shared.models.nix_evaluation import (
     NixChannel,
     NixDerivation,
@@ -403,3 +410,66 @@ def test_concurrent_attrpath_consistency(
     pkg = PackageAttrpath.objects.get(attrpath="shared").package
     assert PackageDerivation.objects.get(derivation=drv_a).package == pkg
     assert PackageDerivation.objects.get(derivation=drv_b).package == pkg
+
+
+def test_cache_rebuilt_after_clustering(
+    cve: Container,
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    old_eval = make_evaluation()
+    new_eval = make_evaluation()
+
+    old_drv = make_drv(pname="foo", evaluation=old_eval)
+    make_drv(pname="foo", evaluation=new_eval, attribute=old_drv.attribute)
+
+    suggestion = make_suggestion(
+        container=cve, drvs={old_drv: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+    cache_new_suggestions(suggestion)
+    cached_before = CachedSuggestions.objects.get(proposal=suggestion)
+
+    cluster_after_evaluation(
+        old=NixEvaluation(state=NixEvaluation.EvaluationState.IN_PROGRESS),
+        new=new_eval,
+    )
+
+    cached_after = CachedSuggestions.objects.get(proposal=suggestion)
+    assert cached_after.updated_at > cached_before.updated_at
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        CVEDerivationClusterProposal.Status.REJECTED,
+        CVEDerivationClusterProposal.Status.PUBLISHED,
+    ],
+)
+def test_only_pending_and_accepted_suggestions_updated(
+    status: CVEDerivationClusterProposal.Status,
+    cve: Container,
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Only PENDING and ACCEPTED suggestions have their derivation links refreshed; REJECTED and PUBLISHED are skipped."""
+    old_eval = make_evaluation()
+    new_eval = make_evaluation()
+
+    old_drv = make_drv(pname="foo", evaluation=old_eval)
+    make_drv(pname="foo", evaluation=new_eval, attribute=old_drv.attribute)
+
+    suggestion = make_suggestion(
+        container=cve,
+        drvs={old_drv: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=status,
+    )
+
+    cluster_after_evaluation(
+        old=NixEvaluation(state=NixEvaluation.EvaluationState.IN_PROGRESS),
+        new=new_eval,
+    )
+
+    link = DerivationClusterProposalLink.objects.get(proposal=suggestion)
+    assert link.derivation == old_drv

--- a/src/shared/tests/test_suggestion_caching.py
+++ b/src/shared/tests/test_suggestion_caching.py
@@ -174,6 +174,32 @@ def test_cache_description_from_package(
     )
 
 
+def test_ensure_fresh_cache_builds_when_missing(
+    suggestion: CVEDerivationClusterProposal,
+) -> None:
+    """Test that the cache created when no row exists."""
+    assert not CachedSuggestions.objects.filter(proposal=suggestion).exists()
+
+    suggestion.ensure_fresh_cache()
+
+    assert CachedSuggestions.objects.filter(proposal=suggestion).exists()
+
+
+def test_ensure_fresh_cache_noop_when_fresh(
+    suggestion: CVEDerivationClusterProposal,
+) -> None:
+    """Test that cache does not rebuild when the cache is already fresh."""
+    cache_new_suggestions(suggestion)
+    original_updated_at = CachedSuggestions.objects.get(proposal=suggestion).updated_at
+
+    suggestion.ensure_fresh_cache()
+
+    assert (
+        CachedSuggestions.objects.get(proposal=suggestion).updated_at
+        == original_updated_at
+    )
+
+
 def test_cache_description_falls_back_to_meta(
     suggestion: CVEDerivationClusterProposal,
 ) -> None:


### PR DESCRIPTION
Closes #618 

Description
When a channel evaluation completes, we update each suggestion's linked derivations
to point to the new evaluation's derivations, matched by attribute path. The
suggestion's cache is then marked stale so it rebuilds on next view, showing the
latest package versions.

**The net effect**: 
- every time a new commit is evaluated for a channel, suggestions in that channel automatically track the latest package versions. 
- A user opening a pending suggestion will always see the current version of each package and its
affected/unaffected status against the CVE version constraints.