### PR TITLE
chore: backfill package links on suggestions at startup

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -367,6 +367,28 @@ in
           '';
         };
 
+        # FIXME(@fricklerhandwerk): This only needs to run once, since new suggestions get the data automatically.
+        # Remove before the next deployment to production.
+        nix-security-tracker-backfill-package-links = {
+          description = "Web security tracker - backfill package links for existing proposals";
+          after = [
+            "network.target"
+            "postgresql.service"
+            "nix-security-tracker-migrations.service"
+            "nix-security-tracker-caching.service"
+          ];
+          requires = [
+            "postgresql.service"
+            "nix-security-tracker-migrations.service"
+          ];
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig.Type = "oneshot";
+          script = ''
+            wst-manage backfill_proposal_package_links
+          '';
+        };
+
         nix-security-tracker-worker = {
           description = "Web security tracker - background job processor";
           after = [

--- a/src/shared/management/commands/backfill_proposal_package_links.py
+++ b/src/shared/management/commands/backfill_proposal_package_links.py
@@ -49,7 +49,6 @@ class Command(BaseCommand):
         )
         cluster_result = cluster_packages(
             NixDerivation.objects.filter(pk__in=derivation_ids),
-            batch_size=batch_size,
         )
         self.stdout.write(
             f"Clustered {cluster_result.packages_created} new packages "

--- a/src/shared/management/commands/backfill_proposal_package_links.py
+++ b/src/shared/management/commands/backfill_proposal_package_links.py
@@ -47,13 +47,17 @@ class Command(BaseCommand):
             .values_list("derivation_id", flat=True)
             .distinct()
         )
+        count = derivation_ids.count()
+        self.stdout.write(
+            f"Clustering {count} derivations into packages...",
+        )
         cluster_result = cluster_packages(
             NixDerivation.objects.filter(pk__in=derivation_ids),
         )
         self.stdout.write(
             f"Clustered {cluster_result.packages_created} new packages "
             f"({cluster_result.attrpaths_created} attrpaths) for "
-            f"previously unlinked derivations."
+            f"{count} previously unlinked derivations."
         )
 
         created = 0


### PR DESCRIPTION
This way we don't have to remember running it manually after deployment.