### PR TITLE
fix: race condition when picking an evaluation

### DIFF
--- a/src/shared/listeners/nix_evaluation.py
+++ b/src/shared/listeners/nix_evaluation.py
@@ -189,10 +189,19 @@ async def drain_lines(
 async def evaluation_entrypoint(
     avg_eval_time: float, evaluation: NixEvaluation
 ) -> None:
+    already_completed = False
+
     # Acquire an evaluation slot atomically: lock all IN_PROGRESS rows
     # to prevent concurrent workers from racing past the count check.
     def _try_acquire_slot() -> bool:
+        nonlocal already_completed
         with transaction.atomic():
+            if NixEvaluation.objects.filter(
+                id=evaluation.pk,
+                state=NixEvaluation.EvaluationState.COMPLETED,
+            ).exists():
+                already_completed = True
+                return True
             in_progress = (
                 NixEvaluation.objects.select_for_update()
                 .filter(state=NixEvaluation.EvaluationState.IN_PROGRESS)
@@ -210,6 +219,10 @@ async def evaluation_entrypoint(
         # Add in average 30s as a jitter to enable clear winners during the grab for the evaluation slot.
         jitter = random.randint(1, 60)
         await asyncio.sleep(avg_eval_time + jitter)
+
+    if already_completed:
+        return
+
     repo = GitRepo(settings.LOCAL_NIXPKGS_CHECKOUT)
     start = time.time()
     try:

--- a/src/shared/tests/test_crash_signals.py
+++ b/src/shared/tests/test_crash_signals.py
@@ -84,7 +84,6 @@ def test_zero_exit_marks_completed(
     assert waiting_evaluation.state == NixEvaluation.EvaluationState.COMPLETED
 
 
-@pytest.mark.xfail(strict=True, reason="Not implemented")
 @pytest.mark.django_db(transaction=True)
 def test_already_completed_evaluation_is_not_re_run(
     make_evaluation: Callable[..., NixEvaluation],

--- a/src/shared/tests/test_crash_signals.py
+++ b/src/shared/tests/test_crash_signals.py
@@ -82,3 +82,44 @@ def test_zero_exit_marks_completed(
     _run_entrypoint(waiting_evaluation, 0)
     waiting_evaluation.refresh_from_db()
     assert waiting_evaluation.state == NixEvaluation.EvaluationState.COMPLETED
+
+
+@pytest.mark.xfail(strict=True, reason="Not implemented")
+@pytest.mark.django_db(transaction=True)
+def test_already_completed_evaluation_is_not_re_run(
+    make_evaluation: Callable[..., NixEvaluation],
+) -> None:
+    completed = make_evaluation(state=NixEvaluation.EvaluationState.COMPLETED)
+    perform_mock = AsyncMock()
+
+    process = MagicMock()
+    stdout = MagicMock()
+    stdout.readline = AsyncMock(return_value=b"")
+    process.stdout = stdout
+    process.wait = AsyncMock(return_value=0)
+    perform_mock.return_value = process
+
+    mock_repo = MagicMock()
+    mock_repo.update_from_ref = AsyncMock()
+
+    mock_file = MagicMock()
+    mock_file.fileno = MagicMock(return_value=1)
+    mock_aiofiles_open = MagicMock()
+    mock_aiofiles_open.__aenter__ = AsyncMock(return_value=mock_file)
+    mock_aiofiles_open.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("shared.listeners.nix_evaluation.perform_evaluation", perform_mock),
+        patch(
+            "shared.listeners.nix_evaluation.GitRepo", MagicMock(return_value=mock_repo)
+        ),
+        patch(
+            "shared.listeners.nix_evaluation.aiofiles.open",
+            return_value=mock_aiofiles_open,
+        ),
+    ):
+        asyncio.run(evaluation_entrypoint(0.0, completed))
+
+    perform_mock.assert_not_called()
+    completed.refresh_from_db()
+    assert completed.state == NixEvaluation.EvaluationState.COMPLETED


### PR DESCRIPTION
Closes https://github.com/NixOS/nix-security-tracker/issues/1066 (actually)

@adekoder you'll like this. The problem kept coming back, and fancy-search helped uncover the underlying issue: there's a possible race condition when the thread crashes before exiting and removing the notification to process a given evaluation. In that case, the completion state gets written, but the evaluation is restarted again, which resets it to in-progress.

I'm still very confused how it happened so often that we got such cases essentially every day, but now it's provably fixed.