### PR TITLE
chore: disable broken link refreshing

### DIFF
--- a/src/shared/listeners/package_clustering.py
+++ b/src/shared/listeners/package_clustering.py
@@ -2,11 +2,8 @@ import logging
 
 import pgpubsub
 
-from shared.cache_suggestions import cache_new_suggestions
 from shared.channels import NixEvaluationUpdateChannel
-from shared.listeners.automatic_linkage import refresh_suggestion_derivation_links
 from shared.models import NixDerivation, NixEvaluation
-from shared.models.linkage import CVEDerivationClusterProposal
 from shared.package_clustering import cluster_packages
 
 logger = logging.getLogger(__name__)
@@ -29,24 +26,3 @@ def cluster_after_evaluation(old: NixEvaluation, new: NixEvaluation) -> None:
         f"updated {result.packages_updated}, created {result.packages_created} packages, "
         f"updated {result.attrpaths_updated}, created {result.attrpaths_created} attrpaths."
     )
-
-    affected_suggestions = CVEDerivationClusterProposal.objects.filter(
-        derivations__parent_evaluation__channel=evaluation.channel,
-        status__in=[
-            CVEDerivationClusterProposal.Status.PENDING,
-            CVEDerivationClusterProposal.Status.ACCEPTED,
-        ],
-    ).distinct()
-
-    count = 0
-    for suggestion in affected_suggestions:
-        refresh_suggestion_derivation_links(suggestion)
-        cache_new_suggestions(suggestion)
-        count += 1
-
-    if count:
-        logger.info(
-            "Updated derivation links and rebuilt caches for %d suggestion(s) after evaluation %s",
-            count,
-            evaluation,
-        )

--- a/src/shared/tests/test_package_clustering.py
+++ b/src/shared/tests/test_package_clustering.py
@@ -412,6 +412,7 @@ def test_concurrent_attrpath_consistency(
     assert PackageDerivation.objects.get(derivation=drv_b).package == pkg
 
 
+@pytest.mark.xfail(reason="Not implemented", strict=True)
 def test_cache_rebuilt_after_clustering(
     cve: Container,
     make_evaluation: Callable[..., NixEvaluation],


### PR DESCRIPTION
Since the `pgpubsub` trigger handler runs in its own transaction, the slow loop blocks the entire pipeline and crashes due to concurrent updates.
Remove the code path for now until there's a proper fix.