### PR TITLE
refactor: `s/is_rolling_release/is_tracking_branch/g`

### DIFF
--- a/src/shared/cache_suggestions.py
+++ b/src/shared/cache_suggestions.py
@@ -316,7 +316,7 @@ def channel_structure(
         packages[attribute_path].derivation_ids.append(derivation.pk)
         if (
             derivation.metadata
-            and derivation.parent_evaluation.channel.is_rolling_release
+            and derivation.parent_evaluation.channel.is_tracking_branch
         ):
             packages[attribute_path].description = derivation.metadata.get_description()
             packages[attribute_path].maintainers = [

--- a/src/shared/evaluation.py
+++ b/src/shared/evaluation.py
@@ -174,7 +174,7 @@ class SyncBatchAttributeIngester:
     ) -> None:
         self.evaluations = evaluations
         self.parent_evaluation = parent_evaluation
-        self.rolling_release = self.parent_evaluation.channel.is_rolling_release
+        self.tracking_branch = self.parent_evaluation.channel.is_tracking_branch
 
     def initialize(self) -> None:
         self.maintainers = list(NixMaintainer.objects.all())
@@ -305,7 +305,7 @@ class SyncBatchAttributeIngester:
 
                 # Older branches may list people who no longer maintain the package on `master`.
                 # Drop them so they don't get spammed.
-                if not self.rolling_release:
+                if not self.tracking_branch:
                     drv_maintainers = []
 
                 metadata.append(drv_metadata)
@@ -335,8 +335,8 @@ class SyncBatchAttributeIngester:
             bulk_maintainers.values(),
             # This will ignore existing rows and won't return primary keys when `True`.
             # That's okay because we'll fetch the relevant objects aftwards unconditionally.
-            ignore_conflicts=not self.rolling_release,
-            update_conflicts=self.rolling_release,
+            ignore_conflicts=not self.tracking_branch,
+            update_conflicts=self.tracking_branch,
             unique_fields=["github_id"],
             update_fields=["github", "email", "matrix", "name"],
         )
@@ -353,8 +353,8 @@ class SyncBatchAttributeIngester:
         start = time.time()
         NixLicense.objects.bulk_create(
             bulk_licenses.values(),
-            ignore_conflicts=not self.rolling_release,
-            update_conflicts=self.rolling_release,
+            ignore_conflicts=not self.tracking_branch,
+            update_conflicts=self.tracking_branch,
             unique_fields=["spdx_id"],
             update_fields=[
                 "deprecated",

--- a/src/shared/listeners/nix_channels.py
+++ b/src/shared/listeners/nix_channels.py
@@ -21,8 +21,8 @@ def enqueue_evaluation_job(channel: NixChannel) -> tuple[NixEvaluation, bool]:
     # If the commit is shared by multiple channels, prefer the tracking branch.
     if (
         not created
-        and channel.is_rolling_release
-        and not eval_job.channel.is_rolling_release
+        and channel.is_tracking_branch
+        and not eval_job.channel.is_tracking_branch
     ):
         eval_job.channel = channel
         eval_job.save(update_fields=["channel", "updated_at"])

--- a/src/shared/listeners/package_clustering.py
+++ b/src/shared/listeners/package_clustering.py
@@ -19,7 +19,7 @@ def cluster_after_evaluation(old: NixEvaluation, new: NixEvaluation) -> None:
     logger.info("Clustering derivations from evaluation %s", evaluation)
     result = cluster_packages(
         NixDerivation.objects.filter(parent_evaluation_id=new.pk),
-        update_packages=evaluation.channel.is_rolling_release,
+        update_packages=evaluation.channel.is_tracking_branch,
     )
     logger.info(
         f"Done. Clustered {result.derivations_processed} derivations: "

--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -129,11 +129,6 @@ class NixDerivationMeta(models.Model):
         return self.description or ""
 
 
-class NixChannelQuerySet(models.QuerySet):
-    def rolling(self) -> "NixChannelQuerySet":
-        return self.filter(channel_branch=settings.TRACKING_BRANCH)
-
-
 class NixChannel(TimeStampMixin):
     """
     This represents a "Nixpkgs" (*) channel, e.g.
@@ -143,8 +138,6 @@ class NixChannel(TimeStampMixin):
 
     (*): Anything that looks like Nixpkgs is also good.
     """
-
-    objects = NixChannelQuerySet.as_manager()
 
     class ChannelState(models.TextChoices):
         END_OF_LIFE = "unmaintained", _("End of life")
@@ -182,7 +175,7 @@ class NixChannel(TimeStampMixin):
         return f"{self.release_branch} -> {self.channel_branch}"
 
     @property
-    def is_rolling_release(self) -> bool:
+    def is_tracking_branch(self) -> bool:
         """
         Whether the channel corresponds to a the tracking branch.
 


### PR DESCRIPTION
We actually care about the tracking branch for latest updates, not
whether it's the rolling release.

The queryset for all channels that correspond to the tracking branch is
not used anywhere.