### PR TITLE
chore: replace all shell invocations with `exec`

### DIFF
--- a/src/shared/git.py
+++ b/src/shared/git.py
@@ -68,14 +68,14 @@ class GitRepo:
 
     async def execute_git_command(
         self,
-        cmd: str,
+        *cmd: str,
         stdout: int | IO[Any] | None = None,
         stderr: int | IO[Any] | None = None,
     ) -> asyncio.subprocess.Process:
         final_stdout = stdout or self.stdout or asyncio.subprocess.PIPE
         final_stderr = stderr or self.stderr or asyncio.subprocess.PIPE
-        return await asyncio.create_subprocess_shell(
-            cmd, cwd=self.repo_path, stdout=final_stdout, stderr=final_stderr
+        return await asyncio.create_subprocess_exec(
+            *cmd, cwd=self.repo_path, stdout=final_stdout, stderr=final_stderr
         )
 
     async def clone(
@@ -91,14 +91,31 @@ class GitRepo:
         stdout = self.stdout or asyncio.subprocess.PIPE
         stderr = self.stderr or asyncio.subprocess.PIPE
         if reference_repo_path is not None:
-            clone_process = await asyncio.create_subprocess_shell(
-                f"git clone --depth=1 --bare --progress --reference={reference_repo_path} {repo_clone_url} {self.repo_path}",
+            clone_process = await asyncio.create_subprocess_exec(
+                *[
+                    "git",
+                    "clone",
+                    "--depth=1",
+                    "--bare",
+                    "--progress",
+                    f"--reference={reference_repo_path}",
+                    repo_clone_url,
+                    self.repo_path,
+                ],
                 stdout=stdout,
                 stderr=stderr,
             )
         else:
-            clone_process = await asyncio.create_subprocess_shell(
-                f"git clone --depth=1 --bare --progress {repo_clone_url} {self.repo_path}",
+            clone_process = await asyncio.create_subprocess_exec(
+                *[
+                    "git",
+                    "clone",
+                    "--depth=1",
+                    "--bare",
+                    "--progress",
+                    repo_clone_url,
+                    self.repo_path,
+                ],
                 stdout=stdout,
                 stderr=stderr,
             )
@@ -111,7 +128,14 @@ class GitRepo:
         e.g. filter out the `bare` worktree.
         """
         process = await self.execute_git_command(
-            "git worktree list -z --porcelain", stdout=asyncio.subprocess.PIPE
+            *[
+                "git",
+                "worktree",
+                "list",
+                "-z",
+                "--porcelain",
+            ],
+            stdout=asyncio.subprocess.PIPE,
         )
         stdout, _ = await process.communicate()
         parts = stdout.split(b"\x00")
@@ -146,7 +170,12 @@ class GitRepo:
         exists = (
             await (
                 await self.execute_git_command(
-                    f"git cat-file commit {object_sha1}",
+                    *[
+                        "git",
+                        "cat-file",
+                        "commit",
+                        object_sha1,
+                    ],
                     stderr=asyncio.subprocess.PIPE,
                 )
             ).wait()
@@ -167,7 +196,14 @@ class GitRepo:
                     # The lock is gone, nothing to do.
                     pass
                 process = await self.execute_git_command(
-                    f"git fetch --porcelain --depth=1 {repo_clone_url} {object_sha1}",
+                    *[
+                        "git",
+                        "fetch",
+                        "--porcelain",
+                        "--depth=1",
+                        repo_clone_url,
+                        object_sha1,
+                    ],
                     stderr=asyncio.subprocess.PIPE,
                 )
                 _, stderr = await process.communicate()
@@ -209,7 +245,14 @@ class GitRepo:
 
         Returns `True` if it does exist, otherwise `False`.
         """
-        process = await self.execute_git_command(f"git worktree remove {name}")
+        process = await self.execute_git_command(
+            *[
+                "git",
+                "worktree",
+                "remove",
+                name,
+            ]
+        )
         deleted = await process.wait() == 0
 
         return deleted
@@ -220,7 +263,13 @@ class GitRepo:
 
         Returns `True` if it does get pruned, otherwise `False`.
         """
-        process = await self.execute_git_command("git worktree prune")
+        process = await self.execute_git_command(
+            *[
+                "git",
+                "worktree",
+                "prune",
+            ]
+        )
         pruned = await process.wait() == 0
 
         return pruned
@@ -246,7 +295,13 @@ class GitRepo:
             await self.prune_working_trees()
 
         process = await self.execute_git_command(
-            f"git worktree add {target_path} {commit_sha1}"
+            *[
+                "git",
+                "worktree",
+                "add",
+                target_path,
+                commit_sha1,
+            ]
         )
         created = await process.wait() == 0
 

--- a/src/shared/tests/test_git_update_from_ref.py
+++ b/src/shared/tests/test_git_update_from_ref.py
@@ -14,7 +14,7 @@ from shared.git import GitRepo, RepositoryError
 
 def _proc(command: str, rc: int, stderr: bytes = b"") -> MagicMock:
     p = MagicMock()
-    p.command = command
+    p.command = command.split(" ")
     p.communicate = AsyncMock(return_value=(b"", stderr))
     p.wait = AsyncMock(return_value=rc)
     return p
@@ -49,9 +49,11 @@ def _run(
     # Validate that mocked processes lined up with real call sites:
     # The Nth call to `execute_git_command` should contain the Nth expected process's `command` substring.
     expected = [p.command for p in processes[: exec_mock.await_count]]
-    actual = [call.args[0] for call in exec_mock.await_args_list]
-    for cmd, sig in zip(actual, expected, strict=True):
-        assert sig in cmd, f"expected a {sig!r} command, got: {cmd!r}"
+    actual = [call.args for call in exec_mock.await_args_list]
+    for command, signature in zip(actual, expected, strict=True):
+        assert list(command[: len(signature)]) == signature, (
+            f"expected a {signature!r} command, got: {command!r}"
+        )
 
     return result, exec_mock, sleep_mock, remove_mock
 


### PR DESCRIPTION
This prevents shell injection attacks with strings we take from upstream.
Those were theoretical anyway, since it would have required breaking the much more valuable target of core NixOS infrastructure.

The change has one advantage: Should the commands ever need to be changed by one argument, the diff will be very tidy.

Context: LLMs running in a loop are being pointed at this project. Hopefully this will quiet them down so we don't get even more redundant reports.