### PR TITLE
feat: filters (status & package) in API and UI + suggestion view modes

### DIFF
--- a/frontend/src/components/suggestions/Comment.module.css
+++ b/frontend/src/components/suggestions/Comment.module.css
@@ -5,6 +5,11 @@
   transition: background-color 0.2s ease;
 }
 
+.compact {
+  min-height: 0;
+  resize: none;
+}
+
 .pending {
   background-color: var(--light-yellow);
 }

--- a/frontend/src/components/suggestions/Comment.tsx
+++ b/frontend/src/components/suggestions/Comment.tsx
@@ -8,12 +8,13 @@ type Props = {
   suggestionId: number;
   comment: string | null;
   canEdit: boolean;
+  compact?: boolean;
 };
 
 const DEBOUNCE_SAVE_MS = 500;
 const DEBOUNCE_CLEAR_SAVED_FEEDBACK_MS = 2000;
 
-export function Comment({ suggestionId, comment, canEdit }: Props) {
+export function Comment({ suggestionId, comment, canEdit, compact = false }: Props) {
   const [value, setValue] = useState(comment ?? "");
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -58,13 +59,16 @@ export function Comment({ suggestionId, comment, canEdit }: Props) {
 
   return (
     <textarea
-      className={`box rounded border monospace ${styles.textarea} ${stateClass}`}
+      className={`box rounded border monospace ${styles.textarea} ${compact && "compact"} ${compact ? styles.compact : ""} ${stateClass}`}
       value={value}
       onInput={handleChange}
-      placeholder="Free comment: context, additional info, dismissal reason, etc."
+      placeholder={
+        compact ? "Comment…" : "Free comment: context, additional info, dismissal reason, etc."
+      }
       disabled={!canEdit}
       maxLength={1000}
       data-save-state={saveState}
+      rows={compact ? 1 : 3}
     />
   );
 }

--- a/frontend/src/components/suggestions/Suggestion.tsx
+++ b/frontend/src/components/suggestions/Suggestion.tsx
@@ -1,47 +1,98 @@
 import { Link } from "wouter-preact";
 import type { Suggestion as SuggestionType } from "@/api/generated/models";
 import { useAuth } from "@/hooks/useAuth";
+import type { SuggestionViewMode } from "@/hooks/useSuggestionViewMode";
 import { ActivityLog } from "./ActivityLog";
-import { AffectedProductsList } from "./AffectedProductsList";
-import { CategorizedMaintainersList } from "./CategorizedMaintainersList";
-import { CategorizedPackagesList } from "./CategorizedPackagesList";
-import { CategorizedReferencesList } from "./CategorizedReferencesList";
-import { Comment } from "./Comment";
 import { SeverityBadge } from "./SeverityBadge";
+import { SuggestionCompactBody } from "./SuggestionCompactBody";
+import { SuggestionDetailedBody } from "./SuggestionDetailedBody";
 import { SuggestionStatus } from "./SuggestionStatus";
-import { SuggestionStatusActions } from "./SuggestionStatusActions";
+import { SuggestionTabsBody } from "./SuggestionTabsBody";
+import { SuggestionViewToggle } from "./SuggestionViewToggle";
 
 type Props = {
   suggestion: SuggestionType;
+  /** Purely visual: flags a suggestion that no longer matches active list filters. Independent of `viewMode`. */
+  dimmed?: boolean;
+  /** Effective mode actually rendered (may fall back to "collapsed" or the list default — see `effectiveViewMode`). */
+  viewMode?: SuggestionViewMode;
+  /** Explicit per-suggestion override, if any. Only meaningful when `allowViewModeClear` is set — used to
+   * decide what the toggle highlights (nothing, when the suggestion has no override of its own). */
+  overrideViewMode?: SuggestionViewMode;
+  /** Lets the toggle clear an explicit override by re-clicking the highlighted option. Set by list contexts;
+   * left false for a standalone suggestion (e.g. the detail page) where the toggle is always selected. */
+  allowViewModeClear?: boolean;
+  onViewModeChange?: (viewMode: SuggestionViewMode | undefined) => void;
 };
 
-export function Suggestion({ suggestion }: Props) {
-  const {
-    id,
-    cve_id,
-    title,
-    description,
-    status,
-    rejection_reason,
-    comment,
-    affected_products,
-    packages,
-    ignored_packages,
-    metrics,
-    categorized_maintainers,
-    categorized_url_references,
-  } = suggestion;
+export function Suggestion({
+  suggestion,
+  dimmed = false,
+  viewMode = "detailed",
+  overrideViewMode,
+  allowViewModeClear = false,
+  onViewModeChange = () => {},
+}: Props) {
+  const { id, cve_id, title, description, status, rejection_reason, metrics } = suggestion;
 
   const { user } = useAuth();
   const userCanEdit = Boolean(user?.is_committer || user?.is_admin);
 
   const nvdUrl = `https://nvd.nist.gov/vuln/detail/${encodeURIComponent(cve_id)}`;
 
+  const articleClassName = `box border rounded column gap-big ${dimmed ? "border-dashed" : "shadow"}`;
+
+  // Only highlight the toggle when the suggestion has an explicit override of its own;
+  // when it doesn't nothing is shown as selected (inherit from list-wide setting).
+  const toggleValue = allowViewModeClear ? overrideViewMode : viewMode;
+
+  if (viewMode === "collapsed") {
+    const displayedTitle = title || description;
+    return (
+      <article className={articleClassName} data-testid={`suggestion-${id}-collapsed`}>
+        <div className="row gap spread centered wrap">
+          <div className="row gap centered wrap">
+            <span data-testid={`suggestion-${id}-status`}>
+              <SuggestionStatus status={status} rejectionReason={rejection_reason} iconOnly />
+            </span>
+            <a href={nvdUrl} target="_blank" rel="noreferrer">
+              {cve_id}
+            </a>
+            {displayedTitle && (
+              <span>
+                {displayedTitle.length > 80 ? `${displayedTitle.slice(0, 80)}…` : displayedTitle}
+              </span>
+            )}
+          </div>
+          <div className="row gap centered">
+            <Link href={`/ui-v2/suggestions/by-id/${id}`}>Permalink</Link>
+            <SuggestionViewToggle
+              value={toggleValue}
+              onChange={onViewModeChange}
+              iconOnly
+              allowClear={allowViewModeClear}
+              testId={`suggestion-${id}-view-toggle`}
+            />
+          </div>
+        </div>
+      </article>
+    );
+  }
+
   return (
-    <article className="box shadow border rounded column gap-big" data-testid={`suggestion-${id}`}>
+    <article className={articleClassName} data-testid={`suggestion-${id}`}>
       {/* Header */}
       <div className="column gap-small">
-        <SuggestionStatus status={status} rejectionReason={rejection_reason} />
+        <div className="row gap spread centered">
+          <SuggestionStatus status={status} rejectionReason={rejection_reason} />
+          <SuggestionViewToggle
+            value={toggleValue}
+            onChange={onViewModeChange}
+            iconOnly
+            allowClear={allowViewModeClear}
+            testId={`suggestion-${id}-view-toggle`}
+          />
+        </div>
 
         <div className="row gap spread align-start">
           <div className="row gap">
@@ -62,59 +113,16 @@ export function Suggestion({ suggestion }: Props) {
         </details>
       </div>
 
-      <div className="column gap">
-        {/* References */}
-        {categorized_url_references.original.length > 0 && (
-          <div className="rounded border box column gap">
-            <h2 className="text-l bold text-gray">References</h2>
-            <CategorizedReferencesList
-              categorizedReferences={categorized_url_references}
-              suggestionId={id}
-              editable={userCanEdit && (status === "pending" || status === "accepted")}
-            />
-          </div>
-        )}
+      {viewMode === "compact" && (
+        <SuggestionCompactBody suggestion={suggestion} userCanEdit={userCanEdit} />
+      )}
 
-        {/* Affected products */}
-        {Object.keys(affected_products).length > 0 && (
-          <div className="rounded border box column gap">
-            <h2 className="text-l bold text-gray">Affected products</h2>
-            <AffectedProductsList affectedProducts={affected_products} />
-          </div>
-        )}
+      {viewMode === "tabs" && (
+        <SuggestionTabsBody suggestion={suggestion} userCanEdit={userCanEdit} />
+      )}
 
-        {/* Packages */}
-        <div className="rounded border box column gap">
-          <h2 className="text-l bold text-gray">Matching in nixpkgs</h2>
-          <CategorizedPackagesList
-            suggestionId={id}
-            active={packages}
-            ignored={ignored_packages}
-            editable={userCanEdit && (status === "pending" || status === "accepted")}
-          />
-        </div>
-
-        {/* Maintainers */}
-        {categorized_maintainers.original.length > 0 && (
-          <div className="rounded border box column gap">
-            <h2 className="text-l bold text-gray">Maintainers</h2>
-            <CategorizedMaintainersList
-              suggestionId={id}
-              categorizedMaintainers={categorized_maintainers}
-              editable={userCanEdit && (status === "pending" || status === "accepted")}
-            />
-          </div>
-        )}
-
-        {/* Comment */}
-        {(comment || userCanEdit) && (
-          <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} />
-        )}
-      </div>
-
-      {/* Change status */}
-      {userCanEdit && (
-        <SuggestionStatusActions suggestionId={id} status={status} comment={comment} />
+      {viewMode === "detailed" && (
+        <SuggestionDetailedBody suggestion={suggestion} userCanEdit={userCanEdit} />
       )}
     </article>
   );

--- a/frontend/src/components/suggestions/SuggestionCompactBody.tsx
+++ b/frontend/src/components/suggestions/SuggestionCompactBody.tsx
@@ -1,0 +1,45 @@
+import type { Suggestion as SuggestionType } from "@/api/generated/models";
+import { AffectedProductsList } from "./AffectedProductsList";
+import { CategorizedReferencesList } from "./CategorizedReferencesList";
+import { Comment } from "./Comment";
+import { SuggestionStatusActions } from "./SuggestionStatusActions";
+
+type Props = {
+  suggestion: SuggestionType;
+  userCanEdit: boolean;
+};
+
+export function SuggestionCompactBody({ suggestion, userCanEdit }: Props) {
+  const { id, status, comment, affected_products, categorized_url_references } = suggestion;
+
+  return (
+    <div className="column gap-big">
+      <div className="column gap-small">
+        {categorized_url_references.original.length > 0 && (
+          <>
+            <CategorizedReferencesList
+              categorizedReferences={categorized_url_references}
+              suggestionId={id}
+              editable={userCanEdit && (status === "pending" || status === "accepted")}
+            />
+            <hr className="divider" />
+          </>
+        )}
+
+        {Object.keys(affected_products).length > 0 && (
+          <AffectedProductsList affectedProducts={affected_products} />
+        )}
+      </div>
+
+      {comment && !userCanEdit && (
+        <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} compact />
+      )}
+
+      {userCanEdit && (
+        <SuggestionStatusActions suggestionId={id} status={status} comment={comment}>
+          <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} compact />
+        </SuggestionStatusActions>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/suggestions/SuggestionDetailedBody.tsx
+++ b/frontend/src/components/suggestions/SuggestionDetailedBody.tsx
@@ -1,0 +1,88 @@
+import type { Suggestion as SuggestionType } from "@/api/generated/models";
+import { AffectedProductsList } from "./AffectedProductsList";
+import { CategorizedMaintainersList } from "./CategorizedMaintainersList";
+import { CategorizedPackagesList } from "./CategorizedPackagesList";
+import { CategorizedReferencesList } from "./CategorizedReferencesList";
+import { Comment } from "./Comment";
+import { SuggestionStatusActions } from "./SuggestionStatusActions";
+
+type Props = {
+  suggestion: SuggestionType;
+  userCanEdit: boolean;
+};
+
+export function SuggestionDetailedBody({ suggestion, userCanEdit }: Props) {
+  const {
+    id,
+    status,
+    comment,
+    affected_products,
+    packages,
+    ignored_packages,
+    categorized_maintainers,
+    categorized_url_references,
+  } = suggestion;
+
+  const editable = userCanEdit && (status === "pending" || status === "accepted");
+
+  return (
+    <>
+      <div className="column gap">
+        {/* References */}
+        {categorized_url_references.original.length > 0 && (
+          <div className="rounded border box column gap">
+            <h2 className="text-l bold text-gray">References</h2>
+            <CategorizedReferencesList
+              categorizedReferences={categorized_url_references}
+              suggestionId={id}
+              editable={editable}
+            />
+          </div>
+        )}
+
+        {/* Affected products */}
+        {Object.keys(affected_products).length > 0 && (
+          <div className="rounded border box column gap">
+            <h2 className="text-l bold text-gray">Affected products</h2>
+            <AffectedProductsList affectedProducts={affected_products} />
+          </div>
+        )}
+
+        {/* Packages */}
+        {Object.keys(packages).length + Object.keys(ignored_packages).length > 0 && (
+          <div className="rounded border box column gap">
+            <h2 className="text-l bold text-gray">Matching in nixpkgs</h2>
+            <CategorizedPackagesList
+              suggestionId={id}
+              active={packages}
+              ignored={ignored_packages}
+              editable={editable}
+            />
+          </div>
+        )}
+
+        {/* Maintainers */}
+        {categorized_maintainers.original.length > 0 && (
+          <div className="rounded border box column gap">
+            <h2 className="text-l bold text-gray">Maintainers</h2>
+            <CategorizedMaintainersList
+              suggestionId={id}
+              categorizedMaintainers={categorized_maintainers}
+              editable={editable}
+            />
+          </div>
+        )}
+
+        {/* Comment */}
+        {(comment || userCanEdit) && (
+          <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} />
+        )}
+      </div>
+
+      {/* Change status */}
+      {userCanEdit && (
+        <SuggestionStatusActions suggestionId={id} status={status} comment={comment} />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/suggestions/SuggestionFilters.tsx
+++ b/frontend/src/components/suggestions/SuggestionFilters.tsx
@@ -1,0 +1,125 @@
+import { LayersIcon, PackageIcon } from "lucide-preact";
+import { useEffect, useState } from "preact/hooks";
+import type { ListSuggestionsStatusItem } from "@/api/generated/models";
+import { ListSuggestionsStatusItem as Status } from "@/api/generated/models";
+import { ToggleGroup, type ToggleGroupOption } from "@/components/ui/ToggleGroup";
+import type { SuggestionListFilters } from "@/hooks/useSuggestionListFilters";
+import { statusLabel } from "./SuggestionStatus";
+import { SuggestionStatusIcon } from "./SuggestionStatusIcon";
+
+const STATUS_OPTIONS: ToggleGroupOption[] = [
+  Status.pending,
+  Status.rejected,
+  Status.accepted,
+  Status.published,
+].map((status) => ({
+  value: status,
+  label: (
+    <span className="row gap-small centered">
+      <SuggestionStatusIcon status={status} size="1em" />
+      {statusLabel(status)}
+    </span>
+  ),
+}));
+
+// "in issue draft" is a flag, not status, but presented as an extra toggle alongside
+const ISSUE_DRAFT_VALUE = "issue_draft";
+const TOGGLE_OPTIONS: ToggleGroupOption[] = [
+  ...STATUS_OPTIONS,
+  {
+    value: ISSUE_DRAFT_VALUE,
+    label: (
+      <span className="row gap-small centered">
+        <LayersIcon size="1em" />
+        Issue draft
+      </span>
+    ),
+  },
+];
+
+const DEBOUNCE_PACKAGE_MS = 500;
+
+type Props = {
+  filters: SuggestionListFilters;
+  setStatuses: (statuses: ListSuggestionsStatusItem[]) => void;
+  setInIssueDraft: (inIssueDraft: boolean) => void;
+  setPackageFilter: (packageFilter: string) => void;
+};
+
+/**
+ * Determine the next toggle selection after a click:
+ * - Shift/Ctrl/Meta+click adds/removes `clicked` from the current multi-selection.
+ * - Single click solo-selects or clears
+ */
+function nextToggleSelection(current: string[], clicked: string, event: MouseEvent): string[] {
+  const additive = event.shiftKey || event.ctrlKey || event.metaKey;
+
+  if (additive) {
+    return current.includes(clicked) ? current.filter((s) => s !== clicked) : [...current, clicked];
+  }
+
+  const isOnlySelected = current.length === 1 && current[0] === clicked;
+  return isOnlySelected ? [] : [clicked];
+}
+
+function PackageFilterInput({
+  packageFilter,
+  setPackageFilter,
+}: {
+  packageFilter: string;
+  setPackageFilter: (value: string) => void;
+}) {
+  const [local, setLocal] = useState(packageFilter);
+
+  // Re-sync from the URL (e.g. back/forward navigation, external link).
+  useEffect(() => setLocal(packageFilter), [packageFilter]);
+
+  useEffect(() => {
+    if (local === packageFilter) return;
+    const timeout = setTimeout(() => setPackageFilter(local), DEBOUNCE_PACKAGE_MS);
+    return () => clearTimeout(timeout);
+  }, [local]);
+
+  return (
+    <div className="row gap-small centered">
+      <PackageIcon size="1em" />
+      <input
+        type="text"
+        placeholder="Filter by package…"
+        value={local}
+        onInput={(e) => setLocal(e.currentTarget.value)}
+        className="rounded border box compact"
+        aria-label="Filter by package"
+      />
+    </div>
+  );
+}
+
+export function SuggestionFilters({
+  filters,
+  setStatuses,
+  setInIssueDraft,
+  setPackageFilter,
+}: Props) {
+  const toggleValue = filters.inIssueDraft
+    ? [...filters.statuses, ISSUE_DRAFT_VALUE]
+    : filters.statuses;
+
+  return (
+    <div className="row gap row-gap-big wrap align-center" data-testid="suggestion-filters">
+      <ToggleGroup
+        value={toggleValue}
+        options={TOGGLE_OPTIONS}
+        onItemClick={(value, event) => {
+          const next = nextToggleSelection(toggleValue, value, event);
+          setInIssueDraft(next.includes(ISSUE_DRAFT_VALUE));
+          setStatuses(next.filter((v) => v !== ISSUE_DRAFT_VALUE) as ListSuggestionsStatusItem[]);
+        }}
+      />
+      <PackageFilterInput
+        packageFilter={filters.packageFilter}
+        setPackageFilter={setPackageFilter}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/suggestions/SuggestionStatus.tsx
+++ b/frontend/src/components/suggestions/SuggestionStatus.tsx
@@ -1,12 +1,17 @@
-import type { StatusEnum, SuggestionRejectionReason } from "@/api/generated/models";
+import type {
+  RejectionReasonEnum,
+  StatusEnum,
+  SuggestionRejectionReason,
+} from "@/api/generated/models";
 import { SuggestionStatusIcon } from "./SuggestionStatusIcon";
 
 type Props = {
   status: StatusEnum;
   rejectionReason?: SuggestionRejectionReason;
+  iconOnly?: boolean;
 };
 
-function statusLabel(status: StatusEnum): string {
+export function statusLabel(status: StatusEnum): string {
   switch (status) {
     case "pending":
       return "Untriaged";
@@ -21,12 +26,33 @@ function statusLabel(status: StatusEnum): string {
   }
 }
 
-export function SuggestionStatus({ status, rejectionReason }: Props) {
-  return (
+export function rejectionReasonLabel(rejection_reason: RejectionReasonEnum): string {
+  switch (rejection_reason) {
+    case "not_in_nixpkgs":
+      return "not in Nixpkgs";
+    case "exclusively_hosted_service":
+      return "exclusively hosted service";
+    case "hardware_only_cpe":
+      return "hardware only CPE";
+    case "max_matches_exceeded":
+      return "max matched exceeded";
+    case "known_vulnerability":
+      return "known vulnerability";
+    case "no_matches":
+      return "no matches";
+    default:
+      return rejection_reason;
+  }
+}
+
+export function SuggestionStatus({ status, rejectionReason, iconOnly = false }: Props) {
+  return iconOnly ? (
+    <SuggestionStatusIcon status={status} size="1em" />
+  ) : (
     <div className="row gap-small centered wrap">
       <SuggestionStatusIcon status={status} size="1em" />
       <span>{statusLabel(status)}</span>
-      {rejectionReason && <span>({rejectionReason})</span>}
+      {rejectionReason && <span>({rejectionReasonLabel(rejectionReason)})</span>}
     </div>
   );
 }

--- a/frontend/src/components/suggestions/SuggestionStatusActions.tsx
+++ b/frontend/src/components/suggestions/SuggestionStatusActions.tsx
@@ -1,4 +1,5 @@
 import { PenToolIcon, Trash2Icon } from "lucide-preact";
+import type { ComponentChild } from "preact";
 import type { StatusEnum, SuggestionStatusRejectionReason } from "@/api/generated/models";
 import { Menu } from "@/components/ui/Menu";
 import { useSuggestionStatusMutation } from "@/hooks/useSuggestionStatus";
@@ -7,9 +8,10 @@ type Props = {
   suggestionId: number;
   status: StatusEnum;
   comment?: string | null;
+  children?: ComponentChild; // Component to insert between the status change buttons: e.g. comment in compact mode
 };
 
-export function SuggestionStatusActions({ suggestionId, status, comment }: Props) {
+export function SuggestionStatusActions({ suggestionId, status, comment, children }: Props) {
   const mutation = useSuggestionStatusMutation(suggestionId);
 
   if (status === "published") {
@@ -32,7 +34,7 @@ export function SuggestionStatusActions({ suggestionId, status, comment }: Props
 
   return (
     <div
-      className={`${canDismiss ? "row" : "row-reverse"} gap-small centered spread`}
+      className="row gap-small centered spread"
       data-testid={`suggestion-${suggestionId}-status-actions`}
     >
       {canDismiss && (
@@ -58,6 +60,7 @@ export function SuggestionStatusActions({ suggestionId, status, comment }: Props
           ]}
         />
       )}
+      {children ?? <div></div>}
       {canAccept && (
         <button
           type="button"

--- a/frontend/src/components/suggestions/SuggestionTabsBody.tsx
+++ b/frontend/src/components/suggestions/SuggestionTabsBody.tsx
@@ -1,0 +1,102 @@
+import { BugIcon, LinkIcon, PackageIcon, UserIcon } from "lucide-preact";
+import { useState } from "preact/hooks";
+import type { Suggestion as SuggestionType } from "@/api/generated/models";
+import { type Tab, Tabs } from "@/components/ui/Tabs";
+import { AffectedProductsList } from "./AffectedProductsList";
+import { CategorizedMaintainersList } from "./CategorizedMaintainersList";
+import { CategorizedPackagesList } from "./CategorizedPackagesList";
+import { CategorizedReferencesList } from "./CategorizedReferencesList";
+import { Comment } from "./Comment";
+import { SuggestionStatusActions } from "./SuggestionStatusActions";
+
+type Props = {
+  suggestion: SuggestionType;
+  userCanEdit: boolean;
+};
+
+export function SuggestionTabsBody({ suggestion, userCanEdit }: Props) {
+  const {
+    id,
+    status,
+    comment,
+    affected_products,
+    packages,
+    ignored_packages,
+    categorized_maintainers,
+    categorized_url_references,
+  } = suggestion;
+
+  const editable = userCanEdit && (status === "pending" || status === "accepted");
+
+  const tabs: (Tab | false)[] = [
+    categorized_url_references.original.length > 0 && {
+      value: "references",
+      label: "References",
+      icon: <LinkIcon size="1em" />,
+      content: (
+        <CategorizedReferencesList
+          categorizedReferences={categorized_url_references}
+          suggestionId={id}
+          editable={editable}
+        />
+      ),
+    },
+    Object.keys(affected_products).length > 0 && {
+      value: "affected-products",
+      label: "Affected products",
+      icon: <BugIcon size="1em" />,
+      content: <AffectedProductsList affectedProducts={affected_products} />,
+    },
+    Object.keys(packages).length + Object.keys(ignored_packages).length > 0 && {
+      value: "packages",
+      label: "Matching in Nixpkgs",
+      icon: <PackageIcon size="1em" />,
+      content: (
+        <CategorizedPackagesList
+          suggestionId={id}
+          active={packages}
+          ignored={ignored_packages}
+          editable={editable}
+        />
+      ),
+    },
+    categorized_maintainers.original.length > 0 && {
+      value: "maintainers",
+      label: "Maintainers",
+      icon: <UserIcon size="1em" />,
+      content: (
+        <CategorizedMaintainersList
+          suggestionId={id}
+          categorizedMaintainers={categorized_maintainers}
+          editable={editable}
+        />
+      ),
+    },
+  ];
+  const populatedTabs = tabs.filter((tab): tab is Tab => Boolean(tab));
+
+  const [activeTab, setActiveTab] = useState(populatedTabs[0]?.value);
+
+  return (
+    <div className="column gap-big" data-testid={`suggestion-${id}-tabs`}>
+      {populatedTabs.length > 0 && (
+        <Tabs
+          value={activeTab ?? populatedTabs[0].value}
+          onValueChange={setActiveTab}
+          tabs={populatedTabs}
+          compact
+        />
+      )}
+
+      {comment && !userCanEdit && (
+        <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} compact />
+      )}
+
+      {userCanEdit && (
+        <SuggestionStatusActions suggestionId={id} status={status} comment={comment}>
+          <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} compact />
+        </SuggestionStatusActions>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/suggestions/SuggestionViewToggle.tsx
+++ b/frontend/src/components/suggestions/SuggestionViewToggle.tsx
@@ -1,0 +1,64 @@
+import {
+  type LucideIcon,
+  PanelTopIcon,
+  RectangleHorizontalIcon,
+  Rows2Icon,
+  Rows4Icon,
+} from "lucide-preact";
+import { ToggleGroup, type ToggleGroupOption } from "@/components/ui/ToggleGroup";
+import type { SuggestionViewMode } from "@/hooks/useSuggestionViewMode";
+
+const VIEW_MODES: { value: SuggestionViewMode; label: string; Icon: LucideIcon }[] = [
+  { value: "detailed", label: "Detailed", Icon: Rows4Icon },
+  { value: "compact", label: "Compact", Icon: Rows2Icon },
+  { value: "collapsed", label: "Collapsed", Icon: RectangleHorizontalIcon },
+  { value: "tabs", label: "Tabs", Icon: PanelTopIcon },
+];
+
+type Props = {
+  value: SuggestionViewMode | undefined;
+  onChange: (viewMode: SuggestionViewMode | undefined) => void;
+  testId: string;
+  /** Only show icons without labels */
+  iconOnly?: boolean;
+  /** Allows to unselect. Used to inherit from the list-wide view mode. */
+  allowClear?: boolean;
+};
+
+export function SuggestionViewToggle({
+  value,
+  onChange,
+  testId,
+  iconOnly = false,
+  allowClear = false,
+}: Props) {
+  const options: ToggleGroupOption[] = VIEW_MODES.map(({ value: mode, label, Icon }) => ({
+    value: mode,
+    title: iconOnly ? label : undefined,
+    label: iconOnly ? (
+      <Icon size="1em" />
+    ) : (
+      <span className="row gap-small centered">
+        <Icon size="1em" />
+        {label}
+      </span>
+    ),
+  }));
+
+  return (
+    <div data-testid={testId}>
+      <ToggleGroup
+        value={value ? [value] : []}
+        options={options}
+        variant="segmented"
+        onItemClick={(clicked) => {
+          if (allowClear && clicked === value) {
+            onChange(undefined);
+          } else {
+            onChange(clicked as SuggestionViewMode);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Tabs.module.css
+++ b/frontend/src/components/ui/Tabs.module.css
@@ -1,5 +1,5 @@
 .tab {
-  padding: 0.5em 1em;
+  padding: 0 1em 0.5em 1em;
   background: none;
   border: none;
   border-bottom: 0.2em solid transparent;
@@ -16,7 +16,6 @@
 }
 
 .tab[data-selected] {
-  color: black;
-  border-color: black;
+  border-color: var(--nixos-blue);
   font-weight: bold;
 }

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -2,7 +2,7 @@ import { TabContent, TabList, TabsRoot, TabTrigger } from "@ark-ui/react";
 import type { ComponentChildren } from "preact";
 import styles from "./Tabs.module.css";
 
-type Tab = {
+export type Tab = {
   value: string;
   label: string;
   icon?: ComponentChildren;
@@ -13,16 +13,17 @@ type TabsProps = {
   value: string;
   onValueChange: (value: string) => void;
   tabs: Tab[];
+  compact?: boolean;
   lazyMount?: boolean;
 };
 
-export function Tabs({ value, onValueChange, tabs, lazyMount }: TabsProps) {
+export function Tabs({ value, onValueChange, tabs, lazyMount, compact = false }: TabsProps) {
   return (
     <TabsRoot
       value={value}
       onValueChange={({ value }) => onValueChange(value)}
       lazyMount={lazyMount}
-      className="column gap-big"
+      className={`column ${compact ? "gap" : "gap-big"}`}
     >
       <TabList className={`row ${styles.tabList}`}>
         {tabs.map((tab) => (

--- a/frontend/src/components/ui/ToggleGroup.module.css
+++ b/frontend/src/components/ui/ToggleGroup.module.css
@@ -1,0 +1,36 @@
+.item {
+  padding: 0.3em 0.8em;
+  background: var(--light-gray);
+}
+
+.item:hover {
+  border-color: var(--nixos-blue);
+}
+
+.item[data-state="on"] {
+  background: var(--nixos-blue);
+  border-color: var(--nixos-blue);
+  color: white;
+  font-weight: bold;
+}
+
+/* Segmented variant: single connected control instead of separate pills */
+
+.segmentedRoot {
+  gap: 0;
+  flex-wrap: nowrap;
+  border: 1px solid var(--gray);
+  border-radius: 0.4em;
+  overflow: hidden;
+  width: fit-content;
+}
+
+.segmentedItem {
+  border: none;
+  border-radius: 0;
+  padding: 0.35em 0.6em;
+}
+
+.segmentedItem:not(:first-child) {
+  border-left: 1px solid var(--gray);
+}

--- a/frontend/src/components/ui/ToggleGroup.tsx
+++ b/frontend/src/components/ui/ToggleGroup.tsx
@@ -1,0 +1,47 @@
+import { ToggleGroupItem, ToggleGroupRoot } from "@ark-ui/react";
+import type { ComponentChildren } from "preact";
+import styles from "./ToggleGroup.module.css";
+
+export type ToggleGroupOption = {
+  value: string;
+  label: ComponentChildren;
+  /** Tooltip/accessible name */
+  title?: string;
+};
+
+type ToggleGroupProps = {
+  value: string[];
+  options: ToggleGroupOption[];
+  /**
+   * `"pills"` (default): separate rounded
+   * `"segmented"`: single connected control
+   */
+  variant?: "pills" | "segmented";
+  onItemClick: (value: string, event: MouseEvent) => void;
+};
+
+export function ToggleGroup({ value, options, variant = "pills", onItemClick }: ToggleGroupProps) {
+  const rootClassName =
+    variant === "segmented" ? `row ${styles.segmentedRoot}` : "row gap-small wrap";
+  const itemClassName =
+    variant === "segmented"
+      ? `cursor-pointer ${styles.item} ${styles.segmentedItem}`
+      : `rounded-full border cursor-pointer ${styles.item}`;
+
+  return (
+    <ToggleGroupRoot value={value} onValueChange={() => {}} multiple className={rootClassName}>
+      {options.map((option) => (
+        <ToggleGroupItem
+          key={option.value}
+          value={option.value}
+          title={option.title}
+          aria-label={option.title}
+          onClick={(event: MouseEvent) => onItemClick(option.value, event)}
+          className={itemClassName}
+        >
+          {option.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroupRoot>
+  );
+}

--- a/frontend/src/hooks/useSuggestionListFilters.ts
+++ b/frontend/src/hooks/useSuggestionListFilters.ts
@@ -1,0 +1,78 @@
+import { useSearchParams } from "wouter-preact";
+import type { ListSuggestionsStatusItem } from "@/api/generated/models";
+import { ListSuggestionsStatusItem as Status } from "@/api/generated/models";
+
+/** URL-search-param-backed suggestion list filters. */
+export type SuggestionListFilters = {
+  statuses: ListSuggestionsStatusItem[];
+  inIssueDraft: boolean;
+  packageFilter: string;
+};
+
+const VALID_STATUSES = new Set<string>(Object.values(Status));
+
+function isValidStatus(value: string): value is ListSuggestionsStatusItem {
+  return VALID_STATUSES.has(value);
+}
+
+function parseFilters(searchParams: URLSearchParams): SuggestionListFilters {
+  return {
+    statuses: searchParams.getAll("status").filter(isValidStatus),
+    inIssueDraft: searchParams.get("in_issue_draft") === "true",
+    packageFilter: searchParams.get("package") ?? "",
+  };
+}
+
+export function useSuggestionListFilters(): {
+  filters: SuggestionListFilters;
+  setStatuses: (statuses: ListSuggestionsStatusItem[]) => void;
+  setInIssueDraft: (inIssueDraft: boolean) => void;
+  setPackageFilter: (packageFilter: string) => void;
+} {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = parseFilters(searchParams);
+
+  // Any filter change invalidates the current page, so we jump back to page 1.
+  // Uses `replace` so typing in the package filter doesn't spam browser history.
+  const updateParams = (mutate: (next: URLSearchParams) => void) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        mutate(next);
+        next.delete("page");
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const setStatuses = (statuses: ListSuggestionsStatusItem[]) => {
+    updateParams((next) => {
+      next.delete("status");
+      for (const status of statuses) next.append("status", status);
+    });
+  };
+
+  const setInIssueDraft = (inIssueDraft: boolean) => {
+    updateParams((next) => {
+      if (inIssueDraft) {
+        next.set("in_issue_draft", "true");
+      } else {
+        next.delete("in_issue_draft");
+      }
+    });
+  };
+
+  const setPackageFilter = (packageFilter: string) => {
+    updateParams((next) => {
+      const trimmed = packageFilter.trim();
+      if (trimmed) {
+        next.set("package", trimmed);
+      } else {
+        next.delete("package");
+      }
+    });
+  };
+
+  return { filters, setStatuses, setInIssueDraft, setPackageFilter };
+}

--- a/frontend/src/hooks/useSuggestionStatus.ts
+++ b/frontend/src/hooks/useSuggestionStatus.ts
@@ -28,6 +28,8 @@ export function useSuggestionStatusMutation(suggestionId: number) {
           ...prev,
           status: data.status,
           rejection_reason: data.status === "rejected" ? data.rejection_reason : undefined,
+          // Remove from issue draft during optimistic update
+          in_issue_draft: prev.in_issue_draft && data.status === "accepted",
         }));
 
         return { previous };

--- a/frontend/src/hooks/useSuggestionViewMode.ts
+++ b/frontend/src/hooks/useSuggestionViewMode.ts
@@ -1,0 +1,54 @@
+import { useSearchParams } from "wouter-preact";
+
+/**
+ * How much detail is shown for a suggestion card.
+ *
+ * - `detailed`: all sections expanded
+ * - `compact`: no "matching packages" nor "maintainers", compact presentation
+ * - `collapsed`: only status icon, CVE id, and title
+ * - `tabs`: all sections, each in a given tab
+ */
+export type SuggestionViewMode = "detailed" | "collapsed" | "compact" | "tabs";
+
+export const DEFAULT_SUGGESTION_VIEW_MODE: SuggestionViewMode = "detailed";
+
+const VALID_VIEW_MODES = new Set<string>([
+  "detailed",
+  "collapsed",
+  "compact",
+  "tabs",
+] satisfies SuggestionViewMode[]);
+
+function isValidViewMode(value: string | null): value is SuggestionViewMode {
+  return value !== null && VALID_VIEW_MODES.has(value);
+}
+
+/**
+ * URL-search-param-backed list-wide default view mode (`view`).
+ * Suggestions may locally override.
+ */
+export function useSuggestionListViewMode(): {
+  viewMode: SuggestionViewMode;
+  setViewMode: (viewMode: SuggestionViewMode) => void;
+} {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const raw = searchParams.get("view");
+  const viewMode = isValidViewMode(raw) ? raw : DEFAULT_SUGGESTION_VIEW_MODE;
+
+  const setViewMode = (next: SuggestionViewMode) => {
+    setSearchParams(
+      (prev) => {
+        const nextParams = new URLSearchParams(prev);
+        if (next === DEFAULT_SUGGESTION_VIEW_MODE) {
+          nextParams.delete("view");
+        } else {
+          nextParams.set("view", next);
+        }
+        return nextParams;
+      },
+      { replace: true },
+    );
+  };
+
+  return { viewMode, setViewMode };
+}

--- a/frontend/src/hooks/useSuggestionViewOverrides.ts
+++ b/frontend/src/hooks/useSuggestionViewOverrides.ts
@@ -1,0 +1,25 @@
+import { useState } from "preact/hooks";
+import type { SuggestionViewMode } from "./useSuggestionViewMode";
+
+/** Per-suggestion view mode overrides, keyed by suggestion id */
+export function useSuggestionViewOverrides(): {
+  getOverride: (suggestionId: number) => SuggestionViewMode | undefined;
+  /** `undefined` clears the override: falls back to list-wide setting. */
+  setOverride: (suggestionId: number, viewMode: SuggestionViewMode | undefined) => void;
+} {
+  const [overrides, setOverrides] = useState<Record<number, SuggestionViewMode>>({});
+
+  const getOverride = (suggestionId: number) => overrides[suggestionId];
+
+  const setOverride = (suggestionId: number, viewMode: SuggestionViewMode | undefined) => {
+    setOverrides((prev) => {
+      if (viewMode === undefined) {
+        const { [suggestionId]: _removed, ...rest } = prev;
+        return rest;
+      }
+      return { ...prev, [suggestionId]: viewMode };
+    });
+  };
+
+  return { getOverride, setOverride };
+}

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -1,4 +1,5 @@
 import { CircleCheckBigIcon } from "lucide-preact";
+import { Link } from "wouter-preact";
 
 const doneFeatures = [
   "Main framework",
@@ -17,17 +18,21 @@ const doneFeatures = [
   "Suggestions: maintainer ignore/restore",
   "Suggestions: status change (publication excluded)",
   "Suggestion lists: pagination",
+  "Suggestion lists: per status",
+  "Suggestion lists: by package",
+  "Suggestion lists: draft issue",
+  "Suggestion lists: compact view",
+  "Suggestion lists: collapsed view",
+  "Suggestion lists: tabs view",
+  "Suggestion lists: list and per-suggestion override view modes",
+  "Suggestion lists: visual feedback for 'out of search critera' suggestions",
 ];
 
 const pendingFeatures = [
   "Suggestions: maintainer add/delete",
   "Notification center",
   "Notification pill (in navbar)",
-  "Notification polling",
-  "Suggestion lists: compact view",
-  "Suggestion lists: per status",
-  "Suggestion lists: by package",
-  "Suggestion lists: draft issue",
+  "Suggestion lists: optimized batch activity log queries",
   "Suggestions: publication and batch publication",
   "Navigation bar",
   "Published issues list",
@@ -51,6 +56,9 @@ export function Home() {
   return (
     <div className="column gap-big">
       <h1 className="text-xl bold">Nixpkgs security tracker</h1>
+      <p>
+        <Link href="/ui-v2/suggestions">Browse suggestions</Link>
+      </p>
       <p>
         New UI under construction. Features are gradually ported and improved from the legacy UI.
         You may continue to use the <a href="/">legacy UI</a>.

--- a/frontend/src/routes/SuggestionDetail.tsx
+++ b/frontend/src/routes/SuggestionDetail.tsx
@@ -1,12 +1,15 @@
+import { useState } from "preact/hooks";
 import { useParams } from "wouter-preact";
 import { ApiError } from "@/api/client";
 import { useGetSuggestion } from "@/api/generated/endpoints";
 import { Suggestion } from "@/components/suggestions/Suggestion";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { DEFAULT_SUGGESTION_VIEW_MODE } from "@/hooks/useSuggestionViewMode";
 
 export function SuggestionDetail() {
   const params = useParams<{ id: string }>();
   const id = Number(params.id);
+  const [viewMode, setViewMode] = useState(DEFAULT_SUGGESTION_VIEW_MODE);
 
   const { data, isLoading, isError, error } = useGetSuggestion(id, {
     query: { enabled: !Number.isNaN(id) },
@@ -35,5 +38,11 @@ export function SuggestionDetail() {
     return null;
   }
 
-  return <Suggestion suggestion={data} />;
+  return (
+    <Suggestion
+      suggestion={data}
+      viewMode={viewMode}
+      onViewModeChange={(mode) => mode && setViewMode(mode)}
+    />
+  );
 }

--- a/frontend/src/routes/SuggestionList.tsx
+++ b/frontend/src/routes/SuggestionList.tsx
@@ -1,8 +1,18 @@
+import { EyeIcon } from "lucide-preact";
 import { useSearchParams } from "wouter-preact";
 import { useListSuggestions } from "@/api/generated/endpoints";
+import type { Suggestion as SuggestionType } from "@/api/generated/models";
 import { Suggestion } from "@/components/suggestions/Suggestion";
+import { SuggestionFilters } from "@/components/suggestions/SuggestionFilters";
+import { SuggestionViewToggle } from "@/components/suggestions/SuggestionViewToggle";
 import { Pagination } from "@/components/ui/Pagination";
 import { Skeleton } from "@/components/ui/Skeleton";
+import {
+  type SuggestionListFilters,
+  useSuggestionListFilters,
+} from "@/hooks/useSuggestionListFilters";
+import { type SuggestionViewMode, useSuggestionListViewMode } from "@/hooks/useSuggestionViewMode";
+import { useSuggestionViewOverrides } from "@/hooks/useSuggestionViewOverrides";
 import { getApiErrorMessage } from "@/utils/apiError";
 
 // FIXME(@florentc): Hardcoded in the API for now, we should ultimately make it a query param
@@ -13,11 +23,53 @@ function parsePage(searchParams: URLSearchParams): number {
   return Number.isInteger(raw) && raw > 0 ? raw : 1;
 }
 
+function effectiveViewMode({
+  override,
+  matchesFilters,
+  listViewMode,
+}: {
+  override: SuggestionViewMode | undefined;
+  matchesFilters: boolean;
+  listViewMode: SuggestionViewMode;
+}): SuggestionViewMode {
+  if (override) {
+    return override;
+  }
+  return matchesFilters ? listViewMode : "collapsed";
+}
+
+function suggestionMatchesFilters(
+  suggestion: SuggestionType,
+  filters: SuggestionListFilters,
+): boolean {
+  if (filters.statuses.length > 0 && !filters.statuses.includes(suggestion.status)) {
+    return false;
+  }
+
+  if (filters.inIssueDraft && !suggestion.in_issue_draft) {
+    return false;
+  }
+
+  if (filters.packageFilter && !(filters.packageFilter in suggestion.packages)) {
+    return false;
+  }
+
+  return true;
+}
+
 export function SuggestionList() {
   const [searchParams, setSearchParams] = useSearchParams();
   const page = parsePage(searchParams);
+  const { filters, setStatuses, setInIssueDraft, setPackageFilter } = useSuggestionListFilters();
+  const { viewMode, setViewMode } = useSuggestionListViewMode();
+  const { getOverride, setOverride } = useSuggestionViewOverrides();
 
-  const { data, isLoading, isError, error } = useListSuggestions({ page });
+  const { data, isLoading, isError, error } = useListSuggestions({
+    page,
+    status: filters.statuses.length > 0 ? filters.statuses : undefined,
+    in_issue_draft: filters.inIssueDraft || undefined,
+    package: filters.packageFilter || undefined,
+  });
 
   const handlePageChange = (newPage: number) => {
     setSearchParams((prev) => {
@@ -32,47 +84,78 @@ export function SuggestionList() {
     window.scrollTo({ top: 0 });
   };
 
-  if (isLoading) {
-    return (
-      <div className="column gap-big">
-        <div className="column gap">
-          {Array.from({ length: PAGE_SIZE }).map((_, i) => (
-            <Skeleton key={i} width="100%" height="20em" />
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <p className="rounded box bg-red-light">
-        Failed to load suggestions: {getApiErrorMessage(error)}
-      </p>
-    );
-  }
-
-  if (!data) {
-    return null;
-  }
-
   return (
     <div className="column gap-big centered">
-      {data.results.length === 0 ? (
-        <p>No suggestions found.</p>
-      ) : (
-        <div className="column gap-big">
-          {data.results.map((suggestion) => (
-            <Suggestion key={suggestion.id} suggestion={suggestion} />
-          ))}
+      <div className="column gap">
+        <SuggestionFilters
+          filters={filters}
+          setStatuses={setStatuses}
+          setInIssueDraft={setInIssueDraft}
+          setPackageFilter={setPackageFilter}
+        />
+        <div className="row gap centered justify-right">
+          <div className="row gap-small centered">
+            <EyeIcon size="1em" />
+            <span>View</span>
+          </div>
+          <SuggestionViewToggle
+            value={viewMode}
+            onChange={(mode) => mode && setViewMode(mode)}
+            testId="suggestion-view-toggle"
+          />
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="column gap-big full-width">
+          <div className="column gap">
+            {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+              <Skeleton key={i} width="100%" height="20em" />
+            ))}
+          </div>
         </div>
       )}
-      <Pagination
-        page={page}
-        count={data.count}
-        pageSize={PAGE_SIZE}
-        onPageChange={handlePageChange}
-      />
+
+      {isError && (
+        <p className="rounded box bg-red-light">
+          Failed to load suggestions: {getApiErrorMessage(error)}
+        </p>
+      )}
+
+      {data && (
+        <>
+          {data.results.length === 0 ? (
+            <p>No suggestions found.</p>
+          ) : (
+            <div className="column gap-big stretched full-width">
+              {data.results.map((suggestion) => {
+                const matches = suggestionMatchesFilters(suggestion, filters);
+                return (
+                  <Suggestion
+                    key={suggestion.id}
+                    suggestion={suggestion}
+                    dimmed={!matches}
+                    viewMode={effectiveViewMode({
+                      override: getOverride(suggestion.id),
+                      matchesFilters: matches,
+                      listViewMode: viewMode,
+                    })}
+                    overrideViewMode={getOverride(suggestion.id)}
+                    allowViewModeClear
+                    onViewModeChange={(mode) => setOverride(suggestion.id, mode)}
+                  />
+                );
+              })}
+            </div>
+          )}
+          <Pagination
+            page={page}
+            count={data.count}
+            pageSize={PAGE_SIZE}
+            onPageChange={handlePageChange}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/routes/UserSettings.tsx
+++ b/frontend/src/routes/UserSettings.tsx
@@ -19,7 +19,7 @@ export function UserSettings() {
   const activeTab = getTabFromLocation(location);
 
   return (
-    <div className="column gap">
+    <div className="column gap-big">
       {isLoading ? (
         <>
           <div className="row gap centered">

--- a/frontend/src/styles/utility.css
+++ b/frontend/src/styles/utility.css
@@ -259,6 +259,7 @@
  *
  * Spacing (use one or none):
  * .gap, .gap-small, .gap-big - Gap between items
+ * .row-gap, .row-gap-small, .row-gap-big - Gap between items in a row, may be combined with `gap` variants (useful when wrapping is possible)
  * .dividers - Display a separation line between items (handles gaps, don't use gap classes)
  *
  * Horizontal separator line:
@@ -331,6 +332,10 @@
   justify-content: space-between;
 }
 
+.self-stretch {
+  align-self: stretch;
+}
+
 .gap {
   gap: 1em;
 }
@@ -341,6 +346,18 @@
 
 .gap-small {
   gap: 0.5em;
+}
+
+.row-gap {
+  column-gap: 1em;
+}
+
+.row-gap-big {
+  column-gap: 2em;
+}
+
+.row-gap-small {
+  column-gap: 0.5em;
 }
 
 .grow {
@@ -378,6 +395,7 @@
  *
  * .rounded - Rounded corners
  * .border - Gray border
+ * .border-dashed - Dashed border (to be used with `border`)
  * .circle - Circular shape
  * .box - Padding and scrollbars during overflows.
  *        Modifiers: .spacious, .compact (affects padding)
@@ -393,6 +411,10 @@
 
 .border {
   border: 1px solid var(--gray);
+}
+
+.border-dashed {
+  border-style: dashed;
 }
 
 .box {

--- a/src/api/suggestions/views.py
+++ b/src/api/suggestions/views.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
+from django_filters import rest_framework as filters
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
@@ -68,16 +69,52 @@ class SuggestionPagination(PageNumberPagination):
     page_size = 10  # TODO(@florentc): Allow the user to change it within limits
 
 
+class SuggestionFilterSet(filters.FilterSet):
+    """Filters for the suggestion list endpoint.
+
+    `status` accepts repeated query params (e.g. `?status=pending&status=accepted`) and is combined with OR.
+    Combines with other filters with AND.
+    """
+
+    status = filters.MultipleChoiceFilter(
+        choices=CVEDerivationClusterProposal.Status.choices,
+        label="Filter by status (repeatable, combined with OR)",
+    )
+    in_issue_draft = filters.BooleanFilter(
+        label="Filter by whether the suggestion is in the issue draft",
+    )
+    package = filters.CharFilter(
+        method="filter_package",
+        label="Filter by an active package attribute name (exact match)",
+    )
+
+    class Meta:
+        model = CVEDerivationClusterProposal
+        fields = ["status", "in_issue_draft", "package"]
+
+    def filter_package(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        return queryset.filter(cached__payload__packages__has_key=value)
+
+
 class SuggestionViewSet(ListModelMixin, RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = CVEDerivationClusterProposal.objects.all()
     serializer_class = SuggestionSerializer
     pagination_class = SuggestionPagination
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_class = SuggestionFilterSet
 
     def get_permissions(self) -> list:
         if getattr(self.request, "method", None) != "GET":
             return [IsAuthenticated(), CanEditSuggestion()]
         else:
             return []
+
+    def filter_queryset(self, queryset: QuerySet) -> QuerySet:  # pyright: ignore[reportIncompatibleMethodOverride]
+        # Filters (status/in_issue_draft/package) only apply to the list action.
+        # Other actions (retrieve, status, comment, ...) fetch a single suggestion by pk via get_object() and must not be affected by list-only filters.
+        if self.action != "list":
+            return queryset
+        return super().filter_queryset(queryset)
 
     def get_queryset(self) -> QuerySet[CVEDerivationClusterProposal]:  # pyright: ignore[reportIncompatibleMethodOverride]
         if self.action != "list":

--- a/src/api/tests/test_suggestion_list.py
+++ b/src/api/tests/test_suggestion_list.py
@@ -5,11 +5,20 @@ from django.utils import timezone
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
-from shared.models.linkage import CVEDerivationClusterProposal
+from shared.models.cve import Container
+from shared.models.linkage import (
+    CVEDerivationClusterProposal,
+    ProvenanceFlags,
+)
+from shared.models.nix_evaluation import NixDerivation
 
 
 def url() -> str:
     return reverse("cvederivationclusterproposal-list")
+
+
+def detail_url(pk: int) -> str:
+    return reverse("cvederivationclusterproposal-detail", kwargs={"pk": pk})
 
 
 def test_suggestion_list_anonymous(
@@ -137,3 +146,166 @@ def test_suggestion_list_second_page(
     first_page_ids = {item["id"] for item in first_page.data["results"]}
     second_page_ids = {item["id"] for item in second_page.data["results"]}
     assert first_page_ids.isdisjoint(second_page_ids)
+
+
+def test_suggestion_list_filters_by_single_status(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Filtering by a single status only returns suggestions in that status."""
+    client = APIClient()
+    pending = make_cached_suggestion(status=CVEDerivationClusterProposal.Status.PENDING)
+    accepted = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.ACCEPTED
+    )
+
+    response = client.get(url(), {"status": "accepted"})
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.data["results"]]
+    assert ids == [accepted.pk]
+    assert pending.pk not in ids
+
+
+def test_suggestion_list_filters_by_multiple_statuses(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Filtering by several statuses combines them with OR."""
+    client = APIClient()
+    pending = make_cached_suggestion(status=CVEDerivationClusterProposal.Status.PENDING)
+    accepted = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.ACCEPTED
+    )
+    rejected = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.REJECTED
+    )
+
+    response = client.get(url(), [("status", "pending"), ("status", "accepted")])
+    assert response.status_code == 200
+    ids = {item["id"] for item in response.data["results"]}
+    assert ids == {pending.pk, accepted.pk}
+    assert rejected.pk not in ids
+
+
+def test_suggestion_list_invalid_status_returns_400(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """An unknown status value is rejected."""
+    client = APIClient()
+    make_cached_suggestion()
+
+    response = client.get(url(), {"status": "not-a-real-status"})
+    assert response.status_code == 400
+
+
+def test_suggestion_list_filters_by_in_issue_draft(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Filtering by in_issue_draft only returns matching suggestions."""
+    client = APIClient()
+    in_draft = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.ACCEPTED, in_issue_draft=True
+    )
+    not_in_draft = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.ACCEPTED, in_issue_draft=False
+    )
+
+    response = client.get(url(), {"in_issue_draft": "true"})
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.data["results"]]
+    assert ids == [in_draft.pk]
+
+    response = client.get(url(), {"in_issue_draft": "false"})
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.data["results"]]
+    assert ids == [not_in_draft.pk]
+
+
+def test_suggestion_list_filters_by_package(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+    make_drv: Callable[..., NixDerivation],
+    make_container: Callable[..., Container],
+) -> None:
+    """Filtering by package only returns suggestions with that active package."""
+    client = APIClient()
+    package1 = make_drv(pname="foo")
+    package2 = make_drv(pname="bar")
+    container1 = make_container(cve_id="CVE-2026-1001")
+    container2 = make_container(cve_id="CVE-2026-1002")
+    matching = make_cached_suggestion(
+        container=container1, drvs={package1: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+    other = make_cached_suggestion(
+        container=container2, drvs={package2: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+
+    response = client.get(url(), {"package": package1.attribute})
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.data["results"]]
+    assert ids == [matching.pk]
+    assert other.pk not in ids
+
+
+def test_suggestion_list_filters_excludes_ignored_package(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    """A suggestion whose only matching package has been ignored isn't returned."""
+    client = APIClient()
+    package = make_drv(pname="foo")
+    suggestion = make_cached_suggestion(
+        drvs={package: ProvenanceFlags.PACKAGE_NAME_MATCH}
+    )
+    suggestion.ignore_package(package.attribute)
+
+    response = client.get(url(), {"package": package.attribute})
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.data["results"]]
+    assert suggestion.pk not in ids
+
+
+def test_suggestion_list_combines_filters_with_and(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+    make_drv: Callable[..., NixDerivation],
+    make_container: Callable[..., Container],
+) -> None:
+    """Status, in_issue_draft, and package filters combine with AND."""
+    client = APIClient()
+    package = make_drv(pname="foo")
+    container1 = make_container(cve_id="CVE-2026-2001")
+    container2 = make_container(cve_id="CVE-2026-2002")
+
+    matching = make_cached_suggestion(
+        container=container1,
+        drvs={package: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        in_issue_draft=True,
+    )
+    # Same package and draft state, but wrong status.
+    wrong_status = make_cached_suggestion(
+        container=container2,
+        drvs={package: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=CVEDerivationClusterProposal.Status.PENDING,
+    )
+
+    response = client.get(
+        url(),
+        {"status": "accepted", "in_issue_draft": "true", "package": package.attribute},
+    )
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.data["results"]]
+    assert ids == [matching.pk]
+    assert wrong_status.pk not in ids
+
+
+def test_suggestion_detail_unaffected_by_list_filters(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Query params meant for the list endpoint don't filter out detail lookups."""
+    client = APIClient()
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+
+    # A status filter that this suggestion doesn't match must not 404 the detail view.
+    response = client.get(detail_url(suggestion.pk), {"status": "accepted"})
+    assert response.status_code == 200
+    assert response.data["id"] == suggestion.pk

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -371,6 +371,10 @@ class CVEDerivationClusterProposal(TimeStampMixin):
         if status == self.status:
             raise ValidationError({"status": f"Already in status '{self.status}'"})
 
+        # Automatically remove from issue draft when changing status away from accepted
+        if status != SuggestionStatus.ACCEPTED:
+            self.in_issue_draft = False
+
         self.status = status
         self.rejection_reason = rejection_reason
         if comment:

--- a/src/webview/tests/ui_v2/test_suggestion_list.py
+++ b/src/webview/tests/ui_v2/test_suggestion_list.py
@@ -1,12 +1,15 @@
+import re
 from collections.abc import Callable
 from datetime import timedelta
+from urllib.parse import urlencode
 
 from django.utils import timezone
 from playwright.sync_api import Page, expect
 from pytest_django.live_server_helper import LiveServer
 
 from shared.models.cve import Container
-from shared.models.linkage import CVEDerivationClusterProposal
+from shared.models.linkage import CVEDerivationClusterProposal, ProvenanceFlags
+from shared.models.nix_evaluation import NixDerivation
 
 from .routes import SUGGESTION_LIST
 
@@ -85,3 +88,214 @@ def test_suggestion_list_page_navigation_shows_different_suggestions(
     page.get_by_role("button", name="Next page").click()
     expect(page.get_by_test_id(f"suggestion-{oldest.pk}")).to_be_visible()
     expect(page.get_by_test_id(f"suggestion-{newest.pk}")).not_to_be_visible()
+
+
+def test_suggestion_list_status_filter_via_query_param(
+    live_server: LiveServer,
+    page: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """A `status` query param only shows suggestions in that status."""
+    pending = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3001"),
+        status=CVEDerivationClusterProposal.Status.PENDING,
+    )
+    accepted = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3002"),
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+    )
+
+    page.goto(
+        live_server.url + SUGGESTION_LIST + "?" + urlencode({"status": "accepted"})
+    )
+    expect(page.get_by_test_id(f"suggestion-{accepted.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{pending.pk}")).not_to_be_visible()
+
+
+def test_suggestion_list_status_toggle_click_filters_and_updates_url(
+    live_server: LiveServer,
+    page: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Clicking a status toggle solo-selects it, filtering the list and the URL."""
+    pending = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3011"),
+        status=CVEDerivationClusterProposal.Status.PENDING,
+    )
+    accepted = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3012"),
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+    )
+
+    page.goto(live_server.url + SUGGESTION_LIST)
+    expect(page.get_by_test_id(f"suggestion-{pending.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{accepted.pk}")).to_be_visible()
+
+    filters = page.get_by_test_id("suggestion-filters")
+    filters.get_by_role("button", name="Accepted").click()
+
+    expect(page.get_by_test_id(f"suggestion-{accepted.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{pending.pk}")).not_to_be_visible()
+    expect(page).to_have_url(re.compile(r"[?&]status=accepted"))
+
+
+def test_suggestion_list_status_shift_click_adds_to_multi_selection(
+    live_server: LiveServer,
+    page: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Shift-clicking a second status adds it to the selection; a plain click then solos back."""
+    pending = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3021"),
+        status=CVEDerivationClusterProposal.Status.PENDING,
+    )
+    accepted = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3022"),
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+    )
+    rejected = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3023"),
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+        rejection_reason=CVEDerivationClusterProposal.RejectionReason.NOT_IN_NIXPKGS,
+    )
+
+    page.goto(live_server.url + SUGGESTION_LIST)
+    filters = page.get_by_test_id("suggestion-filters")
+
+    filters.get_by_role("button", name="Accepted").click()
+    filters.get_by_role("button", name="Dismissed").click(modifiers=["Shift"])
+
+    expect(page.get_by_test_id(f"suggestion-{accepted.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{rejected.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{pending.pk}")).not_to_be_visible()
+
+    # A plain click back on "Accepted" solos back to just that status.
+    filters.get_by_role("button", name="Accepted").click()
+    expect(page.get_by_test_id(f"suggestion-{accepted.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{rejected.pk}")).not_to_be_visible()
+
+
+def test_suggestion_list_in_issue_draft_filter(
+    live_server: LiveServer,
+    page: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Toggling "Issue draft" only shows suggestions in the draft."""
+    in_draft = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3031"),
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        in_issue_draft=True,
+    )
+    not_in_draft = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3032"),
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        in_issue_draft=False,
+    )
+
+    page.goto(live_server.url + SUGGESTION_LIST)
+    filters = page.get_by_test_id("suggestion-filters")
+    filters.get_by_role("button", name="Issue draft").click()
+
+    expect(page.get_by_test_id(f"suggestion-{in_draft.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{not_in_draft.pk}")).not_to_be_visible()
+    expect(page).to_have_url(re.compile(r"[?&]in_issue_draft=true"))
+
+
+def test_suggestion_list_package_filter(
+    live_server: LiveServer,
+    page: Page,
+    make_drv: Callable[..., NixDerivation],
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Typing in the package filter only shows suggestions with that active package."""
+    package1 = make_drv(pname="foo")
+    package2 = make_drv(pname="bar")
+    matching = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3041"),
+        drvs={package1: ProvenanceFlags.PACKAGE_NAME_MATCH},
+    )
+    other = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3042"),
+        drvs={package2: ProvenanceFlags.PACKAGE_NAME_MATCH},
+    )
+
+    page.goto(live_server.url + SUGGESTION_LIST)
+    page.get_by_label("Filter by package").fill(package1.attribute)
+
+    expect(page.get_by_test_id(f"suggestion-{matching.pk}")).to_be_visible()
+    expect(page.get_by_test_id(f"suggestion-{other.pk}")).not_to_be_visible()
+
+
+def test_suggestion_list_deep_link_preselects_filter_widgets(
+    live_server: LiveServer,
+    page: Page,
+    make_drv: Callable[..., NixDerivation],
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Loading the list with filter query params pre-selects the corresponding widgets."""
+    package = make_drv(pname="foo")
+    make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-3051"),
+        drvs={package: ProvenanceFlags.PACKAGE_NAME_MATCH},
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        in_issue_draft=True,
+    )
+
+    query = urlencode(
+        {"status": "accepted", "in_issue_draft": "true", "package": package.attribute}
+    )
+    page.goto(live_server.url + SUGGESTION_LIST + "?" + query)
+
+    filters = page.get_by_test_id("suggestion-filters")
+    expect(filters.get_by_role("button", name="Accepted")).to_have_attribute(
+        "data-state", "on"
+    )
+    expect(filters.get_by_role("button", name="Issue draft")).to_have_attribute(
+        "data-state", "on"
+    )
+    expect(page.get_by_label("Filter by package")).to_have_value(package.attribute)
+
+
+def test_suggestion_list_shows_collapsed_card_after_mutation_stops_matching_filter(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Accepting a suggestion while filtered to "pending" collapses its card
+    instead of just removing it, showing status/CVE id/title/permalink."""
+    suggestion = make_cached_suggestion(
+        container=make_container(
+            cve_id="CVE-2026-3061", title="Collapsible suggestion"
+        ),
+        status=CVEDerivationClusterProposal.Status.PENDING,
+    )
+
+    as_committer.goto(
+        live_server.url + SUGGESTION_LIST + "?" + urlencode({"status": "pending"})
+    )
+    card = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}")
+    expect(card).to_be_visible()
+
+    actions = card.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    actions.get_by_role("button", name="Accept").click()
+
+    collapsed = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-collapsed")
+    expect(collapsed).to_be_visible()
+    expect(collapsed).to_contain_text("CVE-2026-3061")
+    expect(collapsed).to_contain_text("Collapsible suggestion")
+    expect(
+        collapsed.get_by_test_id(f"suggestion-{suggestion.pk}-status")
+    ).to_be_visible()
+    expect(collapsed.get_by_role("link", name="Permalink")).to_be_visible()
+
+    # The full card (with status actions, package section, etc.) is gone.
+    expect(
+        as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    ).to_have_count(0)

--- a/src/webview/tests/ui_v2/test_suggestion_status.py
+++ b/src/webview/tests/ui_v2/test_suggestion_status.py
@@ -133,7 +133,7 @@ def test_dismiss_not_in_nixpkgs_transitions_and_shows_reason(
     as_committer.get_by_role("menuitem", name="Not in nixpkgs").click()
 
     expect(as_committer.get_by_text("Dismissed")).to_be_visible()
-    expect(as_committer.get_by_text("not_in_nixpkgs")).to_be_visible()
+    expect(as_committer.get_by_text("not in Nixpkgs")).to_be_visible()
 
 
 @pytest.mark.django_db

--- a/src/webview/tests/ui_v2/test_suggestion_view_modes.py
+++ b/src/webview/tests/ui_v2/test_suggestion_view_modes.py
@@ -1,0 +1,154 @@
+import re
+from collections.abc import Callable
+
+from playwright.sync_api import Page, expect
+from pytest_django.live_server_helper import LiveServer
+
+from shared.models.cve import Container
+from shared.models.linkage import CVEDerivationClusterProposal
+
+from .routes import SUGGESTION_DETAIL, SUGGESTION_LIST
+
+
+def test_suggestion_list_defaults_to_detailed_view(
+    live_server: LiveServer,
+    page: Page,
+    cached_suggestion: CVEDerivationClusterProposal,
+) -> None:
+    """By default, suggestions render in the detailed view (all sections shown)."""
+    page.goto(live_server.url + SUGGESTION_LIST)
+    card = page.get_by_test_id(f"suggestion-{cached_suggestion.pk}")
+    expect(card).to_be_visible()
+    expect(card.get_by_role("heading", name="Matching in nixpkgs")).to_be_visible()
+    expect(card.get_by_role("heading", name="Maintainers")).to_be_visible()
+
+
+def test_list_wide_toggle_switches_to_collapsed(
+    live_server: LiveServer,
+    page: Page,
+    cached_suggestion: CVEDerivationClusterProposal,
+) -> None:
+    """Picking "Collapsed" in the list-wide toggle collapses every suggestion."""
+    page.goto(live_server.url + SUGGESTION_LIST)
+    page.get_by_test_id("suggestion-view-toggle").get_by_role(
+        "button", name="Collapsed"
+    ).click()
+
+    collapsed = page.get_by_test_id(f"suggestion-{cached_suggestion.pk}-collapsed")
+    expect(collapsed).to_be_visible()
+    expect(collapsed).to_contain_text(cached_suggestion.cve.cve_id)
+    expect(page.get_by_test_id(f"suggestion-{cached_suggestion.pk}")).to_have_count(0)
+    expect(page).to_have_url(re.compile(r"[?&]view=collapsed"))
+
+
+def test_list_wide_toggle_switches_to_compact(
+    live_server: LiveServer,
+    page: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Picking "Compact" shows references but hides packages/maintainers sections."""
+    suggestion = make_cached_suggestion(
+        container=make_container(
+            cve_id="CVE-2026-4001",
+            references=[("Ref text", "https://example.com/ref", [])],
+        )
+    )
+
+    page.goto(live_server.url + SUGGESTION_LIST)
+    page.get_by_test_id("suggestion-view-toggle").get_by_role(
+        "button", name="Compact"
+    ).click()
+
+    card = page.get_by_test_id(f"suggestion-{suggestion.pk}")
+    expect(card).to_be_visible()
+    expect(card.get_by_role("link", name="Ref text")).to_be_visible()
+    expect(card.get_by_role("heading", name="Matching in nixpkgs")).to_have_count(0)
+    expect(card.get_by_role("heading", name="Maintainers")).to_have_count(0)
+
+
+def test_list_wide_toggle_switches_to_tabs(
+    live_server: LiveServer,
+    page: Page,
+    cached_suggestion: CVEDerivationClusterProposal,
+) -> None:
+    """Picking "Tabs" shows a tab list covering the suggestion's populated sections."""
+    page.goto(live_server.url + SUGGESTION_LIST)
+    page.get_by_test_id("suggestion-view-toggle").get_by_role(
+        "button", name="Tabs"
+    ).click()
+
+    tabs = page.get_by_test_id(f"suggestion-{cached_suggestion.pk}-tabs")
+    expect(tabs).to_be_visible()
+    expect(tabs.get_by_role("tab", name="Matching in Nixpkgs")).to_be_visible()
+    expect(tabs.get_by_role("tab", name="Maintainers")).to_be_visible()
+
+
+def test_per_suggestion_override_only_affects_that_suggestion(
+    live_server: LiveServer,
+    page: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Overriding one suggestion's own view toggle leaves other suggestions alone."""
+    first = make_cached_suggestion(container=make_container(cve_id="CVE-2026-4011"))
+    second = make_cached_suggestion(container=make_container(cve_id="CVE-2026-4012"))
+
+    page.goto(live_server.url + SUGGESTION_LIST)
+    first_card = page.get_by_test_id(f"suggestion-{first.pk}")
+    first_card.get_by_test_id(f"suggestion-{first.pk}-view-toggle").get_by_role(
+        "button", name="Compact"
+    ).click()
+
+    expect(first_card.get_by_role("heading", name="Matching in nixpkgs")).to_have_count(
+        0
+    )
+    second_card = page.get_by_test_id(f"suggestion-{second.pk}")
+    expect(
+        second_card.get_by_role("heading", name="Matching in nixpkgs")
+    ).to_be_visible()
+
+
+def test_filter_mismatch_collapsed_suggestion_can_be_unfolded(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """A suggestion forced into "collapsed" by no longer matching the active
+    filter can still be unfolded back to "Detailed" via its own toggle."""
+    suggestion = make_cached_suggestion(
+        container=make_container(cve_id="CVE-2026-4021"),
+        status=CVEDerivationClusterProposal.Status.PENDING,
+    )
+
+    as_committer.goto(live_server.url + SUGGESTION_LIST + "?status=pending")
+    card = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}")
+    actions = card.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    actions.get_by_role("button", name="Accept").click()
+
+    collapsed = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-collapsed")
+    expect(collapsed).to_be_visible()
+    collapsed.get_by_test_id(f"suggestion-{suggestion.pk}-view-toggle").get_by_role(
+        "button", name="Detailed"
+    ).click()
+
+    unfolded = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}")
+    expect(unfolded).to_be_visible()
+    expect(unfolded.get_by_role("heading", name="Matching in nixpkgs")).to_be_visible()
+
+
+def test_suggestion_detail_own_toggle_switches_to_tabs(
+    live_server: LiveServer,
+    page: Page,
+    cached_suggestion: CVEDerivationClusterProposal,
+) -> None:
+    """On the detail page, the suggestion's own toggle switches its view."""
+    page.goto(live_server.url + SUGGESTION_DETAIL + f"/{cached_suggestion.pk}")
+    page.get_by_test_id(f"suggestion-{cached_suggestion.pk}-view-toggle").get_by_role(
+        "button", name="Tabs"
+    ).click()
+
+    expect(
+        page.get_by_test_id(f"suggestion-{cached_suggestion.pk}-tabs")
+    ).to_be_visible()


### PR DESCRIPTION
- Composable-filters based suggestion lists
- Filters
    - “In issue draft” filter
    - Status filters
    - Filter by package
- API endpoint & tests
- New UI support with improved features
    - Widgets on top of lists to compose filters (0, 1 or several) including a long expected feature: free text package filter (no search or autocomplete yet, must be an exact match)
    - Suggestion view modes
        - Detailed mode: the classic polyvalent one that shows everything
        - Compact mode: like the compact mode in legacy webview which hides part of the info
        - Collapsed mode: only shows the CVE id, status, and title, a bit like after moving a suggestion to another status in legacy view
        - Tabs mode: all the info viewable but organized in tabs
    - Suggestion view mode selection
    - Widget to choose among the 4 modes
    - List wide: applies to all the suggestions in the list
    - On specific suggestion: locally overrides the view mode. Example: collapsed or compact mode list wide but you want to expand one suggestion in detail mode to do something.
    - Better management of suggestion changes in lists
        - In legacy UI: ad hoc solutions and hacks to display suggestion stubs and undo actions. Not very flexible and limited to status change.
        - In new UI: when a change is performed and it makes the suggestion no longer fit the filters set for the given list, then the suggestion is dimmed a little for visual feedback and it defaults to collapsed mode.
        - Managing “undo”: now it suffices to expand the collapsed suggestion and change back whatever you want and the suggestion will appear once again as normal in the list
        - After refreshing the page or content, suggestions that no longer fit the filters no longer appear


<img width="1130" height="886" alt="2026-07-31 15-29-47" src="https://github.com/user-attachments/assets/51ee907c-2f10-4321-8796-89e3e4953aaa" />
