### PR TITLE
correct backtick formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ Fetch the tips of all [channel branches](https://nix.dev/concepts/faq#channel-br
 manage fetch_all_channels
 ```
 
-Select a ``head_sha1_commit` from the output and run evaluation on that:
+Select a `head_sha1_commit` from the output and run evaluation on that:
 
 ```console
 manage run_evaluation <commit>

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -80,6 +80,7 @@ in
       django-pghistory
       django-pglock
       django-pgtrigger
+      django-prometheus
       pytest
       pytest-django
       pytest-playwright

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -356,6 +356,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_prometheus",
     "django_filters",
     "debug_toolbar",
     # AllAuth config
@@ -379,6 +380,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -390,6 +392,7 @@ MIDDLEWARE = [
     # Allauth account middleware
     "allauth.account.middleware.AccountMiddleware",
     "pghistory.middleware.HistoryMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "project.urls"

--- a/src/project/urls.py
+++ b/src/project/urls.py
@@ -19,6 +19,7 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
+    path("", include("django_prometheus.urls")),
     path("", include("webview.urls")),
     path("api/", include("api.urls")),
     path("feeds/", include("feeds.urls")),


### PR DESCRIPTION
there was one extra backtick causing incorrect rendering of `head_sha1_commit`