### PR TITLE
fix: read CVE problemTypes via the schema's plural 'descriptions' key

### DIFF
--- a/src/shared/fetchers.py
+++ b/src/shared/fetchers.py
@@ -248,7 +248,7 @@ def make_container(
     problems = [
         desc
         for problem in data.get("problemTypes", [])
-        for desc in problem.get("description", [])
+        for desc in problem.get("descriptions", [])
     ]
     obj.problem_types.set(map(make_problem_type, problems))
     obj.references.set(map(make_reference, data.get("references", [])))

--- a/src/shared/tests/test_fetchers.py
+++ b/src/shared/tests/test_fetchers.py
@@ -1,5 +1,5 @@
-from shared.fetchers import make_metric
-from shared.models.cve import Metric
+from shared.fetchers import make_container, make_metric
+from shared.models.cve import Container, CveRecord, Metric, Organization
 
 
 def test_make_metric_none(
@@ -29,3 +29,59 @@ def test_make_metric_fallback_v3(
     assert metric
     assert metric.format == Metric.Format.V30
     assert metric.vector_string == cvss_v3_metric[Metric.Format.V30]["vectorString"]
+
+
+def _bare_cve_record() -> CveRecord:
+    org, _ = Organization.objects.get_or_create(
+        uuid="11111111-1111-1111-1111-111111111111", short_name="test-org"
+    )
+    return CveRecord.objects.create(cve_id="CVE-2025-0002", assigner=org)
+
+
+# A real CVE Record problemTypes entry per the CVE JSON 5.0 schema: an array of
+# objects that each hold a "descriptions" array, whose items carry lang,
+# description, cweId, type and (optionally) references.
+_PROBLEM_TYPES = [
+    {
+        "descriptions": [
+            {
+                "lang": "en",
+                "description": "Cross-site Scripting (XSS)",
+                "cweId": "CWE-79",
+                "type": "CWE",
+            }
+        ]
+    }
+]
+
+
+def test_make_container_ingests_problem_types_with_cwe_metadata(
+    db: None,
+) -> None:
+    """A CVE container's problemTypes must be ingested at all (the schema
+    keys the array by the plural 'descriptions', not 'description') *and*
+    each ingested ProblemType must keep the cweId/type/description metadata
+    carried on its schema-shaped entry.
+
+    Both symptoms come from the same flatten step (fetchers.py, building the
+    `problems` list from `data["problemTypes"]`): reading the wrong key
+    collapses the list to empty (zero problem types), while dropping fields
+    off the flattened entries would null out cwe_id/_type/description on
+    whatever *is* created. A fix that only addresses one half leaves this
+    single test red.
+    """
+    cve = _bare_cve_record()
+    data = {
+        "providerMetadata": {"orgId": "22222222-2222-2222-2222-222222222222"},
+        "problemTypes": _PROBLEM_TYPES,
+    }
+
+    container = make_container(data, _type=Container.Type.CNA, cve=cve)
+
+    assert container.problem_types.count() == 1
+    problem_type = container.problem_types.get()
+    assert problem_type.cwe_id == "CWE-79"
+    assert problem_type._type == "CWE"
+    assert list(problem_type.description.values_list("value", flat=True)) == [
+        "Cross-site Scripting (XSS)"
+    ]


### PR DESCRIPTION
## Summary

`make_container()` in `src/shared/fetchers.py` read
`problem.get("description", [])` when flattening `problemTypes` entries, but
the CVE JSON 5.0 schema keys this field `descriptions` (plural) — see the
[schema reference](https://cveproject.github.io/cve-schema/schema/docs/#oneOf_i0_containers_cna_problemTypes).
The singular key never matches real CVE data, so `.get()` always fell back
to `[]`, meaning **every ingested CVE ends up with zero problem types**
regardless of what the source record actually contains, as reported in #715.

## Fix

One-line key fix: `problem.get("description", [])` → `problem.get("descriptions", [])`.

While investigating, I also checked the concern (raised alongside #715) that
flattening loses each problem's `cweId`/`type` metadata. Per the actual CVE
5.0 schema, each entry in `problemTypes[].descriptions[]` already carries
`lang`, `description`, `cweId`, and `type` together — exactly the flat shape
`make_problem_type()` expects — so the metadata isn't actually lost; this
single key fix is sufficient on its own.

## Tests

Added `test_make_container_ingests_problem_types_with_cwe_metadata` to
`src/shared/tests/test_fetchers.py`, which builds a `problemTypes` payload
matching the real schema shape and asserts both that a `ProblemType` record
is created at all, and that its `cwe_id`/`_type`/`description` fields are
populated correctly. `pyright` clean, all 4 tests in
`shared/tests/test_fetchers.py` pass.

Fixes #715

🤖 Found and fixed via an automated bug-discovery sweep (code-review-graph +
adversarial multi-agent verification), with human review gating every step
from source selection through this PR.