### PR TITLE
feat: delete linked derivations from channels running behind

### DIFF
--- a/src/shared/management/commands/garbage_collect.py
+++ b/src/shared/management/commands/garbage_collect.py
@@ -4,14 +4,25 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser, DjangoHelpFormatter
 from django.db import connection, models
-from django.db.models import Q, QuerySet
+from django.db.models import (
+    Case,
+    IntegerField,
+    OuterRef,
+    Q,
+    QuerySet,
+    Subquery,
+    When,
+)
 from django.utils import timezone
 
 from shared.models import (  # type: ignore
     CVEDerivationClusterProposalStatusEvent,
     DerivationClusterProposalLinkEvent,
 )
-from shared.models.linkage import CVEDerivationClusterProposal
+from shared.models.linkage import (
+    CVEDerivationClusterProposal,
+    DerivationClusterProposalLink,
+)
 from shared.models.nix_evaluation import (
     NixChannel,
     NixDerivation,
@@ -66,15 +77,17 @@ class Command(BaseCommand):
         # `pghistory` events are never auto-deleted — each step explicitly clears relevant events first.
 
         # FIXME(@fricklerhandwerk): Make the numbering implicit, otherwise we'll have noisy diffs every time something changes here.
-        self.stdout.write("\n[1/5] Deleting stale matches")
+        self.stdout.write("\n[1/6] Deleting stale matches")
         self._delete_stale_matches(cutoff, batch_size)
-        self.stdout.write("\n[2/5] Deleting unmatched derivations")
+        self.stdout.write("\n[2/6] Purging obsolete channel links")
+        self._purge_obsolete_channel_links(batch_size)
+        self.stdout.write("\n[3/6] Deleting unmatched derivations")
         self._delete_unmatched_derivations(cutoff, batch_size)
-        self.stdout.write("\n[3/5] Deleting empty evaluations")
+        self.stdout.write("\n[4/6] Deleting empty evaluations")
         self._delete_empty_evaluations(cutoff, batch_size)
-        self.stdout.write("\n[4/5] Deleting inactive channels")
+        self.stdout.write("\n[5/6] Deleting inactive channels")
         self._delete_inactive_channels(batch_size)
-        self.stdout.write("\n[5/5] Pruning stale package attrpaths")
+        self.stdout.write("\n[6/6] Pruning stale package attrpaths")
         self._prune_stale_package_attrpaths(batch_size)
 
         self.stdout.write(self.style.SUCCESS("\nGarbage collection complete."))
@@ -116,6 +129,59 @@ class Command(BaseCommand):
             label="stale suggestions",
             batch_size=batch_size,
             event_model=CVEDerivationClusterProposalStatusEvent,
+        )
+
+    def _purge_obsolete_channel_links(self, batch_size: int) -> None:
+        """
+        For each `(suggestion, attribute)`, keep only the derivatons from the most current channel.
+        Links to derivations from older channels with the same attribute count as obsolete if a more current channel is present.
+
+        This procedure can be removed once we evaluate the tip of each release branch once and match only against those.
+        """
+
+        # This priority corresponds to how far evaluated commits are behind `master`.
+        priority = Case(
+            When(
+                derivation__parent_evaluation__channel__channel_branch__endswith="-small",
+                then=0,
+            ),
+            When(
+                derivation__parent_evaluation__channel__channel_branch__startswith="nixos-",
+                then=1,
+            ),
+            # Stable releases can be considered even older and ordered lexicographically.
+            default=2,
+            output_field=IntegerField(),
+        )
+
+        # We only need the latest version of a "package" at matching time.
+        # A "package" currently merely constsists of derivations grouped by attribute path.
+        latest_link = (
+            DerivationClusterProposalLink.objects.filter(
+                proposal_id=OuterRef("proposal_id"),
+                derivation__attribute=OuterRef("derivation__attribute"),
+                derivation__parent_evaluation__channel__release_branch=OuterRef(
+                    "derivation__parent_evaluation__channel__release_branch"
+                ),
+            )
+            .annotate(prio=priority)
+            # Some channels in old suggestions appear multiple times, we take only the latest evaluation for each.
+            # We only introduced taking the latest evaluation at some point after going live.
+            .order_by("prio", "-derivation__parent_evaluation__created_at")
+            .values("pk")[:1]
+        )
+
+        candidates = DerivationClusterProposalLink.objects.exclude(
+            pk=Subquery(latest_link)
+        )
+
+        self._delete_in_batches(
+            qs=candidates,
+            model=DerivationClusterProposalLink,
+            pk_field="id",
+            label="obsolete channel links",
+            batch_size=batch_size,
+            event_model=DerivationClusterProposalLinkEvent,
         )
 
     def _delete_unmatched_derivations(self, cutoff: Any, batch_size: int) -> None:

--- a/src/shared/management/commands/garbage_collect.py
+++ b/src/shared/management/commands/garbage_collect.py
@@ -6,11 +6,11 @@ from django.core.management.base import BaseCommand, CommandParser, DjangoHelpFo
 from django.db import connection, models
 from django.db.models import (
     Case,
+    Exists,
     IntegerField,
     OuterRef,
     Q,
     QuerySet,
-    Subquery,
     When,
 )
 from django.utils import timezone
@@ -156,24 +156,31 @@ class Command(BaseCommand):
 
         # We only need the latest version of a "package" at matching time.
         # A "package" currently merely constsists of derivations grouped by attribute path.
+        # Some channels in old suggestions appear multiple times, we take only the latest evaluation for each.
+        # We only introduced taking the latest evaluation at some point after going live.
         latest_link = (
-            DerivationClusterProposalLink.objects.filter(
+            DerivationClusterProposalLink.objects.annotate(priority=priority)
+            .filter(
                 proposal_id=OuterRef("proposal_id"),
                 derivation__attribute=OuterRef("derivation__attribute"),
                 derivation__parent_evaluation__channel__release_branch=OuterRef(
                     "derivation__parent_evaluation__channel__release_branch"
                 ),
             )
-            .annotate(prio=priority)
-            # Some channels in old suggestions appear multiple times, we take only the latest evaluation for each.
-            # We only introduced taking the latest evaluation at some point after going live.
-            .order_by("prio", "-derivation__parent_evaluation__created_at")
-            .values("pk")[:1]
+            .filter(
+                Q(priority__lt=OuterRef("priority"))
+                | Q(
+                    priority=OuterRef("priority"),
+                    derivation__parent_evaluation__created_at__gt=OuterRef(
+                        "derivation__parent_evaluation__created_at"
+                    ),
+                )
+            )
         )
 
-        candidates = DerivationClusterProposalLink.objects.exclude(
-            pk=Subquery(latest_link)
-        )
+        candidates = DerivationClusterProposalLink.objects.annotate(
+            priority=priority
+        ).filter(Exists(latest_link))
 
         self._delete_in_batches(
             qs=candidates,

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -203,7 +203,8 @@ def make_evaluation(
 
         if age > timedelta(0):
             NixEvaluation.objects.filter(pk=evaluation.pk).update(
-                updated_at=timezone.now() - age
+                created_at=timezone.now() - age,
+                updated_at=timezone.now() - age,
             )
             evaluation.refresh_from_db()
 

--- a/src/shared/tests/test_garbage_collect.py
+++ b/src/shared/tests/test_garbage_collect.py
@@ -1,3 +1,4 @@
+import itertools
 from collections.abc import Callable
 from datetime import timedelta
 from enum import Enum
@@ -24,6 +25,7 @@ from shared.models.nix_evaluation import (
     NixDerivationMeta,
     NixEvaluation,
     NixMaintainer,
+    NixpkgsBranch,
 )
 from shared.models.package import PackageAttrpath, PackageDerivation
 from shared.package_clustering import cluster_packages
@@ -429,6 +431,175 @@ def test_stale_proposal_deletion_cascades_to_cache(
     assert CVEDerivationClusterProposal.objects.count() == 0
     assert DerivationClusterProposalLink.objects.count() == 0
     assert CachedSuggestions.objects.count() == 0
+
+
+@pytest.mark.parametrize(
+    "winner_branch, loser_branch",
+    list(
+        itertools.combinations(
+            ["nixos-unstable-small", "nixos-unstable", "nixpkgs-unstable"], 2
+        )
+    )
+    + [("nixos-25.05-small", "nixos-25.05")],
+)
+def test_gc_channel_priority_order(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+    winner_branch: str,
+    loser_branch: str,
+) -> None:
+    """
+    The higher-priority channel link is kept; the lower-priority one is removed.
+    """
+    drv_winner = make_drv(
+        attribute="foo",
+        evaluation=make_evaluation(channel=make_channel(channel_branch=winner_branch)),
+    )
+    drv_loser = make_drv(
+        attribute="foo",
+        evaluation=make_evaluation(channel=make_channel(channel_branch=loser_branch)),
+    )
+    make_suggestion(
+        drvs={
+            drv_winner: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv_loser: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        }
+    )
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert DerivationClusterProposalLink.objects.filter(derivation=drv_winner).exists()
+    assert not DerivationClusterProposalLink.objects.filter(
+        derivation=drv_loser
+    ).exists()
+
+
+def test_gc_preserves_links_from_different_release_branches(
+    make_branch: Callable[..., NixpkgsBranch],
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """
+    Links for the same attribute on different release branches are both preserved.
+    """
+    branch_stable = make_branch(name="release-25.05")
+    drv_unstable = make_drv(
+        attribute="foo",
+        evaluation=make_evaluation(
+            channel=make_channel(channel_branch="nixos-unstable")
+        ),
+    )
+    drv_stable = make_drv(
+        attribute="foo",
+        evaluation=make_evaluation(
+            channel=make_channel(
+                channel_branch="nixos-25.05", release_branch=branch_stable
+            )
+        ),
+    )
+    make_suggestion(
+        drvs={
+            drv_unstable: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv_stable: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        }
+    )
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert DerivationClusterProposalLink.objects.filter(
+        derivation=drv_unstable
+    ).exists()
+    assert DerivationClusterProposalLink.objects.filter(derivation=drv_stable).exists()
+
+
+def test_gc_preserves_sole_link(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """A single link per (suggestion, attribute) is never removed."""
+    drv = make_drv(
+        attribute="foo",
+        evaluation=make_evaluation(channel=make_channel(channel_branch="nixos-24.11")),
+    )
+    make_suggestion(drvs={drv: ProvenanceFlags.PACKAGE_NAME_MATCH})
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert DerivationClusterProposalLink.objects.filter(derivation=drv).exists()
+
+
+def test_gc_channel_priority_independent_per_attribute(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Deduplication is scoped per (suggestion, attribute); each attribute keeps its own best link."""
+    eval_small = make_evaluation(
+        channel=make_channel(channel_branch="nixos-unstable-small")
+    )
+    eval_unstable = make_evaluation(
+        channel=make_channel(channel_branch="nixos-unstable")
+    )
+    drv_foo_small = make_drv(attribute="foo", evaluation=eval_small)
+    drv_foo_unstable = make_drv(attribute="foo", evaluation=eval_unstable)
+    drv_bar_small = make_drv(pname="bar", evaluation=eval_small)
+    drv_bar_unstable = make_drv(pname="bar", evaluation=eval_unstable)
+    make_suggestion(
+        drvs={
+            drv_foo_small: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv_foo_unstable: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv_bar_small: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv_bar_unstable: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        }
+    )
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert DerivationClusterProposalLink.objects.filter(
+        derivation=drv_foo_small
+    ).exists()
+    assert not DerivationClusterProposalLink.objects.filter(
+        derivation=drv_foo_unstable
+    ).exists()
+    assert DerivationClusterProposalLink.objects.filter(
+        derivation=drv_bar_small
+    ).exists()
+    assert not DerivationClusterProposalLink.objects.filter(
+        derivation=drv_bar_unstable
+    ).exists()
+
+
+def test_gc_prefers_latest_evaluation_for_same_channel(
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """When the same attribute appears in two evaluations of the same channel, the link to the newer evaluation is kept."""
+    channel = make_channel(channel_branch="nixos-unstable")
+    eval_old = make_evaluation(channel=channel, age=timedelta(days=1))
+    eval_new = make_evaluation(channel=channel)
+
+    drv_old = make_drv(attribute="foo", evaluation=eval_old)
+    drv_new = make_drv(attribute="foo", evaluation=eval_new)
+    make_suggestion(
+        drvs={
+            drv_old: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv_new: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        }
+    )
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert DerivationClusterProposalLink.objects.filter(derivation=drv_new).exists()
+    assert not DerivationClusterProposalLink.objects.filter(derivation=drv_old).exists()
 
 
 def test_stale_proposal_deletion_cascades_to_notifications(


### PR DESCRIPTION
We're not using the older commits for anything in practice.

The change will only keep what we know to be the most recent commits for
each release branch at the time of matching.

Depends on #1239

This is the data-facing part of #864, since we stopped evaluating anything but the small channels in #1168.