### PR TITLE
docs: extract data ingestion and matching into a separate guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ This document is for anyone wanting to contribute to the implementation of the N
 Resources to help you get started:
 
 - [**Quickstart guide**](./docs/quickstart.md): Set up a database, run the service locally.
+- [**Manual data ingestion and matching**](./docs/data_ingestion_and_matching.md): Ingest Nixpkgs metadata and CVEs into your local instance.
 - [**Architecture Overview**](docs/README.md): High-level system design and component interaction.
 - [**Architecture Diagram**](docs/architecture.mermaid): Visual representation of the system (Mermaid source).
 - [**Design Documents**](docs/design/): Detailed design specifications for individual features (E.g., linkage).
@@ -161,37 +162,6 @@ To replicate this on a traditional Unix-like system:
 - Inspect the [local database configuration](./nix/dev-setup.nix)
 - Read the documentation on the respective module options for the general idea, e.g. [`services.postgresql.ensureDatabases`](https://search.nixos.org/options?query=postgresql.ensureDatabases)
 - Search the linked module source for the option names for implementation details, e.g. [`postgresql.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/databases/postgresql.nix)
-
-### Ingest Nixpkgs metadata
-
-Fetch the tips of all [channel branches](https://nix.dev/concepts/faq#channel-branches):
-
-```console
-manage fetch_all_channels
-```
-
-Select a `head_sha1_commit` from the output and run evaluation on that:
-
-```console
-manage run_evaluation <commit>
-```
-
-### Start matching listeners and ingest CVEs for matching
-
-Matching CVEs against Nixpkgs metadata is triggered by `pgpubsub` notifications internally as CVEs are ingested.
-To test this dataflow locally, start the listeners:
-
-```console
-manage listen -v3 --recover
-```
-
-Ingest some CVEs:
-
-```console
-manage ingest_bulk_cve --from 2024-01-01 --to 2024-01-31
-```
-
-This should produce untriaged matches.
 
 ### Resetting the database
 

--- a/docs/data_ingestion_and_matching.md
+++ b/docs/data_ingestion_and_matching.md
@@ -1,0 +1,91 @@
+# Working with data locally
+
+This document shows how to fetch channels, run evaluations, ingest CVEs and produce untriaged matches on your local instance.
+
+## Prerequisites
+
+- Follow [Quickstart](./quickstart.md) to set up a running local instance with a database.
+
+### Ingest Nixpkgs metadata
+
+1. Fetch the tips of all [channel branches](https://nix.dev/concepts/faq#channel-branches).
+
+```console
+manage fetch_all_channels
+```
+
+When running this command for first time, this would take a couple of minutes.
+In the meantime you can watch some cat videos.
+The output will look like this:
+
+```console
+{'channel_branch': 'nixos-25.05',
+ 'head_sha1_commit': 'ac62194c3917d5f474c1a844b6fd6da2db95077d',
+ 'release_branch': 'release-25.05',
+ 'state': NixChannel.ChannelState.END_OF_LIFE}
+{'channel_branch': 'nixos-25.05-small',
+ 'head_sha1_commit': 'ac62194c3917d5f474c1a844b6fd6da2db95077d',
+ 'release_branch': 'release-25.05',
+ 'state': NixChannel.ChannelState.END_OF_LIFE}
+```
+
+2. Select a `head_sha1_commit` from the output of `fetch_all_channels` command and run evaluation on that:
+
+```console
+manage run_evaluation <commit>
+```
+
+This would take `6-7`G of memory and `20-30` min on reasonably modern machine.
+
+This command _evaluates_ the Nix expression describing the Nixpkgs package collection at that commit, extracting their versions, maintainers, licenses, etc. into your local database.
+
+Without this, there's nothing for CVEs to match against.
+
+The output of this command will look something like this:
+
+```console
+DEBUG 2026-06-19 15:50:08,640 evaluation 62141 130663090386624 Skipping license without SPDX-ID: {
+  "fullName": "Unfree",
+  "deprecated": false,
+  "free": false,
+  "redistributable": false,
+  "shortName": "unfree",
+  "spdxId": null,
+  "url": null
+}
+DEBUG 2026-06-19 15:50:08,640 evaluation 62141 130663090386624 Skipping license without SPDX-ID: {
+  "fullName": "Unfree",
+  "deprecated": false,
+  "free": false,
+  "redistributable": false,
+  "shortName": "unfree",
+  "spdxId": null,
+  "url": null
+}
+DEBUG 2026-06-19 15:50:08,652 evaluation 62141 130663090386624 Parsed 0 maintainers and 107 licences for 22023 derivations in 1.985667 s
+DEBUG 2026-06-19 15:50:08,652 evaluation 62141 130663090386624 Ingested 0 maintainers for 22023 derivations in 0.000060 s
+```
+
+### Start matching listeners and ingest CVEs for matching
+
+1. Matching CVEs against Nixpkgs metadata is triggered by `pgpubsub` notifications internally as CVEs are ingested.
+   To test this dataflow locally, start the listeners:
+
+```console
+manage listen -v3 --recover
+```
+
+This will run in foreground and block this terminal.
+
+2. Open a second terminal, enter development shell and Ingest some CVEs:
+
+> [!NOTE]
+> `ingest_bulk_cve` requires a configured GitHub App with access to `CVEProject/cvelistV5`.
+> If you see `InvalidKeyError: Could not parse the provided public key`, your GitHub App private key is missing or misconfigured.
+> [Set up GitHub credentials](../CONTRIBUTING.md#setting-up-credentials) in that case.
+
+```console
+manage ingest_bulk_cve --from 2026-01-01 --to 2026-01-31
+```
+
+This should produce untriaged matches.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,3 +45,5 @@ open http://127.0.0.1:8000
 ## Next steps
 
 In order to log in to the service with your GitHub account, [set up credentials](../CONTRIBUTING.md#setting-up-credentials).
+
+Then try it out with real data by running [manual data ingestion and matching](./data_ingestion_and_matching.md).


### PR DESCRIPTION
Continuing https://github.com/NixOS/nix-security-tracker/pull/1085#issuecomment-4739776166

Plan is to create a isolated and more beginner friendly guide to show how to ingest and match data locally . 

What i plan to do further is show example of `ingest bulk ...` command, and want some thoughts on if it would be good to remove the relevant part from `contributing.md` and let this doc be sufficient or not. 

apart from that , there's resetting db table which i am assuming is only for those who have ssh access so it would be nice to add another section for devs who don't have the access ... 