### PR TITLE
fix: don't collect replication stats

### DIFF
--- a/infra/common.nix
+++ b/infra/common.nix
@@ -93,6 +93,9 @@ in
   services.prometheus.exporters.postgres = {
     enable = true;
     openFirewall = true;
+    # FIXME(@fricklerhandwerk): Remove when the fix to the upstream issue has landed in Nixpkgs:
+    # https://github.com/prometheus-community/postgres_exporter/issues/1310
+    extraFlags = [ "--no-collector.stat_replication" ];
   };
 
   services.prometheus.exporters.sql = {


### PR DESCRIPTION
Since the last Nixpkgs bump, `prometheus-postgres-exporter` has a buggy query that produces:

    pq: column \"slot_name\" does not exist

This change disables triggering the offending query.