### PR TITLE
Add a pgbouncer to be used by the ASGI server only

### DIFF
--- a/infra/production.nix
+++ b/infra/production.nix
@@ -86,6 +86,9 @@ in
     enable = true;
     production = true;
     domain = "tracker.security.nixos.org";
+
+    enablePgbouncer = true;
+
     settings = {
       SYNC_GITHUB_STATE_AT_STARTUP = true;
       GH_ISSUES_PING_MAINTAINERS = true;

--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -88,6 +88,9 @@ in
     enable = true;
     production = true;
     domain = "tracker-staging.security.nixos.org";
+
+    enablePgbouncer = true;
+
     settings = {
       SHOW_DEMO_DISCLAIMER = true;
       SYNC_GITHUB_STATE_AT_STARTUP = true;

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -240,14 +240,15 @@ in
           pgbouncer = {
             pool_mode = "transaction";
             auth_type = "trust";
-            auth_file = toString (pkgs.writeText "pgbouncer-userlist" ''
-              "nix-security-tracker" ""
-            '');
+            auth_file = toString (
+              pkgs.writeText "pgbouncer-userlist" ''
+                "nix-security-tracker" ""
+              ''
+            );
             ignore_startup_parameters = "extra_float_digits";
           };
           databases = {
-            nix-security-tracker =
-              "host=/run/postgresql dbname=nix-security-tracker";
+            nix-security-tracker = "host=/run/postgresql dbname=nix-security-tracker";
           };
         };
       };
@@ -283,252 +284,253 @@ in
       in
       mkMerge [
         (mapAttrs (_: recursiveUpdate defaults) {
-        nix-security-tracker-migrations = {
-          description = "Web security tracker - database migrations";
-          after = [
-            "network.target"
-            "postgresql.service"
-          ];
-          requires = [ "postgresql.service" ];
-          wantedBy = [ "multi-user.target" ];
+          nix-security-tracker-migrations = {
+            description = "Web security tracker - database migrations";
+            after = [
+              "network.target"
+              "postgresql.service"
+            ];
+            requires = [ "postgresql.service" ];
+            wantedBy = [ "multi-user.target" ];
 
-          serviceConfig.Type = "oneshot";
+            serviceConfig.Type = "oneshot";
 
-          # Auto-migrate on first run or if the package has changed
-          script = ''
-            versionFile="/var/lib/nix-security-tracker/package-version"
-            if [[ $(cat "$versionFile" 2>/dev/null) != ${cfg.package} ]]; then
-              wst-manage migrate --no-input
-              wst-manage collectstatic --no-input --clear
-              echo ${cfg.package} > "$versionFile"
-            fi
-          '';
-        };
-        nix-security-tracker-server = {
-          description = "Web security tracker ASGI server";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ] ++ lib.optionals cfg.enablePgbouncer [ "pgbouncer.service" ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ] ++ lib.optionals cfg.enablePgbouncer [ "pgbouncer.service" ];
-          wantedBy = [ "multi-user.target" ];
-          serviceConfig = {
-            Restart = cfg.restart;
-            TimeoutStartSec = lib.mkDefault "10m";
-          };
-          script =
-            let
-              networking =
-                if cfg.unixSocket != null then
-                  "-u ${cfg.unixSocket}"
-                else
-                  "-b 127.0.0.1 -p ${toString cfg.wsgi-port}";
-            in
-            ''
-              daphne ${networking} project.asgi:application
+            # Auto-migrate on first run or if the package has changed
+            script = ''
+              versionFile="/var/lib/nix-security-tracker/package-version"
+              if [[ $(cat "$versionFile" 2>/dev/null) != ${cfg.package} ]]; then
+                wst-manage migrate --no-input
+                wst-manage collectstatic --no-input --clear
+                echo ${cfg.package} > "$versionFile"
+              fi
             '';
-        }
-        // optionalAttrs cfg.enablePgbouncer {
-          # When PgBouncer is enabled, the ASGI server connects through it over
-          # its unix socket on port 6432
-          environment.DATABASE_URL = let
-            port = config.services.pgbouncer.settings.pgbouncer.listen_port;
-          in
-          "postgres:///nix-security-tracker?host=/run/pgbouncer&port=${toString port}";
-          # The ASGI server should not hold Django-level persistent connections
-          # when PgBouncer multiplexes server connections. Setting
-          # CONN_MAX_AGE=0 lets PgBouncer do the pooling. Other services
-          # (workers and management commands) keep the value from
-          # `cfg.settings` so their direct connections persist.
-          environment.DJANGO_SETTINGS = builtins.toJSON (
-            cfg.settings // { DATABASE_CONN_MAX_AGE = 0; }
-          );
-        };
-
-        nix-security-tracker-evaluator = {
-          description = "Web security tracker - Nixpkgs evaluation worker";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-worker.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-worker.service"
-          ];
-          wantedBy = [ "multi-user.target" ];
-
-          script = ''
-            # Before starting, crash all the in-progress evaluations.
-            # This will prevent them from being stalled forever, since workers would not pick up evaluations marked as in-progress.
-            wst-manage crash_all_evaluations
-            wst-manage listen --recover \
-              --processes ${toString cfg.maxJobProcessors} \
-              --channels \
-                shared.channels.NixEvaluationChannel
-          '';
-        };
-
-        nix-security-tracker-caching = {
-          description = "Web security tracker - cache regeneration";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          wantedBy = [ "multi-user.target" ];
-
-          serviceConfig = {
-            Type = "oneshot";
-            # Make performance metrics file, produced as a side effect, readable by Prometheus node exporter
-            UMask = "0027";
           };
-          script = ''
-            wst-manage backfill_package_clustering
-            wst-manage regenerate_cached_suggestions
-          '';
-        };
+          nix-security-tracker-server = {
+            description = "Web security tracker ASGI server";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ]
+            ++ lib.optionals cfg.enablePgbouncer [ "pgbouncer.service" ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ]
+            ++ lib.optionals cfg.enablePgbouncer [ "pgbouncer.service" ];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              Restart = cfg.restart;
+              TimeoutStartSec = lib.mkDefault "10m";
+            };
+            script =
+              let
+                networking =
+                  if cfg.unixSocket != null then
+                    "-u ${cfg.unixSocket}"
+                  else
+                    "-b 127.0.0.1 -p ${toString cfg.wsgi-port}";
+              in
+              ''
+                daphne ${networking} project.asgi:application
+              '';
+          }
+          // optionalAttrs cfg.enablePgbouncer {
+            # When PgBouncer is enabled, the ASGI server connects through it over
+            # its unix socket on port 6432
+            environment.DATABASE_URL =
+              let
+                port = config.services.pgbouncer.settings.pgbouncer.listen_port;
+              in
+              "postgres:///nix-security-tracker?host=/run/pgbouncer&port=${toString port}";
+            # The ASGI server should not hold Django-level persistent connections
+            # when PgBouncer multiplexes server connections. Setting
+            # CONN_MAX_AGE=0 lets PgBouncer do the pooling. Other services
+            # (workers and management commands) keep the value from
+            # `cfg.settings` so their direct connections persist.
+            environment.DJANGO_SETTINGS = builtins.toJSON (cfg.settings // { DATABASE_CONN_MAX_AGE = 0; });
+          };
 
-        # FIXME(@fricklerhandwerk): This only needs to run once, since new suggestions get the data automatically.
-        # Remove before the next deployment to production.
-        nix-security-tracker-backfill-package-links = {
-          description = "Web security tracker - backfill package links for existing proposals";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-            "nix-security-tracker-caching.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          wantedBy = [ "multi-user.target" ];
+          nix-security-tracker-evaluator = {
+            description = "Web security tracker - Nixpkgs evaluation worker";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-worker.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-worker.service"
+            ];
+            wantedBy = [ "multi-user.target" ];
 
-          serviceConfig.Type = "oneshot";
-          script = ''
-            wst-manage backfill_proposal_package_links
-          '';
-        };
+            script = ''
+              # Before starting, crash all the in-progress evaluations.
+              # This will prevent them from being stalled forever, since workers would not pick up evaluations marked as in-progress.
+              wst-manage crash_all_evaluations
+              wst-manage listen --recover \
+                --processes ${toString cfg.maxJobProcessors} \
+                --channels \
+                  shared.channels.NixEvaluationChannel
+            '';
+          };
 
-        nix-security-tracker-worker = {
-          description = "Web security tracker - background job processor";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          wantedBy = [ "multi-user.target" ];
+          nix-security-tracker-caching = {
+            description = "Web security tracker - cache regeneration";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            wantedBy = [ "multi-user.target" ];
 
-          script = ''
-            wst-manage listen --recover \
-              --channels \
-                shared.channels.NixChannelInsertChannel \
-                shared.channels.NixChannelUpdateChannel \
-                shared.channels.ContainerChannel \
-                shared.channels.CVEDerivationClusterProposalChannel \
-          '';
-        };
+            serviceConfig = {
+              Type = "oneshot";
+              # Make performance metrics file, produced as a side effect, readable by Prometheus node exporter
+              UMask = "0027";
+            };
+            script = ''
+              wst-manage backfill_package_clustering
+              wst-manage regenerate_cached_suggestions
+            '';
+          };
 
-        nix-security-tracker-worker-rematching = {
-          description = "Web security tracker - post-evaluation suggestion rematching";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          wantedBy = [ "multi-user.target" ];
+          # FIXME(@fricklerhandwerk): This only needs to run once, since new suggestions get the data automatically.
+          # Remove before the next deployment to production.
+          nix-security-tracker-backfill-package-links = {
+            description = "Web security tracker - backfill package links for existing proposals";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+              "nix-security-tracker-caching.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            wantedBy = [ "multi-user.target" ];
 
-          script = ''
-            wst-manage listen --recover \
-              --channels \
-                shared.channels.NixEvaluationUpdateChannel \
-          '';
-        };
+            serviceConfig.Type = "oneshot";
+            script = ''
+              wst-manage backfill_proposal_package_links
+            '';
+          };
 
-        nix-security-tracker-fetch-all-channels = {
-          description = "Web security tracker - fetch channel branches to trigger evaluation";
+          nix-security-tracker-worker = {
+            description = "Web security tracker - background job processor";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            wantedBy = [ "multi-user.target" ];
 
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-worker.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-worker.service"
-          ];
+            script = ''
+              wst-manage listen --recover \
+                --channels \
+                  shared.channels.NixChannelInsertChannel \
+                  shared.channels.NixChannelUpdateChannel \
+                  shared.channels.ContainerChannel \
+                  shared.channels.CVEDerivationClusterProposalChannel \
+            '';
+          };
 
-          serviceConfig.Type = "oneshot";
+          nix-security-tracker-worker-rematching = {
+            description = "Web security tracker - post-evaluation suggestion rematching";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            wantedBy = [ "multi-user.target" ];
 
-          script = ''
-            wst-manage fetch_all_channels
-          '';
+            script = ''
+              wst-manage listen --recover \
+                --channels \
+                  shared.channels.NixEvaluationUpdateChannel \
+            '';
+          };
 
-          # Ideally, start at whatever night means.
-          startAt = "*-*-* 04:00:00";
-        };
+          nix-security-tracker-fetch-all-channels = {
+            description = "Web security tracker - fetch channel branches to trigger evaluation";
 
-        nix-security-tracker-delta = {
-          description = "Web security tracker - catch up with CVEs";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-worker.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-worker.service"
-          ];
-          serviceConfig.Type = "oneshot";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-worker.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-worker.service"
+            ];
 
-          script = ''
-            wst-manage ingest_delta_cve "$(date --date='yesterday' --iso)" ${
-              optionalString (cfg.cve.startDate != null) "--default-start-ingestion ${cfg.cve.startDate}"
-            }
-          '';
+            serviceConfig.Type = "oneshot";
 
-          # Start at 03h so that the data will have been published
-          startAt = "*-*-* 03:00:00";
-        };
+            script = ''
+              wst-manage fetch_all_channels
+            '';
 
-        nix-security-tracker-garbage-collection = {
-          description = "Web security tracker - garbage collection";
-          after = [
-            "network.target"
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
-          requires = [
-            "postgresql.service"
-            "nix-security-tracker-migrations.service"
-          ];
+            # Ideally, start at whatever night means.
+            startAt = "*-*-* 04:00:00";
+          };
 
-          serviceConfig.Type = "oneshot";
-          script = ''
-            wst-manage garbage_collect
-          '';
+          nix-security-tracker-delta = {
+            description = "Web security tracker - catch up with CVEs";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-worker.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-worker.service"
+            ];
+            serviceConfig.Type = "oneshot";
 
-          # Weekly cleanup.
-          # The time is almost arbitrary, just keep it out of the way of ingestions and peak traffic.
-          startAt = "Fri *-*-* 20:00:00";
-        };
+            script = ''
+              wst-manage ingest_delta_cve "$(date --date='yesterday' --iso)" ${
+                optionalString (cfg.cve.startDate != null) "--default-start-ingestion ${cfg.cve.startDate}"
+              }
+            '';
+
+            # Start at 03h so that the data will have been published
+            startAt = "*-*-* 03:00:00";
+          };
+
+          nix-security-tracker-garbage-collection = {
+            description = "Web security tracker - garbage collection";
+            after = [
+              "network.target"
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+            requires = [
+              "postgresql.service"
+              "nix-security-tracker-migrations.service"
+            ];
+
+            serviceConfig.Type = "oneshot";
+            script = ''
+              wst-manage garbage_collect
+            '';
+
+            # Weekly cleanup.
+            # The time is almost arbitrary, just keep it out of the way of ingestions and peak traffic.
+            startAt = "Fri *-*-* 20:00:00";
+          };
         })
         (optionalAttrs cfg.enablePgbouncer {
           # Make PgBouncer wait for PostgreSQL so the web server can rely on

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     types
     mkIf
+    mkMerge
     mkEnableOption
     mkPackageOption
     mkOption
@@ -16,6 +17,7 @@ let
     mkDefault
     concatStringsSep
     recursiveUpdate
+    optionalAttrs
     optionalString
     ;
   inherit (pkgs) writeScriptBin writeShellApplication stdenv;
@@ -165,6 +167,14 @@ in
       type = types.int;
       default = 2;
     };
+
+    enablePgbouncer = mkEnableOption ''
+      PgBouncer connection pooling in front of PostgreSQL for the ASGI web server.
+
+      When enabled, only `nix-security-tracker-server` connects through
+      PgBouncer. The pgpubsub workers and management commands keep direct database
+      connections, which is required for PostgreSQL LISTEN/NOTIFY.
+    '';
   };
 
   config = mkIf cfg.enable {
@@ -221,6 +231,26 @@ in
         ];
         ensureDatabases = [ "nix-security-tracker" ];
       };
+
+      # PgBouncer fronts only the ASGI web server. Workers and management
+      # commands bypass it.
+      pgbouncer = mkIf cfg.enablePgbouncer {
+        enable = true;
+        settings = {
+          pgbouncer = {
+            pool_mode = "transaction";
+            auth_type = "trust";
+            auth_file = toString (pkgs.writeText "pgbouncer-userlist" ''
+              "nix-security-tracker" ""
+            '');
+            ignore_startup_parameters = "extra_float_digits";
+          };
+          databases = {
+            nix-security-tracker =
+              "host=/run/postgresql dbname=nix-security-tracker";
+          };
+        };
+      };
     };
 
     users.users.nix-security-tracker = {
@@ -251,7 +281,8 @@ in
           };
         };
       in
-      mapAttrs (_: recursiveUpdate defaults) {
+      mkMerge [
+        (mapAttrs (_: recursiveUpdate defaults) {
         nix-security-tracker-migrations = {
           description = "Web security tracker - database migrations";
           after = [
@@ -279,11 +310,11 @@ in
             "network.target"
             "postgresql.service"
             "nix-security-tracker-migrations.service"
-          ];
+          ] ++ lib.optionals cfg.enablePgbouncer [ "pgbouncer.service" ];
           requires = [
             "postgresql.service"
             "nix-security-tracker-migrations.service"
-          ];
+          ] ++ lib.optionals cfg.enablePgbouncer [ "pgbouncer.service" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             Restart = cfg.restart;
@@ -300,6 +331,22 @@ in
             ''
               daphne ${networking} project.asgi:application
             '';
+        }
+        // optionalAttrs cfg.enablePgbouncer {
+          # When PgBouncer is enabled, the ASGI server connects through it over
+          # its unix socket on port 6432
+          environment.DATABASE_URL = let
+            port = config.services.pgbouncer.settings.pgbouncer.listen_port;
+          in
+          "postgres:///nix-security-tracker?host=/run/pgbouncer&port=${toString port}";
+          # The ASGI server should not hold Django-level persistent connections
+          # when PgBouncer multiplexes server connections. Setting
+          # CONN_MAX_AGE=0 lets PgBouncer do the pooling. Other services
+          # (workers and management commands) keep the value from
+          # `cfg.settings` so their direct connections persist.
+          environment.DJANGO_SETTINGS = builtins.toJSON (
+            cfg.settings // { DATABASE_CONN_MAX_AGE = 0; }
+          );
         };
 
         nix-security-tracker-evaluator = {
@@ -482,6 +529,15 @@ in
           # The time is almost arbitrary, just keep it out of the way of ingestions and peak traffic.
           startAt = "Fri *-*-* 20:00:00";
         };
-      };
+        })
+        (optionalAttrs cfg.enablePgbouncer {
+          # Make PgBouncer wait for PostgreSQL so the web server can rely on
+          # the `pgbouncer.service` ordering declared above.
+          pgbouncer = {
+            after = [ "postgresql.service" ];
+            requires = [ "postgresql.service" ];
+          };
+        })
+      ];
   };
 }

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -223,6 +223,15 @@ class Settings(BaseSettings):
             """,
             default=30,
         )
+        DATABASE_CONN_MAX_AGE: int = Field(
+            description="""
+            Django CONN_MAX_AGE for the default database connection (in
+            seconds). If the ASGI server is fronted by PgBouncer, it overrides
+            this to 0. The direct connections (workers and management commands)
+            use this value instead.
+            """,
+            default=600,
+        )
         EMAIL_BACKEND: str = "django.core.mail.backends.console.EmailBackend"
         EMAIL_HOST: str = "localhost"
         EMAIL_PORT: int = 25
@@ -476,7 +485,10 @@ WSGI_APPLICATION = "project.wsgi.application"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
 DATABASES = {}
-DATABASES["default"] = dj_database_url.config(conn_max_age=600, conn_health_checks=True)
+DATABASES["default"] = dj_database_url.config(
+    conn_max_age=DATABASE_CONN_MAX_AGE,  # noqa: F821 # pyright: ignore [reportUndefinedVariable]
+    conn_health_checks=True,
+)
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
Adds a pgbouncer service (optionally) to the host configuration and configures it so that only the ASGI server goes through it. Worker processes and management commands will use the direct database connection.

I've split this in two commits, because the autoformatting created a big diff and I hope this makes it easier to review.

Closes #1019 