### PR TITLE
feat: collect performance metrics for regenerating cached suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 .credentials
 *.jsonl
 cve-cache
+prometheus-metrics
 nixpkgs
 nixpkgs-gc-roots/*
 nixpkgs-evaluation-logs/*.log

--- a/contrib/grafana-dashboard.json
+++ b/contrib/grafana-dashboard.json
@@ -884,6 +884,149 @@
       ],
       "title": "Database Size",
       "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Application metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Duration of the last cache regeneration run (oneshot batch job)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sectracker_cache_regeneration_duration_seconds{job=\"node\", instance=\"$Instance\"}",
+          "legendFormat": "{{mode}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache regeneration duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Suggestions regenerated in the last cache regeneration run",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sectracker_cache_regeneration_suggestions{job=\"node\", instance=\"$Instance\"}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache regeneration suggestions",
+      "type": "stat"
     }
   ],
   "schemaVersion": 41,

--- a/default.nix
+++ b/default.nix
@@ -120,6 +120,7 @@ rec {
               };
             in
             if git ? dirtyRev then "${git.shortRev}-dirty" else git.shortRev;
+          METRICS_TEXTFILE_DIR = toString ./. + "/prometheus-metrics";
         };
       };
 
@@ -164,6 +165,7 @@ rec {
         ln -sf ${sources.nixos-logo} src/webview/static/nixos-logo.svg
 
         mkdir -p $CREDENTIALS_DIRECTORY
+        mkdir -p ${toString ./.}/prometheus-metrics
         # TODO(@fricklerhandwerk): move all configuration over to pydantic-settings
         touch .settings.py
         export USER_SETTINGS_FILE=${builtins.toString ./.settings.py}

--- a/infra/common.nix
+++ b/infra/common.nix
@@ -88,7 +88,17 @@ in
   services.prometheus.exporters.node = {
     enable = true;
     openFirewall = true;
+    enabledCollectors = [ "textfile" ];
+    extraFlags = [
+      "--collector.textfile.directory=${config.services.nix-security-tracker.settings.METRICS_TEXTFILE_DIR}"
+    ];
   };
+
+  services.nix-security-tracker.settings.METRICS_TEXTFILE_DIR = "/var/lib/nix-security-tracker/metrics";
+
+  systemd.tmpfiles.rules = [
+    "d ${config.services.nix-security-tracker.settings.METRICS_TEXTFILE_DIR} 2750 nix-security-tracker ${config.services.prometheus.exporters.node.user} -"
+  ];
 
   services.prometheus.exporters.postgres = {
     enable = true;

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -348,7 +348,11 @@ in
           ];
           wantedBy = [ "multi-user.target" ];
 
-          serviceConfig.Type = "oneshot";
+          serviceConfig = {
+            Type = "oneshot";
+            # Make performance metrics file, produced as a side effect, readable by Prometheus node exporter
+            UMask = "0027";
+          };
           script = ''
             wst-manage backfill_package_clustering
             wst-manage regenerate_cached_suggestions

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -63,6 +63,7 @@ in
       pytest-socket
       ipython
       pydantic-settings
+      prometheus-client
       pygithub
       requests
       tqdm

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -100,6 +100,12 @@ class Settings(BaseSettings):
             By default, in the root of this Git repository.
             """
         )
+        METRICS_TEXTFILE_DIR: DirectoryPath | None = Field(
+            description="""
+            Directory for Prometheus textfile metrics consumed by node_exporter.
+            """,
+            default=None,
+        )
         CHANNEL_MONITORING_URL: HttpUrl = Field(
             description="""
             URL from which to fetch the current channel structure.

--- a/src/shared/management/commands/regenerate_cached_suggestions.py
+++ b/src/shared/management/commands/regenerate_cached_suggestions.py
@@ -5,8 +5,10 @@ from typing import Any
 
 from django.core.management.base import BaseCommand
 from django.db.models import Exists, OuterRef, Q
+from prometheus_client import CollectorRegistry, Gauge
 
 from shared.cache_suggestions import cache_new_suggestions
+from shared.metrics import write_metrics_textfile
 from shared.models.cached import CachedSuggestions
 from shared.models.linkage import CVEDerivationClusterProposal
 
@@ -61,9 +63,21 @@ class Command(BaseCommand):
         for suggestion in proposals:
             cache_new_suggestions(suggestion)
             count += 1
-        # FIXME(@fricklerhandwerk): Do structured logging for actual metrics so we can keep track of how we're doing.
-        duration = (time.time() - start,)
+        duration = time.time() - start
+
+        registry = CollectorRegistry()
+        Gauge(
+            "sectracker_cache_regeneration_duration_seconds",
+            "Duration of last cache regeneration run",
+            registry=registry,
+        ).set(duration)
+        Gauge(
+            "sectracker_cache_regeneration_suggestions",
+            "Suggestions regenerated in last run",
+            registry=registry,
+        ).set(float(count))
+        write_metrics_textfile("cache_regeneration", registry)
 
         self.stdout.write(
-            f"Regenerated {count} {label} cached suggestions in {duration} seconds."
+            f"Regenerated {count} {label} cached suggestions in {duration:.2f} seconds."
         )

--- a/src/shared/metrics.py
+++ b/src/shared/metrics.py
@@ -1,0 +1,16 @@
+"""Application metrics helpers for Prometheus export."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from prometheus_client import CollectorRegistry, write_to_textfile
+
+
+def write_metrics_textfile(name: str, registry: CollectorRegistry) -> None:
+    """
+    Write metrics for the node_exporter textfile collector.
+    """
+    if settings.METRICS_TEXTFILE_DIR is None:
+        return
+    prom_path = (settings.METRICS_TEXTFILE_DIR / name).with_suffix(".prom")
+    write_to_textfile(str(prom_path), registry)

--- a/src/shared/tests/test_metrics.py
+++ b/src/shared/tests/test_metrics.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from django.test import override_settings
+from prometheus_client import CollectorRegistry, Gauge
+
+from shared.metrics import write_metrics_textfile
+
+
+def test_write_metrics_textfile_produces_prometheus_format(tmp_path: Path) -> None:
+    with override_settings(METRICS_TEXTFILE_DIR=tmp_path):
+        registry = CollectorRegistry()
+        Gauge(
+            "sectracker_example_seconds",
+            "Example metric for tests",
+            registry=registry,
+        ).set(12.5)
+
+        write_metrics_textfile("sample", registry)
+
+    content = (tmp_path / "sample.prom").read_text()
+    assert "# HELP sectracker_example_seconds Example metric for tests" in content
+    assert "# TYPE sectracker_example_seconds gauge" in content
+    assert "sectracker_example_seconds 12.5" in content
+
+
+def test_write_metrics_textfile_writes_cache_regeneration_metrics(
+    tmp_path: Path,
+) -> None:
+    with override_settings(METRICS_TEXTFILE_DIR=tmp_path):
+        registry = CollectorRegistry()
+        Gauge(
+            "sectracker_cache_regeneration_duration_seconds",
+            "Duration of last cache regeneration run",
+            registry=registry,
+        ).set(42.0)
+        Gauge(
+            "sectracker_cache_regeneration_suggestions",
+            "Suggestions regenerated in last run",
+            registry=registry,
+        ).set(7.0)
+
+        write_metrics_textfile("cache_regeneration", registry)
+
+    content = (tmp_path / "cache_regeneration.prom").read_text()
+    assert (
+        "# HELP sectracker_cache_regeneration_duration_seconds "
+        "Duration of last cache regeneration run"
+    ) in content
+    assert (
+        "# HELP sectracker_cache_regeneration_suggestions "
+        "Suggestions regenerated in last run"
+    ) in content
+    assert "sectracker_cache_regeneration_duration_seconds 42.0" in content
+    assert "sectracker_cache_regeneration_suggestions 7.0" in content


### PR DESCRIPTION
Related to #1002

### Problem

Performance-sensitive batch jobs (cache regeneration, CVE ingestion, garbage collection etcetra) only log durations and counts to stdout/logs. Operators have no Grafana view of whether these jobs are slowing down or processing less data over time. The existing SQL exporter gives aggregate counts and recency (`sql_delta`, `sql_matching`), but not job durations or throughput.

### What this PR does

Establishes the **end-to-end wiring** for application-level metrics from batch jobs to Grafana. Per issue scope, this is wiring + **one sample metric**, not full instrumentation.

### Pipeline
regenerate_cached_suggestions -> cache_regeneration.prom -> node_exporter textfile collector -> Prometheus -> Grafana