### PR TITLE
fix: regeneration of cache entries for non-matching CVEs

### DIFF
--- a/src/shared/cache_suggestions.py
+++ b/src/shared/cache_suggestions.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from itertools import chain
 from typing import Any, overload
 
-from django.db.models import Prefetch, Q
+from django.db.models import Case, IntegerField, Prefetch, Q, When
 from pydantic import BaseModel, field_serializer
 
 from shared.models import NixDerivation, NixMaintainer
@@ -83,7 +83,7 @@ class CachedSuggestion(BaseModel):
 
     pk: int
     cve_id: str
-    title: str
+    title: str | None
     description: str | None
     affected_products: dict[str, AffectedProduct]
     original_packages: dict[str, Package]
@@ -160,20 +160,41 @@ def cache_new_suggestions(suggestion: CVEDerivationClusterProposal) -> None:
     # For instance, at the time of writing, most titles in containers are one of
     # - "CVE Program Container" (>600k)
     # - "CISA ADP VUlnrichment" (>270k)
-    relevant_piece = (
-        suggestion.cve.container.values(
-            "title",
-            "descriptions__value",
-        )
-        .filter(
-            Q(affected__package_name__isnull=False)
-            | Q(affected__product__isnull=False),
-        )
-        .first()
+    has_package_data = Q(affected__package_name__isnull=False) | Q(
+        affected__product__isnull=False
     )
 
-    # XXX(@fricklerhandwerk): Satisfy static typecheck. This must hold due to how we construct matches.
-    assert relevant_piece is not None
+    def nonempty(field: str) -> str | None:
+        """
+        Take the first nonempty of the given field, prioritising one that has package data.
+        """
+        return (
+            suggestion.cve.container.annotate(
+                priority=Case(
+                    When(has_package_data, then=0),
+                    default=1,
+                    output_field=IntegerField(),
+                )
+            )
+            .exclude(**{f"{field}__isnull": True})
+            .order_by("priority")
+            .values_list(field, flat=True)
+            .first()
+        )
+
+    title = nonempty("title")
+    description = nonempty("descriptions__value")
+
+    if title is None and description is None:
+        # FIXME(@fricklerhandwerk): Currently there are some entries that hit this case, despite them violating the spec. [tag:invalid-cves]
+        # Example:
+        # - https://nvd.nist.gov/vuln/detail/CVE-2026-11950
+        # - https://nvd.nist.gov/vuln/detail/CVE-2026-47105
+        # Make that impossible:
+        # - Filter them out at ingestion
+        # - Clean up the database in a migration
+        # - Narrow down all types in the pipeline
+        return
 
     affected_products: dict[str, CachedSuggestion.AffectedProduct] = {}
     all_versions = list()
@@ -240,8 +261,8 @@ def cache_new_suggestions(suggestion: CVEDerivationClusterProposal) -> None:
     only_relevant_data = CachedSuggestion(
         pk=suggestion.pk,
         cve_id=suggestion.cve.cve_id,
-        title=relevant_piece["title"],
-        description=relevant_piece["descriptions__value"],
+        title=title,
+        description=description,
         affected_products=affected_products,
         original_packages=original_packages,
         packages=packages,

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -76,8 +76,8 @@ def make_container(
 ) -> Callable[..., Container]:
     def wrapped(
         cve_id: str = "CVE-2025-0001",
-        title: str = "Dummy Title",
-        description: str | None = "Test description",
+        title: str | None = "Dummy Title",
+        description: str = "Test description",
         affected_version: str = "1.0",
         package_name: str | None = "foo",
         product: str | None = "bar",

--- a/src/shared/tests/test_suggestion_caching.py
+++ b/src/shared/tests/test_suggestion_caching.py
@@ -200,6 +200,24 @@ def test_ensure_fresh_cache_noop_when_fresh(
     )
 
 
+# FIXME(@fricklerhandwerk): [ref:invalid-cves] This tests a thing that shouldn't be possible in the first place; fix the underlying problem.
+def test_cache_skipped_without_title_or_description(
+    make_container: Callable[..., Container],
+) -> None:
+    container = make_container(
+        title=None, description=None, package_name=None, product=None
+    )
+    suggestion = CVEDerivationClusterProposal.objects.create(
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+        rejection_reason=CVEDerivationClusterProposal.RejectionReason.NO_MATCHES,
+        cve=container.cve,
+    )
+
+    cache_new_suggestions(suggestion)
+
+    assert not CachedSuggestions.objects.filter(proposal=suggestion).exists()
+
+
 def test_cache_description_falls_back_to_meta(
     suggestion: CVEDerivationClusterProposal,
 ) -> None:

--- a/src/webview/tests/test_issues.py
+++ b/src/webview/tests/test_issues.py
@@ -19,6 +19,7 @@ from shared.models.cve import (
 from shared.models.issue import NixpkgsIssue
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
+    ProvenanceFlags,
 )
 from shared.models.nix_evaluation import (
     NixDerivation,
@@ -52,7 +53,11 @@ def test_publish_gh_issue_empty_title(
 
     container = make_container(title=title, description=description)
     accepted_suggestion = make_suggestion(
-        container=container, status=CVEDerivationClusterProposal.Status.ACCEPTED
+        drvs={
+            drv: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        },
+        container=container,
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
     )
     cache_new_suggestions(accepted_suggestion)
 


### PR DESCRIPTION
This was made necessary after https://github.com/NixOS/nix-security-tracker/pull/1130 started picking up on previously discarded CVEs, that now would go through caching. Blocks testing #1141