### PR TITLE
fix: production type error on Git clone URL

### DIFF
--- a/src/shared/git.py
+++ b/src/shared/git.py
@@ -87,7 +87,7 @@ class GitRepo:
 
         Otherwise, it will use a shallow clone, since we can fetch commits manually.
         """
-        repo_clone_url = settings.GIT_CLONE_URL
+        repo_clone_url = str(settings.GIT_CLONE_URL)
         stdout = self.stdout or asyncio.subprocess.PIPE
         stderr = self.stderr or asyncio.subprocess.PIPE
         if reference_repo_path is not None:
@@ -168,7 +168,7 @@ class GitRepo:
 
         Returns whether this was fetched or already present.
         """
-        repo_clone_url = settings.GIT_CLONE_URL
+        repo_clone_url = str(settings.GIT_CLONE_URL)
         exists = (
             await (
                 await self.execute_git_command(


### PR DESCRIPTION
That type mismatch is currently not caught in tests.
Tests set that URL, which takes the `USER_SETTINGS_FILE` code path.
That's a deprecated way for configuring the service, which bypasses the Pydantic parser and takes the value as `str`.
Production uses the implicit default, which is taken as `HttpUrl` from Pydantic.

The underlying problem is fixed in https://github.com/NixOS/nix-security-tracker/pull/1166, but that takes a bit more care.