### PR TITLE
fix: unsafe GET request for allauth login & headless for new UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "preact/hooks";
 import { Redirect, Route, Switch } from "wouter-preact";
 import { Footer } from "@/components/footer/Footer";
 import { Disclaimer } from "@/components/header/Disclaimer";
@@ -19,6 +20,20 @@ const queryClient = new QueryClient({
 });
 
 export function App() {
+  // Fallback landing page when allauth's GitHub OAuth handshake fails
+  // The url param is set in settings.py: HEADLESS_FRONTEND_URLS["socialaccount_login_error"]
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("login_error")) {
+      toaster.error({
+        title: "Login failed",
+        description: "Something went wrong signing in with GitHub. Please try again.",
+      });
+      url.searchParams.delete("login_error");
+      window.history.replaceState({}, "", url);
+    }
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <HeaderBar />

--- a/frontend/src/components/header/AuthStatus.tsx
+++ b/frontend/src/components/header/AuthStatus.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "wouter-preact";
 import { Avatar } from "@/components/ui/Avatar";
 import { Menu } from "@/components/ui/Menu";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { LOGIN_URL, logout, useAuth } from "@/hooks/useAuth";
+import { login, logout, useAuth } from "@/hooks/useAuth";
 
 export function AuthStatus() {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -20,10 +20,14 @@ export function AuthStatus() {
 
   if (!isAuthenticated || !user) {
     return (
-      <div className="row gap-small centered">
+      <button
+        type="button"
+        className="row gap-small centered text-white cursor-pointer"
+        onClick={login}
+      >
         <LogInIcon />
-        <a href={LOGIN_URL}>Login with GitHub</a>
-      </div>
+        Login with GitHub
+      </button>
     );
   }
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -22,28 +22,43 @@ export function useAuth() {
   };
 }
 
-export const LOGIN_URL = "/accounts/github/login/?process=login&next=/ui-v2/";
-
-export function logout(): void {
-  const csrfToken = getCsrfToken() ?? "";
-
-  // Form submission to allauth's logout endpoint (handles redirect server-side)
+/** Builds and submits a hidden POST form (handles the CSRF token + server-side redirect). */
+function submitForm(action: string, fields: Record<string, string>): void {
   const form = document.createElement("form");
   form.method = "POST";
-  form.action = "/accounts/logout/";
+  form.action = action;
 
   const csrfInput = document.createElement("input");
   csrfInput.type = "hidden";
   csrfInput.name = "csrfmiddlewaretoken";
-  csrfInput.value = csrfToken;
+  csrfInput.value = getCsrfToken() ?? "";
   form.appendChild(csrfInput);
 
-  const nextInput = document.createElement("input");
-  nextInput.type = "hidden";
-  nextInput.name = "next";
-  nextInput.value = "/ui-v2/";
-  form.appendChild(nextInput);
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
 
   document.body.appendChild(form);
   form.submit();
+}
+
+/**
+ * Initiates GitHub login via allauth's headless API.
+ * https://docs.allauth.org/en/latest/headless/index.html
+ */
+export function login(): void {
+  submitForm("/_allauth/browser/v1/auth/provider/redirect", {
+    provider: "github",
+    process: "login",
+    callback_url: "/ui-v2/",
+  });
+}
+
+export function logout(): void {
+  // Form submission to allauth's logout endpoint (handles redirect server-side)
+  submitForm("/accounts/logout/", { next: "/ui-v2/" });
 }

--- a/frontend/src/styles/utility.css
+++ b/frontend/src/styles/utility.css
@@ -498,6 +498,15 @@ details.details-marker-outside > summary {
   border: 1px solid var(--light-gray);
 }
 
+/* Cursor
+ * 
+ * .cursor-pointer - hand cursor like links
+ */
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
 /* Background
  *
  * Background color utilities for theme colors (yellow, red, green, nixos-blue).

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -396,6 +396,7 @@ INSTALLED_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "allauth.socialaccount.providers.github",
+    "allauth.headless",
     "channels",
     "pgpubsub",
     "pgtrigger",
@@ -503,10 +504,17 @@ SITE_ID = 1
 
 # Disable regular signup but allow GitHub auth
 SOCIALACCOUNT_ONLY = True
-# Skip intermediate "Continue" page, redirect to GitHub immediately
-SOCIALACCOUNT_LOGIN_ON_GET = True
 ACCOUNT_ALLOW_REGISTRATION = False
 ACCOUNT_EMAIL_VERIFICATION = "none"
+
+# allauth headless API (see frontend/src/hooks/useAuth.ts)
+HEADLESS_ONLY = False  # Keep classic `allauth.urls` views for Django webviews
+HEADLESS_CLIENTS = ("browser",)
+HEADLESS_FRONTEND_URLS = {
+    # Fallback if the OAuth handshake state is lost (e.g. denied access, expired session mid-flow).
+    # We set login_error for the frontend to recognize it and display an error message
+    "socialaccount_login_error": "/ui-v2/?login_error=1",
+}
 
 # TODO: make configurable so one can log in locally
 LOGIN_REDIRECT_URL = "webview:home"

--- a/src/project/urls.py
+++ b/src/project/urls.py
@@ -17,10 +17,14 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path, re_path
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import TemplateView
 
 # SPA catch-all: serves the same template for all /ui-v2/ sub-paths (client-side routing)
-ui_v2_view = TemplateView.as_view(template_name="ui_v2.html")
+
+# `ensure_csrf_cookie` guarantees a first-time anonymous visitor already has a CSRF cookie before they click "Login with GitHub" (POST).
+# Otherwise the first login attempt fails with a CSRF 403.
+ui_v2_view = ensure_csrf_cookie(TemplateView.as_view(template_name="ui_v2.html"))
 
 urlpatterns = [
     path("", include("webview.urls")),
@@ -28,6 +32,7 @@ urlpatterns = [
     path("feeds/", include("feeds.urls")),
     path("admin/", admin.site.urls),
     path("accounts/", include("allauth.urls")),
+    path("_allauth/", include("allauth.headless.urls")),
     path("debug/", include("debug_toolbar.urls")),
     re_path(r"^ui-v2/(?:.*)?$", ui_v2_view, name="ui_v2"),
 ]


### PR DESCRIPTION
This takes over #1150 to reintroduce POST only allauth login, but also makes it work correctly in the new UI through headless mode