### PR TITLE
 correct backtick formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ Fetch the tips of all [channel branches](https://nix.dev/concepts/faq#channel-br
 manage fetch_all_channels
 ```
 
-Select a ``head_sha1_commit` from the output and run evaluation on that:
+Select a `head_sha1_commit` from the output and run evaluation on that:
 
 ```console
 manage run_evaluation <commit>


### PR DESCRIPTION
`head_sha1_commit` has 1 extra backtick , causing it to not be rendered as expected