### PR TITLE
chore: simplify networking configuration

### DIFF
--- a/infra/common.nix
+++ b/infra/common.nix
@@ -84,7 +84,27 @@ in
 
   # Lifted from https://github.com/NixOS/nixos-wiki-infra/blob/ac9dfe854f748bf8acedf394750d404aaa8dd075/targets/nixos-wiki.nixos.org/configuration.nix#L40
   # and https://wiki.nixos.org/wiki/Install_NixOS_on_Hetzner_Cloud#Network_configuration
-  systemd.network.enable = true;
+  # All this is Hetzner-specific (not machine-specific) and can be considered stable.
+  networking.useDHCP = false;
+
+  systemd.network = {
+    enable = true;
+    networks."10-wan" = {
+      matchConfig.Name = "enp1s0";
+      networkConfig.DHCP = "ipv4";
+      routes = [
+        # create default routes for both IPv6 and IPv4
+        { Gateway = "fe80::1"; }
+        # or when the gateway is not on the same network
+        {
+          Gateway = "172.31.1.1";
+          GatewayOnLink = true;
+        }
+      ];
+      # make the routes on this interface a dependency for network-online.target
+      linkConfig.RequiredForOnline = "routable";
+    };
+  };
 
   services.prometheus.exporters.node = {
     enable = true;

--- a/infra/production.nix
+++ b/infra/production.nix
@@ -30,22 +30,9 @@ in
   };
 
   systemd.network.networks."10-wan" = {
-    matchConfig.MACAddress = "96:00:04:64:8e:77";
     address = [
-      "91.99.31.214/32"
       "2a01:4f8:1c1b:6921::1/64"
     ];
-    routes = [
-      # create default routes for both IPv6 and IPv4
-      { Gateway = "fe80::1"; }
-      # or when the gateway is not on the same network
-      {
-        Gateway = "172.31.1.1";
-        GatewayOnLink = true;
-      }
-    ];
-    # make the routes on this interface a dependency for network-online.target
-    linkConfig.RequiredForOnline = "routable";
   };
 
   nixpkgs.overlays = sectracker.overlays;

--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -25,22 +25,9 @@ in
   swapDevices = [ { device = "/dev/disk/by-label/swap"; } ];
 
   systemd.network.networks."10-wan" = {
-    matchConfig.MACAddress = "96:00:03:d9:7c:85";
     address = [
-      "188.245.41.195/32"
       "2a01:4f8:1c1b:b87b::1/64"
     ];
-    routes = [
-      # create default routes for both IPv6 and IPv4
-      { Gateway = "fe80::1"; }
-      # or when the gateway is not on the same network
-      {
-        Gateway = "172.31.1.1";
-        GatewayOnLink = true;
-      }
-    ];
-    # make the routes on this interface a dependency for network-online.target
-    linkConfig.RequiredForOnline = "routable";
   };
 
   # FIXME(@fricklerhandwerk): Don't give everyone root.


### PR DESCRIPTION
This also gets rid of the warning of `systemd.network.enable` and `networking.useDHCP` being enabled simultaneously.