### PR TITLE
refactor: split branches from channels in data model

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -44,6 +44,8 @@ pkgs.testers.runNixOSTest {
             git init --initial-branch=master
             git add -A
             git -c user.name=test -c user.email=test@test commit -m "test"
+            git branch release-25.11
+            git branch release-25.05
             git rev-parse HEAD > REVISION
           '';
     in
@@ -138,8 +140,10 @@ pkgs.testers.runNixOSTest {
       with subtest("Check that channels are fetched and only small ones get enqueued for evaluation"):
         server.succeed("wst-manage fetch_all_channels")
         ${in-shell "succeed" ''
-          from shared.models import NixChannel
-          assert NixChannel.objects.count() == 6
+          from shared.models import NixChannel, NixpkgsBranch
+
+          assert NixpkgsBranch.objects.count() == 3, f"expected 3 branches, got {NixpkgsBranch.objects.count()}"
+          assert NixChannel.objects.count() == 6, f"expected 6 channels, got {NixChannel.objects.count()}"
         ''}
         ${
           # Give it some time to queue up the evaluations...

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -135,6 +135,12 @@ class Settings(BaseSettings):
                 "https://monitoring.nixos.org/prometheus/api/v1/query?query=channel_revision"
             ),
         )
+        NETWORK_REQUEST_TIMEOUT: int = Field(
+            description="""
+            Timeout in seconds for outbound network requests.
+            """,
+            default=60,
+        )
         SYNC_GITHUB_STATE_AT_STARTUP: bool = Field(
             description="""
             Connect to GitHub when the service is started and update

--- a/src/shared/git.py
+++ b/src/shared/git.py
@@ -4,6 +4,7 @@ import logging
 import os.path
 import pathlib
 import random
+import subprocess
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -11,8 +12,23 @@ from dataclasses import dataclass
 from typing import IO, Any
 
 from django.conf import settings
+from pydantic import AnyUrl
 
 logger = logging.getLogger(__name__)
+
+
+def get_head_sha1(url: AnyUrl, branch: str) -> str:
+    result = subprocess.run(
+        ["git", "ls-remote", str(url), f"refs/heads/{branch}"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=settings.NETWORK_REQUEST_TIMEOUT,
+    )
+    line = result.stdout.strip()
+    if not line:
+        raise ValueError(f"branch {branch!r} not found at {url!r}")
+    return line.split()[0]
 
 
 @dataclass

--- a/src/shared/management/commands/fetch_all_channels.py
+++ b/src/shared/management/commands/fetch_all_channels.py
@@ -8,7 +8,8 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from shared.models.nix_evaluation import NixChannel
+from shared.git import get_head_sha1
+from shared.models.nix_evaluation import NixChannel, NixpkgsBranch
 
 
 class MonitoredChannel(BaseModel):
@@ -57,7 +58,8 @@ def fetch_from_monitoring() -> list[MonitoredChannel]:
         # https://github.com/NixOS/infra/blob/795508213eb35eee099b1b8d12dd46a9f7b03697/build/pluto/prometheus/exporters/channel.nix#L4-L6
         # channel structure:
         # https://github.com/NixOS/infra/blob/795508213eb35eee099b1b8d12dd46a9f7b03697/channels.nix
-        settings.CHANNEL_MONITORING_URL
+        settings.CHANNEL_MONITORING_URL,
+        timeout=settings.NETWORK_REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
     channels = []
@@ -70,11 +72,26 @@ class Command(BaseCommand):
     help = "Fetch current channel tips"
 
     def handle(self, *args: Any, **kwargs: Any) -> str | None:
-        for monitored in fetch_from_monitoring():
-            channel, _ = NixChannel.objects.update_or_create(
+        channels = fetch_from_monitoring()
+
+        branch_tips: dict[str, str] = {
+            release_branch: get_head_sha1(settings.GIT_CLONE_URL, release_branch)
+            for release_branch in {c.release_branch for c in channels}
+        }
+
+        branches: dict[str, NixpkgsBranch] = {}
+        for name, head in branch_tips.items():
+            branch, _ = NixpkgsBranch.objects.update_or_create(
+                name=name,
+                defaults={"head_sha1_commit": head},
+            )
+            branches[name] = branch
+
+        for monitored in channels:
+            NixChannel.objects.update_or_create(
                 channel_branch=monitored.channel,
                 defaults=dict(
-                    release_branch=monitored.release_branch,
+                    release_branch=branches[monitored.release_branch],
                     head_sha1_commit=monitored.revision,
                     state=monitored.status,
                     variant=monitored.variant,

--- a/src/shared/management/commands/fetch_all_channels.py
+++ b/src/shared/management/commands/fetch_all_channels.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from shared.git import get_head_sha1
@@ -79,26 +80,27 @@ class Command(BaseCommand):
             for release_branch in {c.release_branch for c in channels}
         }
 
-        branches: dict[str, NixpkgsBranch] = {}
-        for name, head in branch_tips.items():
-            branch, _ = NixpkgsBranch.objects.update_or_create(
-                name=name,
-                defaults={"head_sha1_commit": head},
-            )
-            branches[name] = branch
+        with transaction.atomic():
+            branches: dict[str, NixpkgsBranch] = {}
+            for name, head in branch_tips.items():
+                branch, _ = NixpkgsBranch.objects.update_or_create(
+                    name=name,
+                    defaults={"head_sha1_commit": head},
+                )
+                branches[name] = branch
 
-        for monitored in channels:
-            NixChannel.objects.update_or_create(
-                channel_branch=monitored.channel,
-                defaults=dict(
-                    release_branch=branches[monitored.release_branch],
-                    head_sha1_commit=monitored.revision,
-                    state=monitored.status,
-                    variant=monitored.variant,
-                ),
-            )
+            for monitored in channels:
+                NixChannel.objects.update_or_create(
+                    channel_branch=monitored.channel,
+                    defaults=dict(
+                        release_branch=branches[monitored.release_branch],
+                        head_sha1_commit=monitored.revision,
+                        state=monitored.status,
+                        variant=monitored.variant,
+                    ),
+                )
 
-            # Can't `pprint()` to `self.stdout` directly...
-            stream = StringIO()
-            pprint(monitored.__dict__, stream=stream)
-            self.stdout.write(stream.getvalue())
+                # Can't `pprint()` to `self.stdout` directly...
+                stream = StringIO()
+                pprint(monitored.__dict__, stream=stream)
+                self.stdout.write(stream.getvalue())

--- a/src/shared/migrations/0101_nixpkgsbranch_nixchannel_release_branch.py
+++ b/src/shared/migrations/0101_nixpkgsbranch_nixchannel_release_branch.py
@@ -1,0 +1,82 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def populate_release_branch(apps, schema_editor):
+    NixChannel = apps.get_model("shared", "NixChannel")
+    NixpkgsBranch = apps.get_model("shared", "NixpkgsBranch")
+    for channel in NixChannel.objects.all():
+        branch, _ = NixpkgsBranch.objects.get_or_create(
+            name=channel.release_branch_name,
+            defaults={"head_sha1_commit": channel.head_sha1_commit},
+        )
+        channel.release_branch = branch
+        channel.save(update_fields=["release_branch"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shared", "0100_rename_overlay_type_column_to_type_column"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="NixpkgsBranch",
+            fields=[
+                (
+                    "name",
+                    models.CharField(max_length=126, primary_key=True, serialize=False),
+                ),
+                ("head_sha1_commit", models.CharField(max_length=40)),
+            ],
+            options={
+                "constraints": [
+                    models.CheckConstraint(
+                        check=models.Q(head_sha1_commit__regex="^[0-9a-f]{40}$"),
+                        name="nixpkgsbranch_head_sha1_commit_valid",
+                    )
+                ]
+            },
+        ),
+        migrations.RenameField(
+            model_name="nixchannel",
+            old_name="release_branch",
+            new_name="release_branch_name",
+        ),
+        migrations.AddField(
+            model_name="nixchannel",
+            name="release_branch",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="channels",
+                to="shared.nixpkgsbranch",
+            ),
+        ),
+        # The table has triggers registered.
+        # Altering it within the migration will defer them to after the transaction, thus failing the whole thing.
+        migrations.RunSQL("ALTER TABLE shared_nixchannel DISABLE TRIGGER USER"),
+        migrations.RunPython(
+            code=populate_release_branch,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="nixchannel",
+            name="release_branch",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="channels",
+                to="shared.nixpkgsbranch",
+            ),
+        ),
+        migrations.RemoveField(
+            model_name="nixchannel",
+            name="release_branch_name",
+        ),
+        migrations.RemoveField(
+            model_name="nixchannel",
+            name="repository",
+        ),
+        migrations.RunSQL("ALTER TABLE shared_nixchannel ENABLE TRIGGER USER"),
+    ]

--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -127,6 +127,26 @@ class NixDerivationMeta(models.Model):
         return self.description or ""
 
 
+class NixpkgsBranch(models.Model):
+    """
+    A Nixpkgs branch that gets evaluated, e.g. `master` or `release-26.05`.
+    """
+
+    name = models.CharField(max_length=126, primary_key=True)
+    head_sha1_commit = models.CharField(max_length=40)
+
+    class Meta:
+        constraints = [
+            models.CheckConstraint(
+                check=models.Q(head_sha1_commit__regex=r"^[0-9a-f]{40}$"),
+                name="nixpkgsbranch_head_sha1_commit_valid",
+            )
+        ]
+
+    def __str__(self) -> str:
+        return self.name
+
+
 class NixChannel(TimeStampMixin):
     """
     This represents a "Nixpkgs" (*) channel, e.g.
@@ -158,9 +178,12 @@ class NixChannel(TimeStampMixin):
         ChannelState.UNSTABLE,
     )
 
-    # A staging branch is the `release-$number` branch or `master` for unstable.
-    # Not to confuse with the `staging` branch itself.
-    release_branch = models.CharField(max_length=255)
+    # The underlying Nixpkgs branch (e.g. `master` or `release-25.05`).
+    release_branch = models.ForeignKey(
+        NixpkgsBranch,
+        on_delete=models.PROTECT,
+        related_name="channels",
+    )
     # A channel branch is the `nixos-$number` branch of
     # `nixos-unstable(-small)` for unstable(-small). Not to confuse with the
     # channel tarballs and scripts from releases.nixos.org.
@@ -169,11 +192,6 @@ class NixChannel(TimeStampMixin):
     head_sha1_commit = models.CharField(max_length=255)
     state = models.CharField(max_length=126, choices=ChannelState.choices)
     variant = models.CharField(max_length=126, choices=Variant.choices, null=True)
-    # Repository can be stored as URLs for now...
-    # We can always reparse them as proper GitHub URIs if necessary
-    # It's a bit annoying though
-    # TODO(raitobezarius): make a proper ForeignKey?
-    repository = models.CharField(max_length=255)
 
     def __str__(self) -> str:
         return f"{self.release_branch} -> {self.channel_branch}"

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -37,6 +37,7 @@ from shared.models.nix_evaluation import (
     NixDerivationMeta,
     NixEvaluation,
     NixMaintainer,
+    NixpkgsBranch,
 )
 from shared.models.package import Package, PackageAttrpath
 from shared.notify_users import create_package_subscription_notifications
@@ -133,10 +134,31 @@ def cve(make_container: Callable[..., Container]) -> Container:
 
 
 @pytest.fixture
-def make_channel(db: None) -> Callable[..., NixChannel]:
+def make_branch(db: None) -> Callable[..., NixpkgsBranch]:
+    def wrapped(name: str = "master") -> NixpkgsBranch:
+        branch, _ = NixpkgsBranch.objects.get_or_create(
+            name=name,
+            defaults={"head_sha1_commit": secrets.token_hex(20)},
+        )
+        return branch
+
+    return wrapped
+
+
+@pytest.fixture
+def branch(make_branch: Callable[..., NixpkgsBranch]) -> NixpkgsBranch:
+    return make_branch()
+
+
+@pytest.fixture
+def make_channel(
+    db: None,
+    branch: NixpkgsBranch,
+) -> Callable[..., NixChannel]:
+    # FIXME(@fricklerhandwerk): This will fall apart when we obtain the channel structure dynamically [ref:channel-structure]
     def wrapped(
         channel_branch: str = settings.TRACKING_BRANCH,
-        release_branch: str = "master",
+        release_branch: NixpkgsBranch = branch,
         state: NixChannel.ChannelState = NixChannel.ChannelState.UNSTABLE,
         variant: NixChannel.Variant | None = None,
     ) -> NixChannel:

--- a/src/shared/tests/test_fetch_all_channels.py
+++ b/src/shared/tests/test_fetch_all_channels.py
@@ -1,25 +1,20 @@
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from unittest.mock import Mock, patch
 
 import pytest
+from django.core.management import call_command
+from django.db import IntegrityError
+from pydantic import AnyUrl
 
+from shared.git import get_head_sha1
 from shared.management.commands.fetch_all_channels import fetch_from_monitoring
+from shared.models.nix_evaluation import NixChannel, NixpkgsBranch
 
 
-def monitoring_response(name: str, revision: str, status: str) -> Mock:
+def monitoring_response(*channels: dict) -> Mock:
     resp = Mock()
-    resp.json.return_value = {
-        "data": {
-            "result": [
-                {
-                    "metric": {
-                        "channel": name,
-                        "revision": revision,
-                        "status": status,
-                    }
-                }
-            ]
-        }
-    }
+    resp.json.return_value = {"data": {"result": [{"metric": c} for c in channels]}}
     return resp
 
 
@@ -63,7 +58,10 @@ def test_input_validation(
     status_valid: bool,
 ) -> None:
     with patch(
-        "requests.get", return_value=monitoring_response(name, revision, status)
+        "requests.get",
+        return_value=monitoring_response(
+            {"channel": name, "revision": revision, "status": status}
+        ),
     ):
         if name_valid and revision_valid and status_valid:
             [channel] = fetch_from_monitoring()
@@ -73,3 +71,109 @@ def test_input_validation(
         else:
             with pytest.raises(Exception):
                 fetch_from_monitoring()
+
+
+def test_get_head_sha1_returns_commit() -> None:
+    with patch(
+        "subprocess.run",
+        return_value=Mock(stdout=f"{'a' * 40}\trefs/heads/master\n"),
+    ):
+        assert (
+            get_head_sha1(AnyUrl("https://github.com/NixOS/nixpkgs"), "master")
+            == "a" * 40
+        )
+
+
+def test_get_head_sha1_raises_on_missing_branch() -> None:
+    with patch("subprocess.run", return_value=Mock(stdout="")):
+        with pytest.raises(ValueError, match="not found"):
+            get_head_sha1(AnyUrl("https://github.com/NixOS/nixpkgs"), "nonexistent")
+
+
+@pytest.mark.django_db
+def test_nixpkgsbranch_rejects_invalid_sha1() -> None:
+    with pytest.raises(IntegrityError):
+        NixpkgsBranch.objects.create(name="master", head_sha1_commit="not-a-sha1")
+
+
+@pytest.fixture
+def mock_monitoring() -> Callable:
+    @contextmanager
+    def factory(*channels: dict) -> Generator[None]:
+        with patch(
+            "requests.get",
+            return_value=monitoring_response(*channels),
+        ):
+            yield
+
+    return factory
+
+
+@pytest.fixture
+def mock_head_sha1() -> Callable:
+    @contextmanager
+    def factory(branch_commits: dict[str, str]) -> Generator[None]:
+        with patch(
+            "shared.management.commands.fetch_all_channels.get_head_sha1",
+            side_effect=lambda _, branch: branch_commits[branch],
+        ):
+            yield
+
+    return factory
+
+
+@pytest.mark.django_db
+def test_handle_creates_branches(
+    mock_monitoring: Callable, mock_head_sha1: Callable
+) -> None:
+    with (
+        mock_monitoring(
+            {
+                "channel": "nixos-unstable",
+                "revision": "a" * 40,
+                "status": "rolling",
+            },
+            {
+                "channel": "nixos-unstable-small",
+                "revision": "b" * 40,
+                "status": "rolling",
+            },
+        ),
+        mock_head_sha1(branch_commits={"master": "c" * 40}),
+    ):
+        call_command("fetch_all_channels")
+
+    assert NixpkgsBranch.objects.count() == 1
+    assert NixpkgsBranch.objects.filter(
+        name="master", head_sha1_commit="c" * 40
+    ).exists()
+    unstable = NixChannel.objects.get(channel_branch="nixos-unstable")
+    assert unstable.head_sha1_commit == "a" * 40
+    unstable_small = NixChannel.objects.get(channel_branch="nixos-unstable-small")
+    assert unstable_small.head_sha1_commit == "b" * 40
+
+
+@pytest.mark.django_db
+def test_handle_updates_branch_head(
+    mock_monitoring: Callable, mock_head_sha1: Callable
+) -> None:
+    NixpkgsBranch.objects.create(name="master", head_sha1_commit="f" * 40)
+
+    with (
+        mock_monitoring(
+            {
+                "channel": "nixos-unstable",
+                "revision": "a" * 40,
+                "status": "rolling",
+            },
+            {
+                "channel": "nixos-unstable-small",
+                "revision": "b" * 40,
+                "status": "rolling",
+            },
+        ),
+        mock_head_sha1(branch_commits={"master": "c" * 40}),
+    ):
+        call_command("fetch_all_channels")
+
+    assert NixpkgsBranch.objects.get(name="master").head_sha1_commit == "c" * 40

--- a/src/shared/tests/test_suggestion_caching.py
+++ b/src/shared/tests/test_suggestion_caching.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from datetime import timedelta
 
 import pytest
-from django.conf import settings
 
 from shared.cache_suggestions import cache_new_suggestions
 from shared.models.cached import CachedSuggestions
@@ -17,6 +16,7 @@ from shared.models.nix_evaluation import (
     NixDerivation,
     NixEvaluation,
     NixMaintainer,
+    NixpkgsBranch,
 )
 from shared.models.package import Package
 from shared.package_clustering import cluster_packages
@@ -86,6 +86,7 @@ def test_caching_newest_package(
 @pytest.mark.parametrize("rolling_has_maintainers", [True, False])
 def test_maintainers_come_from_rolling_release_channel(
     cve: Container,
+    make_branch: Callable[..., NixpkgsBranch],
     make_channel: Callable[..., NixChannel],
     make_evaluation: Callable[..., NixEvaluation],
     make_drv: Callable[..., NixDerivation],
@@ -99,8 +100,11 @@ def test_maintainers_come_from_rolling_release_channel(
     Its maintainers must appear regardless of evaluation order,
     and stable-only maintainers must never appear.
     """
-    stable_channel = make_channel(channel_branch="nixos-26.05-small")
-    rolling_channel = make_channel(channel_branch=settings.TRACKING_BRANCH)
+    stable_channel = make_channel(
+        channel_branch="nixos-26.05-small",
+        release_branch=make_branch(name="release-26.05"),
+    )
+    rolling_channel = make_channel()
     stable_age = timedelta(hours=1) if stable_is_older else timedelta(0)
     rolling_age = timedelta(0) if stable_is_older else timedelta(hours=1)
     eval_stable = make_evaluation(channel=stable_channel, age=stable_age)


### PR DESCRIPTION
Towards #864
Depends on #1176

Also fetch the tip of each underlying release branch when refreshing
channels.

This in principle allows evaluating just the release branches and,
independently, using package data from already evalauted channels. That way
we will be able to track both what maintainers are working on and what is
shipped to users, without evaluating all involved versions ourselves.