### PR TITLE
Fix CVE problem type descriptions and backfill CVEs missing it 

### DIFF
--- a/src/shared/fetchers.py
+++ b/src/shared/fetchers.py
@@ -248,7 +248,7 @@ def make_container(
     problems = [
         desc
         for problem in data.get("problemTypes", [])
-        for desc in problem.get("description", [])
+        for desc in problem.get("descriptions", [])
     ]
     obj.problem_types.set(map(make_problem_type, problems))
     obj.references.set(map(make_reference, data.get("references", [])))


### PR DESCRIPTION
Resolves #715 
- New management command `backfill_cve_data` that downloads the latest CVE bundle and re-runs `make_cve()` for every existing `CveRecord` in the database, backfilling their problem types
-  Extracted common download/bundle-extract/cache logic from `ingest_bulk_cve.py` into reusable functions
- prevent duplicate containers per CVE
- makes reingestion idempotent 
- existing container gets refreshed instead of getting skipped 