### PR TITLE
fix: Require POST for social login instead of GET

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -486,8 +486,6 @@ SITE_ID = 1
 
 # Disable regular signup but allow GitHub auth
 SOCIALACCOUNT_ONLY = True
-# Skip intermediate "Continue" page, redirect to GitHub immediately
-SOCIALACCOUNT_LOGIN_ON_GET = True
 ACCOUNT_ALLOW_REGISTRATION = False
 ACCOUNT_EMAIL_VERIFICATION = "none"
 


### PR DESCRIPTION
The [docs of allauth](https://docs.allauth.org/en/dev/socialaccount/configuration.html) specify:
> For security considerations, it is strongly recommended to require POST requests.

This will add an extra step where the user needs to click on a "Continue" button before they can login. I'm opening this PR to discuss if this is a UX decision we made consciously or something that we happened to include. If it's the former, then I'll edit this PR to add a comment to the setting, because it caught me by surprise when looking at the code.