### PR TITLE
feat: expose proposal false-positive ratio

### DIFF
--- a/contrib/grafana-dashboard.json
+++ b/contrib/grafana-dashboard.json
@@ -800,6 +800,86 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Proposal rejection rate among triaged suggestions: rejected ÷ (accepted + rejected). Published proposals count as accepted. Pending proposals are excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sql_false_positive_ratio{sql_job=\"sectracker\", instance=\"$Instance\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "False-positive ratio",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/infra/README.md
+++ b/infra/README.md
@@ -57,6 +57,6 @@ Moreover, a [Postgres Exporter](https://github.com/prometheus-community/postgres
 
 Metrics are scraped hourly from the tracker database and exposed as `sql_<name>` in Prometheus.
 
-| Metric | Definition |
-|--------|------------|
+| Metric                 | Definition                                                                                                                                                                                                                                                                                            |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `false_positive_ratio` | Proposal rejection rate among triaged suggestions: `rejected / (accepted + rejected)`, where `published` proposals count as accepted. Pending proposals are excluded. Value is 0-1 (display as a percentage in Grafana). Auto-rejections (E.g. hardware-only CPE) are included in the rejected count. |

--- a/infra/README.md
+++ b/infra/README.md
@@ -52,3 +52,11 @@ Then commit `secrets/name_of_secret.age` as usual.
 A [Prometheus Node Exporter](https://github.com/prometheus/node_exporter) is running exposing host specfic metrics. These are scraped by the nixos.org [Prometheus](https://prometheus.nixos.org/graph) and are also available under [Grafana](https://grafana.nixos.org/d/rYdddlPWk/node-exporter-full?orgId=1&from=now-24h&to=now&timezone=browser&var-datasource=default&var-job=node&var-node=tracker.security.nixos.org:9100&var-diskdevices=%5Ba-z%5D%2B%7Cnvme%5B0-9%5D%2Bn%5B0-9%5D%2B%7Cmmcblk%5B0-9%5D%2B&refresh=1m).
 
 Moreover, a [Postgres Exporter](https://github.com/prometheus-community/postgres_exporter) and a [SQL exporter](https://github.com/justwatchcom/sql_exporter) run in the host exposing Postgres and application specific metrics. A dashboard for these metrics is [here](https://grafana.nixos.org/d/beo2uotj65lvkb/nix-security-tracker?orgId=1&from=now-6h&to=now&timezone=browser&var-Instance=tracker.security.nixos.org:9237).
+
+### Application metrics
+
+Metrics are scraped hourly from the tracker database and exposed as `sql_<name>` in Prometheus.
+
+| Metric | Definition |
+|--------|------------|
+| `false_positive_ratio` | Proposal rejection rate among triaged suggestions: `rejected / (accepted + rejected)`, where `published` proposals count as accepted. Pending proposals are excluded. Value is 0-1 (display as a percentage in Grafana). Auto-rejections (E.g. hardware-only CPE) are included in the rejected count. |

--- a/infra/common.nix
+++ b/infra/common.nix
@@ -147,6 +147,22 @@ in
           query = "select count(*) from shared_cvederivationclusterproposal where status='published';";
           values = [ "count" ];
         };
+        false_positive_ratio = {
+          query = ''
+            select coalesce(
+              count(*) filter (where status = 'rejected')::double precision
+              / nullif(
+                count(*) filter (where status = 'rejected')
+                + count(*) filter (where status in ('accepted', 'published')),
+                0
+              ),
+              0
+            ) as ratio
+            from shared_cvederivationclusterproposal
+            where status in ('accepted', 'rejected', 'published');
+          '';
+          values = [ "ratio" ];
+        };
       };
       connections = [ "postgres://postgres@/nix-security-tracker?host=/run/postgresql" ];
       interval = "1h";


### PR DESCRIPTION
Towards #1002

Adds a false_positive_ratio SQL exporter metric: triaged proposal rejection rate (rejected / (accepted + rejected), with published counted as accepted). Users can see matching triage quality without running manual SQL.