### PR TITLE
fix: restore version display in the footer

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -439,6 +439,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "shared.context_processors.deployment_info",
             ],
         },
     },

--- a/src/shared/context_processors.py
+++ b/src/shared/context_processors.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from django.http import HttpRequest
+
+
+def deployment_info(request: HttpRequest) -> dict[str, str]:
+    return {
+        "production": settings.PRODUCTION,
+        "git_revision": settings.REVISION,
+        "show_demo_disclaimer": settings.SHOW_DEMO_DISCLAIMER,
+    }

--- a/src/webview/tests/test_footer.py
+++ b/src/webview/tests/test_footer.py
@@ -1,0 +1,17 @@
+from django.test import Client, override_settings
+from django.urls import reverse
+
+
+def test_footer_revision_in_development(db: None, client: Client) -> None:
+    with override_settings(REVISION="abc1234", PRODUCTION=False):
+        response = client.get(reverse("webview:home"))
+    assert b"abc1234" in response.content
+    assert b"(development)" in response.content
+    # FIXME(@fricklerhandwerk): Also check for the source URL, but that should come from a setting.
+
+
+def test_footer_revision_link_in_production(db: None, client: Client) -> None:
+    with override_settings(REVISION="abc1234", PRODUCTION=True):
+        response = client.get(reverse("webview:home"))
+    assert b"/commit/abc1234" in response.content
+    assert b"(development)" not in response.content


### PR DESCRIPTION
It accidentally got removed in 1043417259a2d8f63ff3e623b3f32f5c46154857.