### PR TITLE
Clean up overlay.nix a bit

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -153,6 +153,7 @@ rec {
         pkgs.nodejs
         pkgs.biome
       ]
+      ++ package.nativeCheckInputs
       ++ git-hooks.enabledPackages;
 
       shellHook = ''

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -43,7 +43,7 @@ rec {
 
       pyright =
         let
-          pyEnv = pkgs.python3.withPackages (_: pkgs.nix-security-tracker.propagatedBuildInputs);
+          pyEnv = pkgs.nix-security-tracker.pythonEnv;
           wrappedPyright = pkgs.runCommand "pyright" { nativeBuildInputs = [ pkgs.makeWrapper ]; } ''
             makeWrapper ${pkgs.pyright}/bin/pyright $out \
               --set PYTHONPATH ${pyEnv}/${pyEnv.sitePackages} \

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -71,7 +71,6 @@ in
       django-types
       django
       djangorestframework
-      pytest-socket
       ipython
       pydantic-settings
       prometheus-client
@@ -88,20 +87,28 @@ in
       django-pghistory
       django-pglock
       django-pgtrigger
-      pytest
-      pytest-django
-      pytest-playwright
-      pytest-mock
       cvss
       cpe
-      freezegun
       django-model-utils
       drf-spectacular
       django-rest-knox
       django-vite
     ];
 
-    passthru.PLAYWRIGHT_BROWSERS_PATH = final.playwright-driver.browsers;
+    nativeCheckInputs = with final.python3.pkgs; [
+      freezegun
+      pytest
+      pytest-django
+      pytest-playwright
+      pytest-mock
+      pytest-socket
+    ];
+
+    passthru = {
+      inherit nativeCheckInputs;
+      PLAYWRIGHT_BROWSERS_PATH = final.playwright-driver.browsers;
+      pythonEnv = final.python3.withPackages (_: propagatedBuildInputs ++ nativeCheckInputs);
+    };
 
     postInstall = ''
       mkdir -p $out/bin

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -4,10 +4,6 @@ let
   meta = with builtins; fromTOML (readFile ../src/pyproject.toml);
 in
 {
-  /*
-    XXX(@fricklerhandwerk): At the time of writing, Nixpkgs has Django 4 as default.
-    Some packages that depend on Django use that default implicitly, so we override it for everything.
-  */
   python3 = prev.python3.override {
     packageOverrides = pyfinal: _pyprev: {
       psycopg2 = pyfinal.psycopg;


### PR DESCRIPTION
This PR includes two small fixes as I was looking at overlay.nix:
* Remove an old comment that doesn't apply anymore since nixpkgs moved to a newer Django version
* Move test time dependencies to `nativeCheckInputs`. I don't think this is important, especially since it needs changes in `git-hooks.nix` too, but it took me a couple of test cycles to figure out what was happening, so maybe it makes sense to improve this a bit.