### PR TITLE
fix: Quadruple max_locks_per_transaction

### DIFF
--- a/infra/production.nix
+++ b/infra/production.nix
@@ -78,6 +78,7 @@ in
         max_parallel_workers_per_gather = "4";
         max_parallel_workers = "8";
         max_parallel_maintenance_workers = "4";
+        max_locks_per_transaction = "256";
       };
       authentication = ''
         local all all trust

--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -81,6 +81,7 @@ in
         max_parallel_workers_per_gather = "4";
         max_parallel_workers = "8";
         max_parallel_maintenance_workers = "4";
+        max_locks_per_transaction = "256";
       };
       authentication = ''
         local all all trust

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -135,6 +135,14 @@ in
         PRODUCTION = cfg.production;
         STATIC_ROOT = "/var/lib/nix-security-tracker/static/"; # trailing slash is required!
         VITE_MANIFEST_PATH = "${cfg.frontend}/.vite/manifest.json";
+        PACKAGE_CLUSTERING_BATCH_SIZE =
+          let
+            parallelism = cfg.maxJobProcessors + 1; # account for periodic backfill
+            # fall back to implicit Postgres defaults
+            connections = cfg.services.postgresql.settings.max_connections or 100;
+            locks = cfg.services.postgresql.settings.max_locks_per_transaction or 64;
+          in
+          connections * locks / parallelism * 4 / 5; # add some margin for other transactions
         REVISION =
           (builtins.fetchGit {
             url = ../.;

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -198,6 +198,17 @@ class Settings(BaseSettings):
         EMAIL_USE_SSL: bool = False
         DEFAULT_FROM_EMAIL: str = ""
         SERVER_EMAIL: str = ""
+        PACKAGE_CLUSTERING_BATCH_SIZE: int = Field(
+            description="""
+            Batch size for package clustering, which uses advisory locks and thus needs to be scaled to the database settings which limit the maximum number of simultaneously locked rows.
+
+            The default is computed from Postgresql default settings for `max_connections` (100) and `max_locks_per_transaction` (64) and some margin to cover for expected parallelism.
+
+            https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-MAX-CONNECTIONS
+            https://www.postgresql.org/docs/current/runtime-config-locks.html#GUC-MAX-LOCKS-PER-TRANSACTION
+            """,
+            default=100 * 64 // 2,
+        )
 
         @model_validator(mode="after")
         def default_server_email(self) -> Self:

--- a/src/shared/package_clustering.py
+++ b/src/shared/package_clustering.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from itertools import groupby
 
 import pglock
+from django.conf import settings
 from django.db import transaction
 from django.db.models import QuerySet
 
@@ -33,7 +34,7 @@ class ClusterResult:
 def cluster_packages(
     derivations: QuerySet[NixDerivation],
     update_packages: bool = False,
-    batch_size: int = 10_000,
+    batch_size: int = settings.PACKAGE_CLUSTERING_BATCH_SIZE,
 ) -> ClusterResult:
     """
     Assign derivations to packages, in batches.


### PR DESCRIPTION
The default for this setting is 64, let's quadruple it to allow for bigger batch sizes.

@fricklerhandwerk @adekoder did you do any fine-tuning on that 10k rows batch size when testing the PR? I believe lowering that would also help, but I don't know how it would impact speed.

Closes #1153